### PR TITLE
Fix deleting app resource tree items

### DIFF
--- a/src/tree/GroupTreeItemBase.ts
+++ b/src/tree/GroupTreeItemBase.ts
@@ -8,13 +8,11 @@ import { TreeItemCollapsibleState } from "vscode";
 import { AppResourceResolver, GroupNodeConfiguration } from "../api";
 import { localize } from "../utils/localize";
 import { treeUtils } from "../utils/treeUtils";
-import { AppResourceTreeItem } from "./AppResourceTreeItem";
 import { ResolvableTreeItemBase } from "./ResolvableTreeItemBase";
 
 export class GroupTreeItemBase extends AzExtParentTreeItem {
     public readonly childTypeLabel: string = localize('resource', 'Resource');
     public treeMap: { [key: string]: ResolvableTreeItemBase } = {};
-    public items: AppResourceTreeItem[];
     public config: GroupNodeConfiguration;
 
     public readonly cTime: number = Date.now();
@@ -23,7 +21,6 @@ export class GroupTreeItemBase extends AzExtParentTreeItem {
     constructor(parent: AzExtParentTreeItem, config: GroupNodeConfiguration) {
         super(parent);
         this.config = config;
-        this.items = [];
     }
 
     public get id(): string {

--- a/src/tree/ResolvableTreeItemBase.ts
+++ b/src/tree/ResolvableTreeItemBase.ts
@@ -26,7 +26,8 @@ export abstract class ResolvableTreeItemBase extends AzExtParentTreeItem impleme
     public async loadMoreChildrenImpl(clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
         await this.resolve(clearCache, context);
         if (this.resolveResult && this.resolveResult.loadMoreChildrenImpl) {
-            return await this.resolveResult.loadMoreChildrenImpl(clearCache, context);
+            // this is actually calling resolveResult.loadMoreChildrenImpl through the Proxy so that the function has the correct thisArg
+            return await this.loadMoreChildrenImpl(clearCache, context);
         } else {
             return [];
         }

--- a/src/tree/ResourceGroupTreeItem.ts
+++ b/src/tree/ResourceGroupTreeItem.ts
@@ -45,7 +45,7 @@ export class ResourceGroupTreeItem extends GroupTreeItemBase {
 
     public get description(): string | undefined {
         const state: string | undefined = this.data?.properties?.provisioningState;
-        return state?.toLowerCase() === 'succeeded' ? `${this.items.length} resources` : state;
+        return state?.toLowerCase() === 'succeeded' ? `${Object.keys(this.treeMap).length} resources` : state;
     }
 
     public get iconPath(): TreeItemIconPath {

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -118,4 +118,21 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
 
         await Promise.all(childPromises);
     }
+
+    public removeChildFromCache(child: AppResourceTreeItem): void {
+        // remove item from cache of any group tree item that has this item as a child
+        Object.values(this._treeMap).forEach((groupTreeItem) => {
+            if (groupTreeItem.treeMap[child.id]) {
+                delete groupTreeItem.treeMap[child.id];
+                groupTreeItem.removeChildFromCache(child);
+            }
+        });
+
+        const index = this.rgsItem.findIndex((ar) => ar.id === child.id);
+        if (index > -1) {
+            this.rgsItem.splice(index, 1);
+        }
+
+        this.treeDataProvider.refreshUIOnly(this);
+    }
 }


### PR DESCRIPTION
Since the leaf nodes actually have the SubscriptionTreeItem as their parent, I had to implement `removeChildFromCache`. The implementation will remove the child from the cache of any GroupTreeItemBase that has the child cached. I had to use some internal properties/methods like `refreshUIOnly` and `removeChildFromCache`, so we might need to expose those.

Other changes:
* Fixed loadMoreChildrenImpl `this` bug (see comment in code)
* Removed unused `items` instance variable on `GroupTreeItemBase`.