### PR TITLE
Add "Help and Feedback" view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Azure Resource Groups for Visual Studio Code (Preview)
+# Azure Resources for Visual Studio Code (Preview)
 
 <!-- region exclude-from-marketplace -->
 
@@ -6,7 +6,7 @@
 
 <!-- endregion exclude-from-marketplace -->
 
-Manage Azure Resource Groups directly from VS Code.
+View and manage Azure Resources directly from VS Code.
 
 ![explorer](resources/readme/explorer.png)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureresourcegroups",
-    "displayName": "Azure Resource Groups",
+    "displayName": "Azure Resources",
     "description": "%azureResourceGroups.description%",
     "version": "0.2.1-alpha",
     "publisher": "ms-azuretools",
@@ -35,10 +35,15 @@
         "onCommand:azureResourceGroups.loadMore",
         "onCommand:azureResourceGroups.openInPortal",
         "onCommand:azureResourceGroups.refresh",
+        "onCommand:azureResourceGroups.reportIssue",
         "onCommand:azureResourceGroups.revealResource",
         "onCommand:azureResourceGroups.selectSubscriptions",
         "onCommand:azureResourceGroups.viewProperties",
-        "onView:azureResourceGroups"
+        "onCommand:ms-azuretools.getStarted",
+        "onCommand:ms-azuretools.reportIssue",
+        "onCommand:ms-azuretools.reviewIssues",
+        "onView:azureResourceGroups",
+        "onView:ms-azuretools.helpAndFeedback"
     ],
     "main": "./main.js",
     "contributes": {
@@ -98,6 +103,26 @@
                 "command": "azureResourceGroups.viewProperties",
                 "title": "%azureResourceGroups.viewProperties%",
                 "category": "Azure Resource Groups"
+            },
+            {
+                "command": "azureResourceGroups.reportIssue",
+                "title": "%azureResourceGroups.reportIssue%",
+                "category": "Azure Resource Groups"
+            },
+            {
+                "command": "ms-azuretools.getStarted",
+                "title": "%ms-azuretools.getStarted%",
+                "category": "Azure"
+            },
+            {
+                "command": "ms-azuretools.reportIssue",
+                "title": "%ms-azuretools.reportIssue%",
+                "category": "Azure"
+            },
+            {
+                "command": "ms-azuretools.reviewIssues",
+                "title": "%ms-azuretools.reviewIssues%",
+                "category": "Azure"
             }
         ],
         "viewsContainers": {
@@ -113,7 +138,13 @@
             "azure": [
                 {
                     "id": "azureResourceGroups",
-                    "name": "Resource Groups"
+                    "name": "Resource Groups",
+                    "visibility": "collapsed"
+                },
+                {
+                    "id": "ms-azuretools.helpAndFeedback",
+                    "name": "%ms-azuretools.helpAndFeedback%",
+                    "visibility": "collapsed"
                 }
             ]
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,7 +2,7 @@
     "azureResourceGroups.createResourceGroup": "Create Resource Group...",
     "azureResourceGroups.deleteResourceGroup": "Delete...",
     "azureResourceGroups.editTags": "Edit Tags...",
-    "azureResourceGroups.description": "An Azure Resource Groups extension for Visual Studio Code.",
+    "azureResourceGroups.description": "An extension for viewing and managing Azure resources.",
     "azureResourceGroups.enableOutputTimestamps": "Prepends each line displayed in the output channel with a timestamp.",
     "azureResourceGroups.loadMore": "Load More",
     "azureResourceGroups.openInPortal": "Open in Portal",
@@ -12,5 +12,10 @@
     "azureResourceGroups.deleteConfirmation": "The behavior to use when confirming delete of a resource group.",
     "azureResourceGroups.deleteConfirmation.EnterName": "Prompts with an input box where you enter the resource group name to delete.",
     "azureResourceGroups.deleteConfirmation.ClickButton": "Prompts with a warning dialog where you click a button to delete.",
-    "azureResourceGroups.showHiddenTypes": "Show some ancillary resources that are created/managed by Azure infrastructure. Displaying them is typically useful when you want to clean up your resource groups or subscriptions."
+    "azureResourceGroups.reportIssue": "Report Issue...",
+    "azureResourceGroups.showHiddenTypes": "Show some ancillary resources that are created/managed by Azure infrastructure. Displaying them is typically useful when you want to clean up your resource groups or subscriptions.",
+    "ms-azuretools.getStarted": "Get Started...",
+    "ms-azuretools.helpAndFeedback": "Help and Feedback",
+    "ms-azuretools.reportIssue": "Report Issue...",
+    "ms-azuretools.reviewIssues": "Review Issues..."
 }

