### PR TITLE
Fix descriptions for leaf tree items

### DIFF
--- a/src/tree/ResolvableTreeItemBase.ts
+++ b/src/tree/ResolvableTreeItemBase.ts
@@ -23,6 +23,10 @@ export abstract class ResolvableTreeItemBase extends AzExtParentTreeItem impleme
         return Array.from(this.contextValues.values()).sort().join(';');
     }
 
+    public get description(): string | undefined {
+        return this.resolveResult?.description;
+    }
+
     public async loadMoreChildrenImpl(clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
         await this.resolve(clearCache, context);
         if (this.resolveResult && this.resolveResult.loadMoreChildrenImpl) {


### PR DESCRIPTION
Without this getter, descriptions present on the resolvedResult are never propagated up to the actual tree item. We may have to do this with some other properties in the future. Probably iconPath