### PR TITLE
Add support for editing tags on resource groups 🏷

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -15,8 +15,10 @@
 // The tests should import '../extension.bundle'. At design-time they live in tests/ and so will pick up this file (extension.bundle.ts).
 // At runtime the tests live in dist/tests and will therefore pick up the main webpack bundle at dist/extension.bundle.js.
 export * from 'vscode-azureextensionui';
+export * from './src/commands/tags/getTagDiagnostics';
 // Export activate/deactivate for main.js
 export { activateInternal, deactivateInternal } from './src/extension';
 export * from './src/extensionVariables';
+export * from './src/utils/nonNull';
 
 // NOTE: The auto-fix action "source.organizeImports" does weird things with this file, but there doesn't seem to be a way to disable it on a per-file basis so we'll just let it happen

--- a/package-lock.json
+++ b/package-lock.json
@@ -4739,6 +4739,11 @@
                 "minimist": "^1.2.0"
             }
         },
+        "jsonc-parser": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+            "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="
+        },
         "jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -8459,9 +8464,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.33.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.33.0.tgz",
-            "integrity": "sha512-3Vs+Yl9d9zmBd85rRimVakPHeo8Vy500oEdiiz7tVry4T3mCKRbShTMamMvWJwVAN92j8PfmYN2R7ItxHNHb/Q==",
+            "version": "0.33.1",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.33.1.tgz",
+            "integrity": "sha512-FlqbpuOCMCo9i/GDVwjoT3Xjend+tpuPrECgITIZB6f7a11RNELJoWa5zXE8jxAZO/0Poz19GHycO/hcAoqxRA==",
             "requires": {
                 "azure-arm-resource": "^3.0.0-preview",
                 "azure-arm-storage": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
     ],
     "preview": true,
     "activationEvents": [
+        "onFileSystem:azureResourceGroups",
         "onCommand:azureResourceGroups.createResourceGroup",
         "onCommand:azureResourceGroups.deleteResourceGroup",
+        "onCommand:azureResourceGroups.editTags",
         "onCommand:azureResourceGroups.loadMore",
         "onCommand:azureResourceGroups.openInPortal",
         "onCommand:azureResourceGroups.refresh",
@@ -53,6 +55,11 @@
             {
                 "command": "azureResourceGroups.deleteResourceGroup",
                 "title": "%azureResourceGroups.deleteResourceGroup%",
+                "category": "Azure Resource Groups"
+            },
+            {
+                "command": "azureResourceGroups.editTags",
+                "title": "%azureResourceGroups.editTags%",
                 "category": "Azure Resource Groups"
             },
             {
@@ -148,6 +155,11 @@
                     "command": "azureResourceGroups.deleteResourceGroup",
                     "when": "view == azureResourceGroups && viewItem == azureResourceGroup",
                     "group": "1@1"
+                },
+                {
+                    "command": "azureResourceGroups.editTags",
+                    "when": "view == azureResourceGroups && viewItem == azureResourceGroup",
+                    "group": "2@1"
                 },
                 {
                     "command": "azureResourceGroups.viewProperties",
@@ -266,7 +278,8 @@
     "dependencies": {
         "azure-arm-resource": "^3.0.0-preview",
         "fs-extra": "^8.1.0",
-        "vscode-azureextensionui": "^0.33.0",
+        "jsonc-parser": "^2.2.1",
+        "vscode-azureextensionui": "^0.33.1",
         "vscode-nls": "^4.1.1"
     },
     "extensionDependencies": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,7 @@
 {
     "azureResourceGroups.createResourceGroup": "Create Resource Group...",
     "azureResourceGroups.deleteResourceGroup": "Delete...",
+    "azureResourceGroups.editTags": "Edit Tags...",
     "azureResourceGroups.description": "An Azure Resource Groups extension for Visual Studio Code.",
     "azureResourceGroups.enableOutputTimestamps": "Prepends each line displayed in the output channel with a timestamp.",
     "azureResourceGroups.loadMore": "Load More",

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -10,6 +10,7 @@ import { createResourceGroup } from './createResourceGroup';
 import { deleteResourceGroup } from './deleteResourceGroup';
 import { openInPortal } from './openInPortal';
 import { revealResource } from './revealResource';
+import { editTags } from './tags/editTags';
 import { viewProperties } from './viewProperties';
 
 export function registerCommands(): void {
@@ -21,4 +22,5 @@ export function registerCommands(): void {
     registerCommand('azureResourceGroups.revealResource', revealResource);
     registerCommand('azureResourceGroups.selectSubscriptions', () => commands.executeCommand('azure-account.selectSubscriptions'));
     registerCommand('azureResourceGroups.viewProperties', viewProperties);
+    registerCommand('azureResourceGroups.editTags', editTags);
 }

--- a/src/commands/tags/AzExtFileSystem.ts
+++ b/src/commands/tags/AzExtFileSystem.ts
@@ -1,0 +1,140 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as querystring from "querystring";
+import { Disposable, Event, EventEmitter, FileChangeEvent, FileChangeType, FileStat, FileSystemError, FileSystemProvider, FileType, Uri, window } from "vscode";
+import { AzExtTreeItem, callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
+import { ext } from "../../extensionVariables";
+import { localize } from "../../utils/localize";
+
+const unsupportedError: Error = new Error(localize('notSupported', 'This operation is not supported.'));
+
+// tslint:disable-next-line: no-reserved-keywords
+export type TreeItemChangeEvent<T extends AzExtTreeItem> = { type: FileChangeType; treeItem: T };
+
+export abstract class AzExtFileSystem<T extends AzExtTreeItem> implements FileSystemProvider {
+    public abstract scheme: string;
+
+    private readonly _emitter: EventEmitter<FileChangeEvent[]> = new EventEmitter<FileChangeEvent[]>();
+    private readonly _bufferedEvents: FileChangeEvent[] = [];
+    private _fireSoonHandle?: NodeJS.Timer;
+
+    public get onDidChangeFile(): Event<FileChangeEvent[]> {
+        return this._emitter.event;
+    }
+
+    public abstract statImpl(context: IActionContext, node: T, originalUri: Uri): Promise<FileStat>;
+    public abstract readFileImpl(context: IActionContext, node: T, originalUri: Uri): Promise<Uint8Array>;
+    public abstract writeFileImpl(context: IActionContext, node: T, content: Uint8Array, originalUri: Uri): Promise<void>;
+    public abstract getFilePath(node: T): string;
+
+    public async showTextDocument(node: T): Promise<void> {
+        await window.showTextDocument(this.getUri(node));
+    }
+
+    public watch(): Disposable {
+        return new Disposable(() => {
+            // Since we're not actually watching "in Azure" (i.e. polling for changes), there's no need to selectively watch based on the Uri passed in here. Thus there's nothing to dispose
+        });
+    }
+
+    public async stat(uri: Uri): Promise<FileStat> {
+        return await callWithTelemetryAndErrorHandling('stat', async (context) => {
+            context.telemetry.suppressIfSuccessful = true;
+
+            const node: T = await this.lookup(context, uri);
+            return await this.statImpl(context, node, uri);
+            // tslint:disable-next-line: strict-boolean-expressions
+        }) || { type: FileType.Unknown, ctime: 0, mtime: 0, size: 0 };
+    }
+
+    public async readFile(uri: Uri): Promise<Uint8Array> {
+        return await callWithTelemetryAndErrorHandling('readFile', async (context) => {
+            context.errorHandling.rethrow = true;
+            context.errorHandling.suppressDisplay = true;
+
+            const node: T = await this.lookup(context, uri);
+            return await this.readFileImpl(context, node, uri);
+            // tslint:disable-next-line: strict-boolean-expressions
+        }) || Buffer.from('');
+    }
+
+    public async writeFile(uri: Uri, content: Uint8Array): Promise<void> {
+        await callWithTelemetryAndErrorHandling('writeFile', async (context) => {
+            const node: T = await this.lookup(context, uri);
+            await this.writeFileImpl(context, node, content, uri);
+            await node.refresh();
+        });
+    }
+
+    public readDirectory(_uri: Uri): [string, FileType][] | Thenable<[string, FileType][]> {
+        throw unsupportedError;
+    }
+
+    public async createDirectory(_uri: Uri): Promise<void> {
+        throw unsupportedError;
+    }
+
+    // tslint:disable-next-line: no-reserved-keywords
+    public async delete(_uri: Uri): Promise<void> {
+        throw unsupportedError;
+    }
+
+    public async rename(_uri: Uri): Promise<void> {
+        throw unsupportedError;
+    }
+
+    /**
+     * Uses a simple buffer to group events that occur within a few milliseconds of each other
+     * Adapted from https://github.com/microsoft/vscode-extension-samples/blob/master/fsprovider-sample/src/fileSystemProvider.ts
+     */
+    // tslint:disable-next-line: no-reserved-keywords
+    public fireSoon(...events: TreeItemChangeEvent<T>[]): void {
+        this._bufferedEvents.push(...events.map(e => {
+            return {
+                type: e.type,
+                uri: this.getUri(e.treeItem)
+            };
+        }));
+
+        if (this._fireSoonHandle) {
+            clearTimeout(this._fireSoonHandle);
+        }
+
+        this._fireSoonHandle = setTimeout(
+            () => {
+                this._emitter.fire(this._bufferedEvents);
+                this._bufferedEvents.length = 0; // clear buffer
+            },
+            5
+        );
+    }
+
+    public areUrisEqual(uri1: Uri, uri2: Uri): boolean {
+        return this.getResourceId(uri1) === this.getResourceId(uri2);
+    }
+
+    private getUri(node: T): Uri {
+        const fileName: string = this.getFilePath(node);
+        return Uri.parse(`${this.scheme}:///${fileName}?resourceId=${node.fullId}`);
+    }
+
+    private async lookup(context: IActionContext, uri: Uri): Promise<T> {
+        const resourceId: string = this.getResourceId(uri);
+        const node: T | undefined = await ext.tree.findTreeItem(resourceId, context);
+        if (!node) {
+            context.telemetry.suppressAll = true;
+            context.errorHandling.rethrow = true;
+            context.errorHandling.suppressDisplay = true;
+            throw FileSystemError.FileNotFound(uri);
+        } else {
+            return node;
+        }
+    }
+
+    private getResourceId(uri: Uri): string {
+        return <string>(querystring.parse(uri.query)).resourceId;
+    }
+}

--- a/src/commands/tags/TagFileSystem.ts
+++ b/src/commands/tags/TagFileSystem.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceManagementClient } from "azure-arm-resource";
+import * as jsonc from 'jsonc-parser';
+import * as os from "os";
+import { commands, Diagnostic, FileStat, FileType, MessageItem, Uri, window } from "vscode";
+import { createAzureClient, IActionContext } from 'vscode-azureextensionui';
+import { ext } from "../../extensionVariables";
+import { ResourceGroupTreeItem } from "../../tree/ResourceGroupTreeItem";
+import { localize } from "../../utils/localize";
+import { AzExtFileSystem } from "./AzExtFileSystem";
+import { getTagDiagnostics } from "./getTagDiagnostics";
+
+const insertKeyHere: string = localize('insertTagName', '<Insert tag name>');
+const insertValueHere: string = localize('insertTagValue', '<Insert tag value>');
+
+/**
+ * For now this file system only supports editing tags.
+ * However, the scheme was left generic so that it could support editing other stuff in this extension without needing to create a whole new file system
+ */
+export class TagFileSystem extends AzExtFileSystem<ResourceGroupTreeItem> {
+    public static scheme: string = 'azureResourceGroups';
+    public scheme: string = TagFileSystem.scheme;
+
+    public async statImpl(_context: IActionContext, node: ResourceGroupTreeItem): Promise<FileStat> {
+        const fileContent: string = this.getFileContentFromTags(node.data.tags);
+        return { type: FileType.File, ctime: node.cTime, mtime: node.mTime, size: Buffer.byteLength(fileContent) };
+    }
+
+    public async readFileImpl(_context: IActionContext, node: ResourceGroupTreeItem): Promise<Uint8Array> {
+        const fileContent: string = this.getFileContentFromTags(node.data.tags);
+        return Buffer.from(fileContent);
+    }
+
+    public async writeFileImpl(context: IActionContext, node: ResourceGroupTreeItem, content: Uint8Array, originalUri: Uri): Promise<void> {
+        const text: string = content.toString();
+
+        // tslint:disable-next-line: strict-boolean-expressions
+        const diagnostics: readonly Diagnostic[] = ext.diagnosticCollection.get(originalUri) || getTagDiagnostics(text);
+        if (diagnostics.length > 0) {
+            context.telemetry.measurements.tagDiagnosticsLength = diagnostics.length;
+
+            const showErrors: MessageItem = { title: localize('showErrors', 'Show Errors') };
+            const message: string = localize('errorsExist', 'Failed to upload tags for resource group "{0}".', node.name);
+            // don't wait
+            window.showErrorMessage(message, showErrors).then(async (result) => {
+                if (result === showErrors) {
+                    const openedUri: Uri | undefined = window.activeTextEditor?.document.uri;
+                    if (!openedUri || !this.areUrisEqual(originalUri, openedUri)) {
+                        await this.showTextDocument(node);
+                    }
+
+                    await commands.executeCommand('workbench.action.showErrorsWarnings');
+                }
+            });
+
+            context.errorHandling.suppressDisplay = true;
+            // This won't be displayed, but might as well track the first diagnostic for telemetry
+            throw new Error(diagnostics[0].message);
+        } else {
+            const message: string = localize('confirmTags', 'Are you sure you want to update tags for resource group "{0}"?', node.name);
+            const update: MessageItem = { title: localize('update', 'Update') };
+            await ext.ui.showWarningMessage(message, { modal: true }, update);
+
+            const tags: {} = <{}>jsonc.parse(text);
+
+            // remove example tag
+            if (Object.keys(tags).includes(insertKeyHere) && tags[insertKeyHere] === insertValueHere) {
+                delete tags[insertKeyHere];
+            }
+
+            const client: ResourceManagementClient = createAzureClient(node.root, ResourceManagementClient);
+            await client.resourceGroups.update(node.name, { tags });
+            window.showInformationMessage(localize('updatedRgTags', 'Successfully updated tags for resource group "{0}".', node.name));
+        }
+    }
+
+    public getFilePath(node: ResourceGroupTreeItem): string {
+        return `${node.name}-tags.jsonc`;
+    }
+
+    private getFileContentFromTags(tags: {} | undefined): string {
+        // tslint:disable-next-line: strict-boolean-expressions
+        tags = tags || {};
+
+        const comment: string = localize('editAndSave', 'Edit and save this file to upload tags in Azure');
+        if (Object.keys(tags).length === 0) {
+            tags[insertKeyHere] = insertValueHere;
+        }
+        return `// ${comment}${os.EOL}${JSON.stringify(tags, undefined, 4)}`;
+    }
+}

--- a/src/commands/tags/editTags.ts
+++ b/src/commands/tags/editTags.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from "vscode-azureextensionui";
+import { ext } from "../../extensionVariables";
+import { ResourceGroupTreeItem } from "../../tree/ResourceGroupTreeItem";
+
+export async function editTags(context: IActionContext, node?: ResourceGroupTreeItem): Promise<void> {
+    if (!node) {
+        node = await ext.tree.showTreeItemPicker<ResourceGroupTreeItem>(ResourceGroupTreeItem.contextValue, context);
+    }
+
+    await ext.tagFS.showTextDocument(node);
+}

--- a/src/commands/tags/getTagDiagnostics.ts
+++ b/src/commands/tags/getTagDiagnostics.ts
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as jsonc from 'jsonc-parser';
+import { Diagnostic, Position, Range } from "vscode";
+import { localize } from "../../utils/localize";
+import { nonNullValue } from "../../utils/nonNull";
+
+export function getTagDiagnostics(text: string): Diagnostic[] {
+    const visitor: TagVisitor = new TagVisitor();
+    jsonc.visit(text, visitor);
+    return visitor.diagnostics;
+}
+
+/**
+ * Tag docs: https://docs.microsoft.com/azure/azure-resource-manager/management/tag-resources#limitations
+ *
+ * Note: 'this' is not properly bound in 'jsonc-parser'. As a workaround, I'm using the following notation for methods:
+ *     public helloWorld = () => { };
+ * instead of this:
+ *     public helloWorld(): void { }
+ */
+class TagVisitor implements jsonc.JSONVisitor {
+    public diagnostics: Diagnostic[] = [];
+    private readonly _objectOpenBracketPositions: Position[] = [];
+    private readonly _arrayOpenBracketPositions: Position[] = [];
+    private _tagCount: number = 0;
+
+    /**
+     * Invoked when an open brace is encountered and an object is started. The offset and length represent the location of the open brace.
+     */
+    public onObjectBegin = (_offset: number, _length: number, startLine: number, startCharacter: number) => {
+        this._objectOpenBracketPositions.push(new Position(startLine, startCharacter));
+    }
+
+    /**
+     * Invoked when a closing brace is encountered and an object is completed. The offset and length represent the location of the closing brace.
+     */
+    public onObjectEnd = (_offset: number, _length: number, closeBracketLine: number, closeBracketChar: number) => {
+        const openBracketPosition: Position = nonNullValue(this._objectOpenBracketPositions.pop());
+        if (this._objectOpenBracketPositions.length === 1) { // only show the error for an outer-most invalid object
+            const range: Range = new Range(openBracketPosition, new Position(closeBracketLine, closeBracketChar + 1));
+            this.addTagValueTypeError(range, 'object');
+        }
+    }
+
+    /**
+     * Invoked when an open bracket is encountered. The offset and length represent the location of the open bracket.
+     */
+    public onArrayBegin = (_offset: number, _length: number, startLine: number, startCharacter: number) => {
+        this._arrayOpenBracketPositions.push(new Position(startLine, startCharacter));
+    }
+
+    /**
+     * Invoked when a closing bracket is encountered. The offset and length represent the location of the closing bracket.
+     */
+    public onArrayEnd = (_offset: number, _length: number, closeBracketLine: number, closeBracketChar: number) => {
+        const openBracketPosition: Position = nonNullValue(this._arrayOpenBracketPositions.pop());
+        if (this._arrayOpenBracketPositions.length === 0) { // only show the error for an outer-most array
+            const range: Range = new Range(openBracketPosition, new Position(closeBracketLine, closeBracketChar + 1));
+            const actualType: string = 'array';
+            if (this._objectOpenBracketPositions.length === 0) {
+                this.addTagsTypeError(range, actualType);
+            } else if (this._objectOpenBracketPositions.length === 1) {
+                this.addTagValueTypeError(range, actualType);
+            }
+        }
+    }
+
+    /**
+     * Invoked when a property is encountered. The offset and length represent the location of the property name.
+     */
+    public onObjectProperty = (property: string, _offset: number, length: number, startLine: number, startCharacter: number) => {
+        if (this._objectOpenBracketPositions.length === 1) {
+            this._tagCount += 1;
+
+            const range: Range = new Range(startLine, startCharacter, startLine, startCharacter + length);
+            const max: number = 512;
+            if (property.length > max) {
+                this.addError(range, localize('tagNameTooLong', 'Tag name must be {0} characters or less.', max));
+            }
+
+            const invalidChars: string[] = ['<', '>', '%', '&', '\\', '?', '/'];
+            const matchingChars: string[] = invalidChars.filter(c => property.includes(c));
+            if (matchingChars.length > 0) {
+                const error: string = localize('tag', 'Tag name cannot contain the following characters: {0}', invalidChars.join(', '));
+                this.addError(range, error);
+            }
+
+            const maxTags: number = 50;
+            if (this._tagCount > maxTags) {
+                this.addError(range, localize('tooManyTags', 'Only {0} tags are allowed.', maxTags));
+            }
+        }
+    }
+
+    /**
+     * Invoked when a literal value is encountered. The offset and length represent the location of the literal value.
+     */
+    public onLiteralValue = (value: unknown, _offset: number, length: number, startLine: number, startChar: number) => {
+        const range: Range = new Range(startLine, startChar, startLine, startChar + length);
+        const actualType: string = typeof value;
+        if (this._objectOpenBracketPositions.length === 0) {
+            this.addTagsTypeError(range, actualType);
+        } else if (typeof value !== 'string') {
+            this.addTagValueTypeError(range, actualType);
+        } else {
+            const max: number = 256;
+            if (value.length > max) {
+                this.addError(range, localize('tagValueTooLong', 'Tag value must be {0} characters or less.', max));
+            }
+        }
+    }
+
+    private addTagsTypeError(range: Range, actualType: string): void {
+        this.addError(range, localize('tagsTypeError', 'Tags must be an object of key/value pairs instead of "{0}".', actualType));
+    }
+
+    private addTagValueTypeError(range: Range, actualType: string): void {
+        this.addError(range, localize('tagTypeError', 'Tag value must be of type "string" instead of "{0}".', actualType));
+    }
+
+    private addError(range: Range, error: string): void {
+        this.diagnostics.push(new Diagnostic(range, error));
+    }
+}

--- a/src/commands/tags/registerTagDiagnostics.ts
+++ b/src/commands/tags/registerTagDiagnostics.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Diagnostic, languages, TextDocument, TextDocumentChangeEvent, TextEditor, window, workspace } from "vscode";
+import { callWithTelemetryAndErrorHandling, IActionContext, registerEvent } from "vscode-azureextensionui";
+import { ext } from "../../extensionVariables";
+import { getTagDiagnostics } from "./getTagDiagnostics";
+import { TagFileSystem } from "./TagFileSystem";
+
+export function registerTagDiagnostics(): void {
+    ext.diagnosticCollection = languages.createDiagnosticCollection('Azure Tags');
+    ext.context.subscriptions.push(ext.diagnosticCollection);
+
+    registerEvent('onDidChangeActiveTextEditor', window.onDidChangeActiveTextEditor, onDidChangeActiveTextEditor);
+}
+
+function onDidChangeActiveTextEditor(context: IActionContext, editor: TextEditor | undefined): void {
+    context.telemetry.suppressIfSuccessful = true;
+    context.errorHandling.suppressDisplay = true;
+
+    if (editor?.document.uri.scheme === TagFileSystem.scheme) {
+        if (!ext.diagnosticWatcher) {
+            ext.diagnosticWatcher = workspace.onDidChangeTextDocument(onDidChangeTextDocument);
+        }
+        updateTagDiagnostics(editor.document);
+    } else if (ext.diagnosticWatcher) {
+        ext.diagnosticWatcher.dispose();
+        ext.diagnosticWatcher = undefined;
+        ext.diagnosticCollection.clear();
+    }
+}
+
+async function onDidChangeTextDocument(e: TextDocumentChangeEvent): Promise<void> {
+    await callWithTelemetryAndErrorHandling('onDidChangeTextDocument', context => {
+        context.telemetry.suppressIfSuccessful = true;
+        context.errorHandling.suppressDisplay = true;
+
+        if (e.contentChanges.length > 0 && e.document.uri.scheme === TagFileSystem.scheme) {
+            updateTagDiagnostics(e.document);
+        }
+    });
+}
+
+function updateTagDiagnostics(document: TextDocument): void {
+    const diagnostics: Diagnostic[] = getTagDiagnostics(document.getText());
+    ext.diagnosticCollection.set(document.uri, diagnostics);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,8 @@ import { AzExtTreeDataProvider, AzureUserInput, callWithTelemetryAndErrorHandlin
 // tslint:disable-next-line:no-submodule-imports
 import { AzureExtensionApiProvider } from 'vscode-azureextensionui/api';
 import { registerCommands } from './commands/registerCommands';
+import { registerTagDiagnostics } from './commands/tags/registerTagDiagnostics';
+import { TagFileSystem } from './commands/tags/TagFileSystem';
 import { ext } from './extensionVariables';
 import { AzureAccountTreeItem } from './tree/AzureAccountTreeItem';
 
@@ -31,12 +33,16 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         ext.tree = new AzExtTreeDataProvider(accountTreeItem, 'azureResourceGroups.loadMore');
         context.subscriptions.push(vscode.window.createTreeView('azureResourceGroups', { treeDataProvider: ext.tree, showCollapseAll: true, canSelectMany: true }));
 
+        ext.tagFS = new TagFileSystem();
+        context.subscriptions.push(vscode.workspace.registerFileSystemProvider(TagFileSystem.scheme, ext.tagFS));
+        registerTagDiagnostics();
+
         registerCommands();
     });
 
     return createApiProvider([]);
 }
 
-// tslint:disable-next-line:no-empty
 export function deactivateInternal(): void {
+    ext.diagnosticWatcher?.dispose();
 }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionContext } from "vscode";
+import { DiagnosticCollection, Disposable, ExtensionContext } from "vscode";
 import { AzExtTreeDataProvider, IAzExtOutputChannel, IAzureUserInput } from "vscode-azureextensionui";
+import { TagFileSystem } from "./commands/tags/TagFileSystem";
 
 /**
  * Namespace for common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
@@ -17,4 +18,8 @@ export namespace ext {
     export let ui: IAzureUserInput;
     export let ignoreBundle: boolean | undefined;
     export let prefix: string = 'azureResourceGroups';
+
+    export let tagFS: TagFileSystem;
+    export let diagnosticWatcher: Disposable | undefined;
+    export let diagnosticCollection: DiagnosticCollection;
 }

--- a/test/getTagDiagnostics.test.ts
+++ b/test/getTagDiagnostics.test.ts
@@ -1,0 +1,188 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Diagnostic } from 'vscode';
+import { getTagDiagnostics, nonNullValue } from '../extension.bundle';
+
+const invalidTagType: RegExp = /tag value.*type/i;
+const invalidTagsType: RegExp = /tags.*object.*pairs/i;
+const invalidCharsKey: RegExp = /cannot contain.*characters/i;
+const tooManyTags: RegExp = /only 50 tags/i;
+const valueTooLong: RegExp = /tag value.*256/i;
+const keyTooLong: RegExp = /tag name.*512/i;
+
+suite('getTagDiagnostics', () => {
+    interface IExpectedDiagnostic {
+        range: [number, number, number, number];
+        error: RegExp;
+    }
+
+    interface ITestCase {
+        name: string;
+        text: unknown;
+        diagnostics: IExpectedDiagnostic[];
+    }
+
+    const testCases: ITestCase[] = [
+        {
+            name: 'valid',
+            text: { test: 'test' },
+            diagnostics: []
+        },
+        //#region Invalid tags type
+        {
+            name: 'numberTags',
+            text: 3,
+            diagnostics: [
+                { range: [0, 0, 0, 1], error: invalidTagsType }
+            ]
+        },
+        {
+            name: 'booleanTags',
+            text: true,
+            diagnostics: [
+                { range: [0, 0, 0, 4], error: invalidTagsType }
+            ]
+        },
+        {
+            name: 'arrayTags',
+            text: [],
+            diagnostics: [
+                { range: [0, 0, 0, 2], error: invalidTagsType }
+            ]
+        },
+        {
+            name: 'nestedArrayTags',
+            text: [[]],
+            diagnostics: [
+                { range: [0, 0, 2, 1], error: invalidTagsType }
+            ]
+        },
+        //#endregion
+        //#region Invalid prop type
+        {
+            name: 'numberProp',
+            text: { test: 3 },
+            diagnostics: [
+                { range: [1, 12, 1, 13], error: invalidTagType }
+            ]
+        },
+        {
+            name: 'booleanProp',
+            text: { test: true },
+            diagnostics: [
+                { range: [1, 12, 1, 16], error: invalidTagType }
+            ]
+        },
+        {
+            name: 'arrayProp',
+            text: { test: [] },
+            diagnostics: [
+                { range: [1, 12, 1, 14], error: invalidTagType }
+            ]
+        },
+        {
+            name: 'nestedArrayProp',
+            text: { test: [[]] },
+            diagnostics: [
+                { range: [1, 12, 3, 5], error: invalidTagType }
+            ]
+        },
+        {
+            name: 'objectProp',
+            text: { test: {} },
+            diagnostics: [
+                { range: [1, 12, 1, 14], error: invalidTagType }
+            ]
+        },
+        {
+            name: 'nestedObjectProp',
+            text: { test: { test2: {} } },
+            diagnostics: [
+                { range: [1, 12, 3, 5], error: invalidTagType }
+            ]
+        },
+        {
+            name: 'nestObjectWithInvalidProp',
+            text: { test: { 'test%2': {} } },
+            diagnostics: [
+                { range: [1, 12, 3, 5], error: invalidTagType }
+            ]
+        },
+        //#endregion
+        {
+            name: 'disallowedCharKey',
+            text: { 'tes%t': 'test' },
+            diagnostics: [
+                { range: [1, 4, 1, 11], error: invalidCharsKey }
+            ]
+        },
+        {
+            name: 'tooLongKey',
+            text: (() => {
+                const value = {};
+                value['a'.repeat(513)] = 'test';
+                return value;
+            })(),
+            diagnostics: [
+                { range: [1, 4, 1, 519], error: keyTooLong }
+            ]
+        },
+        {
+            name: 'tooLongProp',
+            text: { test: 'a'.repeat(257) },
+            diagnostics: [
+                { range: [1, 12, 1, 271], error: valueTooLong }
+            ]
+        },
+        {
+            name: 'tooManyProps',
+            text: (() => {
+                const value = {};
+                let count: number = 0;
+                while (count < 52) {
+                    value[String(count)] = 'test';
+                    count += 1;
+                }
+                return value;
+            })(),
+            diagnostics: [
+                { range: [51, 4, 51, 8], error: tooManyTags },
+                { range: [52, 4, 52, 8], error: tooManyTags }
+            ]
+        },
+        {
+            name: 'multipleErrors',
+            text: {
+                test: '5',
+                'test/': '3',
+                test2: '5',
+                test3: false
+            },
+            diagnostics: [
+                { range: [2, 4, 2, 11], error: invalidCharsKey },
+                { range: [4, 13, 4, 18], error: invalidTagType }
+            ]
+        }
+    ];
+
+    for (const testCase of testCases) {
+        test(testCase.name, () => {
+            const text = typeof testCase.text === 'object' ? JSON.stringify(testCase.text, undefined, 4) : String(testCase.text);
+            const diagnostics: Diagnostic[] = getTagDiagnostics(text);
+            assert.strictEqual(diagnostics.length, testCase.diagnostics.length, 'Number of diagnostics does not match.');
+            for (const actual of diagnostics) {
+                const expected = nonNullValue(testCase.diagnostics.shift());
+                const [startLine, startChar, endLine, endChar]: number[] = expected.range;
+                assert.strictEqual(actual.range.start.line, startLine, 'Start line does not match.');
+                assert.strictEqual(actual.range.start.character, startChar, 'Start char does not match.');
+                assert.strictEqual(actual.range.end.line, endLine, 'End line does not match.');
+                assert.strictEqual(actual.range.end.character, endChar, 'End char does not match.');
+                assert.ok(expected.error.test(actual.message), 'Message does not match.');
+            }
+        });
+    }
+});


### PR DESCRIPTION
I implemented a pared down version of VS Code's `FileSystemProvider` that only supports editing single files (aka no read directory, etc.). This should hopefully replace `AzureBaseEditor` in the UI package - I'll do that once I make sure this works for at least one other scenario (probably App Service since I think that's the only thing using `AzureBaseEditor` at the moment).

I went the file system route because I think it's easier to view/edit tags in a file than a wizard and it felt like displaying tags in the tree would clutter it up too much. Users still get basic validation in the form of standard VS Code problems:

<img width="646" alt="Screen Shot 2020-06-03 at 5 00 40 PM" src="https://user-images.githubusercontent.com/11282622/83700508-db018a00-a5bb-11ea-8260-00bf6f7709bb.png">

I plan to support editing tags on resources in a future PR.