--- a/src/AzExtWrapper.ts
+++ b/src/AzExtWrapper.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceManagementModels } from "@azure/arm-resources";
+import { commands, Extension, extensions } from "vscode";
+import { IAzureQuickPickItem } from "vscode-azureextensionui";
+// tslint:disable-next-line: no-submodule-imports
+import { AzureExtensionApiProvider } from "vscode-azureextensionui/api";
+import { azureExtensions, IAzExtMetadata, IAzExtResourceType, IAzExtTutorial } from "./azureExtensions";
+
+let wrappers: AzExtWrapper[] | undefined;
+export function getAzureExtensions(): AzExtWrapper[] {
+    if (!wrappers) {
+        wrappers = azureExtensions.map(d => new AzExtWrapper(d));
+    }
+    return wrappers;
+}
+
+export function getInstalledAzureExtensions(): AzExtWrapper[] {
+    const azExtensions: AzExtWrapper[] = getAzureExtensions();
+    return azExtensions.filter(e => !!e.getCodeExtension());
+}
+
+export function getInstalledExtensionPicks(): IAzureQuickPickItem<AzExtWrapper>[] {
+    return getInstalledAzureExtensions()
+        .map(e => { return { label: e.label, data: e }; })
+        .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export class AzExtWrapper {
+    public readonly id: string;
+
+    private readonly _resourceTypes: IAzExtResourceType[];
+    private readonly _data: IAzExtMetadata;
+    private _verifiedReportIssueCommandId?: string;
+
+    constructor(data: IAzExtMetadata) {
+        this._data = data;
+        // tslint:disable-next-line: strict-boolean-expressions
+        this.id = `${data.publisher || 'ms-azuretools'}.${data.name}`;
+        this._resourceTypes = data.resourceTypes.map(rt => {
+            return typeof rt === 'object' ? rt : {
+                name: rt,
+                matchesResource: () => true
+            };
+        });
+    }
+
+    public get name(): string {
+        return this._data.name;
+    }
+
+    public get label(): string {
+        return this._data.label;
+    }
+
+    public get tutorial(): IAzExtTutorial | undefined {
+        return this._data.tutorial;
+    }
+
+    public matchesResourceType(resource: ResourceManagementModels.GenericResource): boolean {
+        return this._resourceTypes.some(rt => {
+            return rt.name === resource.type?.toLowerCase() && rt.matchesResource(resource);
+        });
+    }
+
+    public getCodeExtension(): Extension<AzureExtensionApiProvider> | undefined {
+        return extensions.getExtension(this.id);
+    }
+
+    public async getReportIssueCommandId(): Promise<string | undefined> {
+        if (!this._verifiedReportIssueCommandId && this._data.reportIssueCommandId) {
+            const commandIs: string[] = await commands.getCommands(true /* filterInternal */);
+            if (commandIs.some(c => c === this._data.reportIssueCommandId)) {
+                // We want to verify because older versions of the Azure extensions might not support the "report issue" command yet
+                this._verifiedReportIssueCommandId = this._data.reportIssueCommandId;
+            }
+        }
+        return this._verifiedReportIssueCommandId;
+    }
+}

--- a/src/azureExtensions.ts
+++ b/src/azureExtensions.ts
@@ -46,7 +46,8 @@ export const azureExtensions: IAzExtMetadata[] = [
         tutorial: {
             label: localize('deployStatic', 'Deploy a static app'),
             url: 'https://aka.ms/AAb5xp8'
-        }
+        },
+        reportIssueCommandId: 'staticWebApps.reportIssue'
     },
     {
         name: 'vscode-azureresourcegroups',
@@ -59,14 +60,16 @@ export const azureExtensions: IAzExtMetadata[] = [
         label: 'Storage',
         resourceTypes: [
             'microsoft.storage/storageaccounts'
-        ]
+        ],
+        reportIssueCommandId: 'azureStorage.reportIssue'
     },
     {
         name: 'vscode-azurevirtualmachines',
         label: 'Virtual Machines',
         resourceTypes: [
             'microsoft.compute/virtualmachines'
-        ]
+        ],
+        reportIssueCommandId: 'azureVirtualMachines.reportIssue'
     },
     {
         name: 'vscode-azureeventgrid',
@@ -82,7 +85,8 @@ export const azureExtensions: IAzExtMetadata[] = [
         resourceTypes: [
             'microsoft.documentdb/databaseaccounts',
             'microsoft.dbforpostgresql/servers'
-        ]
+        ],
+        reportIssueCommandId: 'azureDatabases.reportIssue'
     }
 ];
 

