### PR TITLE
Use same contributes key for commands and activation

### DIFF
--- a/src/commands/createResource.ts
+++ b/src/commands/createResource.ts
@@ -6,12 +6,13 @@
 
 import { IActionContext, IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
 import { Command, commands, extensions } from 'vscode';
+import { contributesKey } from '../constants';
 import { SubscriptionTreeItem } from '../tree/SubscriptionTreeItem';
 
 export async function createResource(_context: IActionContext, _node?: SubscriptionTreeItem): Promise<void> {
     const all = extensions.all;
 
-    const extCommands = all.map((azExt) => (azExt.packageJSON as any)?.contributes?.azExt?.commands as unknown).filter((value) => value !== undefined);
+    const extCommands = all.map((azExt) => azExt.packageJSON?.contributes?.[contributesKey]?.commands as unknown).filter((value) => value !== undefined);
     const createCommands: Command[] = [];
 
     extCommands.forEach((extCommand: Command[]) => createCommands.push(...extCommand));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,4 @@
  *--------------------------------------------------------------------------------------------*/
 
 export const azureResourceProviderId: string = 'vscode-azureresourcegroups.azureResourceProvider';
+export const contributesKey = 'x-azResources';

--- a/src/utils/ExtensionActivationManager.ts
+++ b/src/utils/ExtensionActivationManager.ts
@@ -5,6 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { contributesKey } from '../constants';
 
 const builtInExtensionIdRegex = /^vscode\./i;
 
@@ -17,7 +18,7 @@ interface AzResourceContributionPoint {
 
 interface AzExtensionManifest {
     readonly contributes?: {
-        readonly 'x-azResources'?: AzResourceContributionPoint;
+        readonly [contributesKey]?: AzResourceContributionPoint;
     }
 }
 
@@ -49,7 +50,7 @@ export class ExtensionActivationManager implements vscode.Disposable {
             .filter(ext => !builtInExtensionIdRegex.test(ext.id)); // We don't need to look at any built-in extensions (often the majority of them)
 
         for (const ext of possibleExtensions) {
-            const activation = (ext.packageJSON as AzExtensionManifest)?.contributes?.['x-azResources']?.activation;
+            const activation = (ext.packageJSON as AzExtensionManifest)?.contributes?.[contributesKey]?.activation;
 
             activation?.onFetch?.forEach(fetchType => this.addExtensionToActivationList(fetchType, ext.id, this.onFetchExtensions));
             activation?.onResolve?.forEach(resolveType => this.addExtensionToActivationList(resolveType, ext.id, this.onResolveExtensions));


### PR DESCRIPTION
ex:
```json
"contributes": {
    "x-azResources": {
        "activation": {
            "onFetch": [
                "microsoft.web/staticsites"
            ]
        },
        "commands": [
            {
                "command": "staticWebApps.createStaticWebApp",
                "title": "%staticWebApps.createStaticWebApp%",
                "type": "microsoft.web/staticsites"
            }
        ]
    }
}
```