### PR TITLE
Hide some resource types

### DIFF
--- a/package.json
+++ b/package.json
@@ -240,6 +240,11 @@
                             "%azureResourceGroups.deleteConfirmation.ClickButton%"
                         ],
                         "default": "EnterName"
+                    },
+                    "azureResourceGroups.showHiddenTypes": {
+                        "type": "boolean",
+                        "description": "%azureResourceGroups.showHiddenTypes%",
+                        "default": false
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -11,5 +11,6 @@
     "azureResourceGroups.viewProperties": "View Properties",
     "azureResourceGroups.deleteConfirmation": "The behavior to use when confirming delete of a resource group.",
     "azureResourceGroups.deleteConfirmation.EnterName": "Prompts with an input box where you enter the resource group name to delete.",
-    "azureResourceGroups.deleteConfirmation.ClickButton": "Prompts with a warning dialog where you click a button to delete."
+    "azureResourceGroups.deleteConfirmation.ClickButton": "Prompts with a warning dialog where you click a button to delete.",
+    "azureResourceGroups.showHiddenTypes": "Show some ancillary resources that are created/managed by Azure infrastructure. Displaying them is typically useful when you want to clean up your resource groups or subscriptions."
 }

--- a/src/tree/ResourceGroupTreeItem.ts
+++ b/src/tree/ResourceGroupTreeItem.ts
@@ -10,6 +10,7 @@ import { ext } from "../extensionVariables";
 import { createResourceClient } from "../utils/azureClients";
 import { localize } from "../utils/localize";
 import { nonNullProp } from "../utils/nonNull";
+import { settingUtils } from "../utils/settingUtils";
 import { treeUtils } from "../utils/treeUtils";
 import { ResourceTreeItem } from "./ResourceTreeItem";
 
@@ -65,7 +66,19 @@ export class ResourceGroupTreeItem extends AzureParentTreeItem {
         return await this.createTreeItemsWithErrorHandling(
             resources,
             'invalidResource',
-            resource => new ResourceTreeItem(this, resource),
+            resource => {
+                const hiddenTypes: string[] = [
+                    'microsoft.alertsmanagement/smartdetectoralertrules',
+                    'microsoft.insights/actiongroups',
+                    'microsoft.security/automations'
+                ];
+
+                if (settingUtils.getWorkspaceSetting<boolean>('showHiddenTypes') || (resource.type && !hiddenTypes.includes(resource.type.toLowerCase()))) {
+                    return new ResourceTreeItem(this, resource);
+                } else {
+                    return undefined;
+                }
+            },
             resource => resource.name
         );
     }


### PR DESCRIPTION
Modeled after the portal:
![Screen Shot 2020-12-03 at 2 42 58 PM](https://user-images.githubusercontent.com/11282622/101103661-3b2eb400-357e-11eb-9c54-3e267c879f43.png)

Unfortunately I don't know all the types that should be hidden, but I figured I'd at least start with the types I saw on my subscription