--- a/src/azureExtensions.ts
+++ b/src/azureExtensions.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceManagementModels } from "@azure/arm-resources";
+import { localize } from "./utils/localize";
+
+export const azureExtensions: IAzExtMetadata[] = [
+    {
+        name: 'vscode-azurefunctions',
+        label: 'Functions',
+        resourceTypes: [
+            {
+                name: 'microsoft.web/sites',
+                matchesResource: isFunctionApp
+            }
+        ],
+        tutorial: {
+            label: localize('deployServerless', 'Create and deploy a serverless app'),
+            url: 'https://aka.ms/AAb5xpj'
+        },
+        reportIssueCommandId: 'azureFunctions.reportIssue'
+    },
+    {
+        name: 'vscode-azureappservice',
+        label: 'App Service',
+        resourceTypes: [
+            {
+                name: 'microsoft.web/sites',
+                matchesResource: r => !isFunctionApp(r)
+            }
+        ],
+        tutorial: {
+            label: localize('deployWebApp', 'Deploy a web app'),
+            url: 'https://aka.ms/AAb5dz2'
+        },
+        reportIssueCommandId: 'appService.ReportIssue'
+    },
+    {
+        name: 'vscode-azurestaticwebapps',
+        label: 'Static Web Apps',
+        resourceTypes: [
+            'microsoft.web/staticsites'
+        ],
+        tutorial: {
+            label: localize('deployStatic', 'Deploy a static app'),
+            url: 'https://aka.ms/AAb5xp8'
+        }
+    },
+    {
+        name: 'vscode-azureresourcegroups',
+        label: 'Resource Groups',
+        resourceTypes: [],
+        reportIssueCommandId: 'azureResourceGroups.reportIssue'
+    },
+    {
+        name: 'vscode-azurestorage',
+        label: 'Storage',
+        resourceTypes: [
+            'microsoft.storage/storageaccounts'
+        ]
+    },
+    {
+        name: 'vscode-azurevirtualmachines',
+        label: 'Virtual Machines',
+        resourceTypes: [
+            'microsoft.compute/virtualmachines'
+        ]
+    },
+    {
+        name: 'vscode-azureeventgrid',
+        label: 'Event Grid',
+        resourceTypes: [
+            'microsoft.eventgrid/eventsubscriptions',
+            'microsoft.eventgrid/topics'
+        ]
+    },
+    {
+        name: 'vscode-cosmosdb',
+        label: 'Databases',
+        resourceTypes: [
+            'microsoft.documentdb/databaseaccounts',
+            'microsoft.dbforpostgresql/servers'
+        ]
+    }
+];
+
+export interface IAzExtMetadata {
+    name: string;
+    label: string;
+    publisher?: string;
+    resourceTypes: (string | IAzExtResourceType)[];
+    tutorial?: IAzExtTutorial;
+    reportIssueCommandId?: string;
+}
+
+export interface IAzExtResourceType {
+    name: string;
+
+    /**
+     * Only necessary if the resourceType itself isn't enough to identify the extension
+     */
+    matchesResource(resource: ResourceManagementModels.GenericResource): boolean;
+}
+
+export interface IAzExtTutorial {
+    label: string;
+    url: string;
+}
+
+function isFunctionApp(resource: ResourceManagementModels.GenericResource): boolean {
+    return !!resource.kind?.toLowerCase().includes('functionapp');
+}

