### PR TITLE
Don't make GroupTreeItem ids lower case

### DIFF
--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -28,7 +28,7 @@ export function getResourceGroupFromId(id: string): string {
 export function createGroupConfigFromResource(resource: GenericResource, subscriptionId: string | undefined): GroupingConfig {
     const id = nonNullProp(resource, 'id');
     return {
-        resourceGroup: { keyLabel: 'Resource Groups', label: getResourceGroupFromId(id), id: id.substring(0, id.indexOf('/providers')).toLowerCase() },
+        resourceGroup: { keyLabel: 'Resource Groups', label: getResourceGroupFromId(id), id: id.substring(0, id.indexOf('/providers')) },
         resourceType: {
             keyLabel: 'Resource Types', label: resource.type?.toLowerCase() ?? 'unknown',
             id: `${subscriptionId}/${resource.type}` ?? 'unknown',


### PR DESCRIPTION
Was investigating an error I was getting trying to open storage blobs. Figured out that [`findTreeItem`](https://github.com/microsoft/vscode-azuretools/blob/d38498f0085deb912675e4d2cb376f973c12f31e/utils/src/tree/AzExtTreeDataProvider.ts#L261) is case sensitive and the fullIds were different only by the casing of `resourceGroups`.

`/subscriptions/843d979b-47f8-4bb9-9fbc-33e33962c304/resourcegroups/funcbasic1a9cbd88f7`
`/subscriptions/843d979b-47f8-4bb9-9fbc-33e33962c304/resourceGroups/funcbasic1ab151b770/...`

I'm not really sure how this is happening because I would think that if we `.toLowerCase()` it in one place, how could it be upper case when we search for it? But I must not be understanding something right because it works when I removed `.toLowerCase()`
