### PR TITLE
PoC for activation manager

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { TagFileSystem } from './commands/tags/TagFileSystem';
 import { ext } from './extensionVariables';
 import { AzureAccountTreeItem } from './tree/AzureAccountTreeItem';
 import { HelpTreeItem } from './tree/HelpTreeItem';
+import { ExtensionActivationManager } from './utils/ExtensionActivationManager';
 
 export async function activateInternal(context: vscode.ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }, ignoreBundle?: boolean): Promise<AzureExtensionApiProvider> {
     ext.context = context;
@@ -44,6 +45,8 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         const helpTreeItem: HelpTreeItem = new HelpTreeItem();
         ext.helpTree = new AzExtTreeDataProvider(helpTreeItem, 'ms-azuretools.loadMore');
         context.subscriptions.push(vscode.window.createTreeView('ms-azuretools.helpAndFeedback', { treeDataProvider: ext.helpTree }));
+
+        context.subscriptions.push(ext.activationManager = new ExtensionActivationManager());
 
         registerCommands();
 

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -6,6 +6,7 @@
 import { AzExtTreeDataProvider, IAzExtOutputChannel } from "@microsoft/vscode-azext-utils";
 import { DiagnosticCollection, Disposable, ExtensionContext } from "vscode";
 import { TagFileSystem } from "./commands/tags/TagFileSystem";
+import { ExtensionActivationManager } from "./utils/ExtensionActivationManager";
 
 /**
  * Namespace for common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
@@ -21,4 +22,6 @@ export namespace ext {
     export let tagFS: TagFileSystem;
     export let diagnosticWatcher: Disposable | undefined;
     export let diagnosticCollection: DiagnosticCollection;
+
+    export let activationManager: ExtensionActivationManager;
 }

--- a/src/utils/ExtensionActivationManager.ts
+++ b/src/utils/ExtensionActivationManager.ts
@@ -1,0 +1,86 @@
+/*!--------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+const builtInExtensionIdRegex = /^vscode\./i;
+
+const activationEventRegex = /^x-onAzNodeType(?<trigger>Fetch|Resolve):(?<type>[\w.\/]+)$/;
+
+export class ExtensionActivationManager implements vscode.Disposable {
+    private readonly onFetchExtensions = new Map<string, Set<string>>();
+    private readonly onResolveExtensions = new Map<string, Set<string>>();
+
+    private readonly extensionChangeDisposable: vscode.Disposable;
+
+    public constructor() {
+        // VSCode doesn't offer any metadata on specifically what has happened when extensions change, so the simplest approach is to just reinitialize
+        // It's not so bad since the init process takes only about 2 ms
+        this.extensionChangeDisposable = vscode.extensions.onDidChange(this.init, this);
+
+        // Run the initialization
+        this.init();
+    }
+
+    public dispose(): void {
+        this.extensionChangeDisposable?.dispose();
+    }
+
+    public init(): void {
+        this.onFetchExtensions.clear();
+        this.onResolveExtensions.clear();
+
+        const possibleExtensions = vscode.extensions.all
+            .filter(ext => !ext.isActive) // We don't need to activate extensions that are already active
+            .filter(ext => !builtInExtensionIdRegex.test(ext.id)); // We don't need to look at any built-in extensions (often the majority of them)
+
+        for (const ext of possibleExtensions) {
+            const activationEvents: string[] = Array.isArray(ext.packageJSON.activationEvents) ? ext.packageJSON.activationEvents : [];
+
+            for (const activationEvent of activationEvents) {
+                const match = activationEventRegex.exec(activationEvent);
+
+                if (match?.groups?.trigger && match?.groups?.type) {
+                    this.addExtensionToActivationList(
+                        match.groups.type,
+                        ext.id,
+                        match.groups.trigger === 'Fetch' ? this.onFetchExtensions : this.onResolveExtensions
+                    );
+                }
+            }
+        }
+    }
+
+    public onNodeTypeFetched = (type: string) => this.onNodeType(type, this.onFetchExtensions);
+    public onNodeTypeResolved = (type: string) => this.onNodeType(type, this.onResolveExtensions);
+
+    private addExtensionToActivationList(type: string, extensionId: string, activationList: Map<string, Set<string>>): void {
+        const typeLower = type.toLowerCase(); // Cast to lowercase
+        if (!activationList.has(typeLower)) {
+            activationList.set(typeLower, new Set<string>());
+        }
+
+        activationList.get(typeLower)!.add(extensionId);
+    }
+
+    private onNodeType(type: string, activationList: Map<string, Set<string>>): void {
+        const typeLower = type.toLowerCase(); // Cast to lowercase
+        const extensionsToActivate = activationList.get(typeLower);
+
+        if (extensionsToActivate) {
+            for (const extensionId of extensionsToActivate.values()) {
+                const extension = vscode.extensions.getExtension(extensionId);
+
+                if (extension && !extension.isActive) {
+                    // Activate without waiting
+                    void extension.activate();
+                }
+            }
+        }
+
+        // Remove the type from the registration because all of the subscribed extensions are now activated
+        activationList.delete(typeLower);
+    }
+}


### PR DESCRIPTION
This can activate extensions using the custom `x-onAzNodeTypeFetch` and `x-onAzNodeTypeResolve` activation events.

This can support having multiple extensions listening to the same type, and also handles extension enable/disable/install/uninstall gracefully.