--- a/src/commands/helpAndFeedback/reportIssue.ts
+++ b/src/commands/helpAndFeedback/reportIssue.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { commands, env, Uri } from "vscode";
+import { IActionContext, IAzureQuickPickItem } from "vscode-azureextensionui";
+import { AzExtWrapper, getInstalledExtensionPicks } from "../../AzExtWrapper";
+import { ext } from "../../extensionVariables";
+import { localize } from "../../utils/localize";
+
+export async function reportIssue(context: IActionContext): Promise<void> {
+    const picks: IAzureQuickPickItem<AzExtWrapper | undefined>[] = getInstalledExtensionPicks();
+    picks.push({
+        label: localize('other', 'Other'),
+        data: undefined
+    });
+
+    const placeHolder: string = localize('selectExtension', 'Select the Azure extension you want to report an issue on');
+    const azExtension: AzExtWrapper | undefined = (await ext.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true })).data;
+    if (azExtension) {
+        context.telemetry.properties.extension = azExtension.name;
+        const commandId: string | undefined = await azExtension.getReportIssueCommandId();
+        if (commandId) {
+            await commands.executeCommand(commandId);
+        } else {
+            await openNewIssuePage(azExtension.name);
+        }
+    } else {
+        await openNewIssuePage('vscode-azuretools');
+    }
+}
+
+async function openNewIssuePage(extensionName: string): Promise<void> {
+    await env.openExternal(Uri.parse(`https://github.com/microsoft/${extensionName}/issues/new`));
+}

--- a/src/commands/helpAndFeedback/reportIssue.ts
+++ b/src/commands/helpAndFeedback/reportIssue.ts
@@ -27,7 +27,7 @@ export async function reportIssue(context: IActionContext): Promise<void> {
             await openNewIssuePage(azExtension.name);
         }
     } else {
-        await openNewIssuePage('vscode-azuretools');
+        await openNewIssuePage('azcode');
     }
 }
 

--- a/src/commands/helpAndFeedback/reviewIssues.ts
+++ b/src/commands/helpAndFeedback/reviewIssues.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { env, Uri } from "vscode";
+import { IActionContext, IAzureQuickPickItem } from "vscode-azureextensionui";
+import { AzExtWrapper, getInstalledExtensionPicks } from "../../AzExtWrapper";
+import { ext } from "../../extensionVariables";
+import { localize } from "../../utils/localize";
+
+export async function reviewIssues(context: IActionContext): Promise<void> {
+    const picks: IAzureQuickPickItem<AzExtWrapper>[] = getInstalledExtensionPicks();
+    const placeHolder: string = localize('selectExtension', 'Select the Azure extension you want to review issues for');
+    const azExtension: AzExtWrapper = (await ext.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true })).data;
+    context.telemetry.properties.extension = azExtension.name;
+    await env.openExternal(Uri.parse(`https://github.com/microsoft/${azExtension.name}/issues`));
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -4,10 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { commands } from 'vscode';
-import { AzureTreeItem, IActionContext, registerCommand } from 'vscode-azureextensionui';
+import { AzExtTreeItem, AzureTreeItem, IActionContext, registerCommand, registerErrorHandler, registerReportIssueCommand } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { createResourceGroup } from './createResourceGroup';
 import { deleteResourceGroup } from './deleteResourceGroup';
+import { getStarted } from './helpAndFeedback/getStarted';
+import { reportIssue } from './helpAndFeedback/reportIssue';
+import { reviewIssues } from './helpAndFeedback/reviewIssues';
 import { openInPortal } from './openInPortal';
 import { revealResource } from './revealResource';
 import { editTags } from './tags/editTags';
@@ -23,4 +26,13 @@ export function registerCommands(): void {
     registerCommand('azureResourceGroups.selectSubscriptions', () => commands.executeCommand('azure-account.selectSubscriptions'));
     registerCommand('azureResourceGroups.viewProperties', viewProperties);
     registerCommand('azureResourceGroups.editTags', editTags);
+
+    registerCommand('ms-azuretools.getStarted', getStarted);
+    registerCommand('ms-azuretools.loadMore', async (context: IActionContext, node: AzExtTreeItem) => await ext.helpTree.loadMore(node, context));
+    registerCommand('ms-azuretools.reportIssue', reportIssue);
+    registerCommand('ms-azuretools.reviewIssues', reviewIssues);
+
+    // Suppress "Report an Issue" button for all errors in favor of the command
+    registerErrorHandler(c => c.errorHandling.suppressReportIssue = true);
+    registerReportIssueCommand('azureResourceGroups.reportIssue');
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { registerTagDiagnostics } from './commands/tags/registerTagDiagnostics';
 import { TagFileSystem } from './commands/tags/TagFileSystem';
 import { ext } from './extensionVariables';
 import { AzureAccountTreeItem } from './tree/AzureAccountTreeItem';
+import { HelpTreeItem } from './tree/HelpTreeItem';
 
 export async function activateInternal(context: vscode.ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }, ignoreBundle?: boolean): Promise<AzureExtensionApiProvider> {
     ext.context = context;
@@ -36,6 +37,10 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         ext.tagFS = new TagFileSystem(ext.tree);
         context.subscriptions.push(vscode.workspace.registerFileSystemProvider(TagFileSystem.scheme, ext.tagFS));
         registerTagDiagnostics();
+
+        const helpTreeItem: HelpTreeItem = new HelpTreeItem();
+        ext.helpTree = new AzExtTreeDataProvider(helpTreeItem, 'ms-azuretools.loadMore');
+        context.subscriptions.push(vscode.window.createTreeView('ms-azuretools.helpAndFeedback', { treeDataProvider: ext.helpTree }));
 
         registerCommands();
     });

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -14,6 +14,7 @@ import { TagFileSystem } from "./commands/tags/TagFileSystem";
 export namespace ext {
     export let context: ExtensionContext;
     export let tree: AzExtTreeDataProvider;
+    export let helpTree: AzExtTreeDataProvider;
     export let outputChannel: IAzExtOutputChannel;
     export let ui: IAzureUserInput;
     export let ignoreBundle: boolean | undefined;

--- a/src/tree/HelpTreeItem.ts
+++ b/src/tree/HelpTreeItem.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ThemeIcon } from 'vscode';
+import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext } from 'vscode-azureextensionui';
+import { localize } from '../utils/localize';
+
+export class HelpTreeItem extends AzExtParentTreeItem {
+    public label: string = localize('helpAndFeedback', 'Help and Feedback');
+    public contextValue: string = 'helpAndFeedback';
+
+    constructor() {
+        super(undefined);
+    }
+
+    public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
+        const getStartedTI: AzExtTreeItem = new GenericTreeItem(this, {
+            label: localize('getStarted', 'Get Started'),
+            contextValue: 'getStarted',
+            commandId: 'ms-azuretools.getStarted',
+            iconPath: new ThemeIcon('star-empty')
+        });
+        const reportIssueTI: AzExtTreeItem = new GenericTreeItem(this, {
+            label: localize('reportIssue', 'Report Issue'),
+            contextValue: 'reportIssue',
+            commandId: 'ms-azuretools.reportIssue',
+            iconPath: new ThemeIcon('comment')
+        });
+        const reviewIssuesTI: AzExtTreeItem = new GenericTreeItem(this, {
+            label: localize('reviewIssues', 'Review Issues'),
+            contextValue: 'reviewIssues',
+            commandId: 'ms-azuretools.reviewIssues',
+            iconPath: new ThemeIcon('issues')
+        });
+        return [getStartedTI, reviewIssuesTI, reportIssueTI];
+    }
+
+    public hasMoreChildrenImpl(): boolean {
+        return false;
+    }
+
+    public compareChildrenImpl(): number {
+        return 0; // Already sorted
+    }
+}


### PR DESCRIPTION
And make the extension a bit more generic to prepare for being a dependency of other Azure extensions
- "Resources" instead of "Resource Groups"
- Collapse both views by default

<img width="259" alt="Screen Shot 2021-02-16 at 11 38 47 AM" src="https://user-images.githubusercontent.com/11282622/108114093-36da4900-704d-11eb-897a-d9cc3d659072.png">