### PR TITLE
Use context menu for Group By setting and make some resolvers not collapsible

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,12 +48,19 @@
     ],
     "main": "./main.js",
     "contributes": {
+        "x-azResources": {
+            "commands": [
+                {
+                    "command": "azureResourceGroups.createResourceGroup",
+                    "title": "%azureResourceGroups.createResourceGroup%"
+                }
+            ]
+        },
         "commands": [
             {
                 "command": "azureResourceGroups.createResourceGroup",
                 "title": "%azureResourceGroups.createResourceGroup%",
-                "category": "Azure Resource Groups",
-                "icon": "$(add)"
+                "category": "Azure Resource Groups"
             },
             {
                 "command": "azureResourceGroups.createResource",
@@ -123,10 +130,22 @@
                 "category": "Azure"
             },
             {
-                "command": "azureResourceGroups.configureExplorer",
-                "title": "%azureResourceGroups.configureExplorer%",
+                "command": "azureResourceGroups.groupBy.resourceGroup",
+                "title": "%azureResourceGroups.groupBy.resourceGroup%",
                 "category": "Azure Resource Groups",
-                "icon": "$(settings-gear)"
+                "icon": "$(gear)"
+            },
+            {
+                "command": "azureResourceGroups.groupBy.resourceType",
+                "title": "%azureResourceGroups.groupBy.resourceType%",
+                "category": "Azure Resource Groups",
+                "icon": "$(gear)"
+            },
+            {
+                "command": "azureResourceGroups.groupBy.location",
+                "title": "%azureResourceGroups.groupBy.location%",
+                "category": "Azure Resource Groups",
+                "icon": "$(gear)"
             },
             {
                 "command": "azureResourceGroups.refreshWorkspace",
@@ -171,17 +190,12 @@
                     "group": "navigation@1"
                 },
                 {
-                    "command": "azureResourceGroups.createResourceGroup",
-                    "when": "view == azureResourceGroups",
-                    "group": "navigation@1"
-                },
-                {
-                    "command": "azureResourceGroups.refresh",
+                    "submenu": "azureResourceGroups.groupBy",
                     "when": "view == azureResourceGroups",
                     "group": "navigation@2"
                 },
                 {
-                    "command": "azureResourceGroups.configureExplorer",
+                    "command": "azureResourceGroups.refresh",
                     "when": "view == azureResourceGroups",
                     "group": "navigation@3"
                 },
@@ -270,8 +284,29 @@
                     "command": "azureResourceGroups.revealResource",
                     "when": "never"
                 }
+            ],
+            "azureResourceGroups.groupBy": [
+                {
+                    "command": "azureResourceGroups.groupBy.resourceGroup",
+                    "group": "1_default@1"
+                },
+                {
+                    "command": "azureResourceGroups.groupBy.resourceType",
+                    "group": "1_default@2"
+                },
+                {
+                    "command": "azureResourceGroups.groupBy.location",
+                    "group": "1_default@3"
+                }
             ]
         },
+        "submenus": [
+            {
+                "id": "azureResourceGroups.groupBy",
+                "label": "Group By",
+                "icon": "$(group-by-ref-type)"
+            }
+        ],
         "keybindings": [
             {
                 "command": "workbench.view.extension.azure",

--- a/package.nls.json
+++ b/package.nls.json
@@ -18,5 +18,7 @@
     "ms-azuretools.helpAndFeedback": "Help and Feedback",
     "ms-azuretools.reportIssue": "Report Issue...",
     "ms-azuretools.reviewIssues": "Review Issues...",
-    "azureResourceGroups.configureExplorer": "Configure Explorer..."
+    "azureResourceGroups.groupBy.resourceGroup": "Group by Resource Group",
+    "azureResourceGroups.groupBy.resourceType": "Group by Resource Type",
+    "azureResourceGroups.groupBy.location": "Group by Location"
 }

--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -112,6 +112,8 @@ export interface AbstractAzExtTreeItem {
     commandId?: string;
     tooltip?: string;
 
+    collapsibleState?: vscode.TreeItemCollapsibleState;
+
     /**
      * The arguments to pass in when executing `commandId`. If not specified, this tree item will be used.
      */

--- a/src/commands/explorer/groupBy.ts
+++ b/src/commands/explorer/groupBy.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { ext } from "../../extensionVariables";
+import { settingUtils } from "../../utils/settingUtils";
+
+export function buildGroupByCommand(setting: string) {
+    return (context: IActionContext): Promise<void> => groupBy(context, setting);
+}
+
+async function groupBy(context: IActionContext, setting: string): Promise<void> {
+    await settingUtils.updateGlobalSetting('groupBy', setting);
+    void ext.tree.refresh(context);
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -6,10 +6,10 @@
 import { AzExtTreeItem, IActionContext, registerCommand, registerErrorHandler, registerReportIssueCommand } from '@microsoft/vscode-azext-utils';
 import { commands } from 'vscode';
 import { ext } from '../extensionVariables';
-import { configureExplorer } from './configureExplorer';
 import { createResource } from './createResource';
 import { createResourceGroup } from './createResourceGroup';
 import { deleteResourceGroup } from './deleteResourceGroup';
+import { buildGroupByCommand } from './explorer/groupBy';
 import { getStarted } from './helpAndFeedback/getStarted';
 import { reportIssue } from './helpAndFeedback/reportIssue';
 import { reviewIssues } from './helpAndFeedback/reviewIssues';
@@ -38,7 +38,9 @@ export function registerCommands(): void {
     // Suppress "Report an Issue" button for all errors in favor of the command
     registerErrorHandler(c => c.errorHandling.suppressReportIssue = true);
     registerReportIssueCommand('azureResourceGroups.reportIssue');
-    registerCommand('azureResourceGroups.configureExplorer', configureExplorer);
     registerCommand('azureResourceGroups.createResource', createResource);
     registerCommand('azureResourceGroups.refreshWorkspace', refreshWorkspace);
+    registerCommand('azureResourceGroups.groupBy.resourceGroup', buildGroupByCommand('resourceGroup'));
+    registerCommand('azureResourceGroups.groupBy.resourceType', buildGroupByCommand('resourceType'));
+    registerCommand('azureResourceGroups.groupBy.location', buildGroupByCommand('location'));
 }

--- a/src/resolvers/NoopResolver.ts
+++ b/src/resolvers/NoopResolver.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { ISubscriptionContext } from "@microsoft/vscode-azext-utils";
+import { TreeItemCollapsibleState } from "vscode";
 import { AppResource, AppResourceResolver, ResolvedAppResourceBase } from "../api";
 import { getAzureExtensions } from "../AzExtWrapper";
 import { BuiltinResolver } from "./BuiltinResolver";
@@ -16,7 +17,9 @@ class NoopResolver implements AppResourceResolver, BuiltinResolver {
     public readonly resolverKind = 'builtin';
 
     public resolveResource(_subContext: ISubscriptionContext, _resource: AppResource): ResolvedAppResourceBase {
-        return {};
+        return {
+            collapsibleState: TreeItemCollapsibleState.None,
+        };
     }
 
     public matchesResource(resource: AppResource): boolean {

--- a/src/resolvers/ShallowResourceResolver.ts
+++ b/src/resolvers/ShallowResourceResolver.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { ISubscriptionContext } from "@microsoft/vscode-azext-utils";
+import { TreeItemCollapsibleState } from "vscode";
 import { AppResource, AppResourceResolver, ResolvedAppResourceBase } from "../api";
 import { getAzureExtensions } from "../AzExtWrapper";
 import { BuiltinResolver } from "./BuiltinResolver";
@@ -17,7 +18,8 @@ class ShallowResourceResolver implements AppResourceResolver, BuiltinResolver {
 
     public resolveResource(_subContext: ISubscriptionContext, _resource: AppResource): ResolvedAppResourceBase {
         return {
-            commandId: 'azureResourceGroups.viewProperties'
+            commandId: 'azureResourceGroups.viewProperties',
+            collapsibleState: TreeItemCollapsibleState.None
         };
     }
 


### PR DESCRIPTION
I like this icon, but I'm open to suggestions.

<img width="354" alt="image" src="https://user-images.githubusercontent.com/12476526/160034342-a768635e-3ad1-4235-835e-fadcd7a390fa.png">

Also made the Noop and Shallow resolver have `collapsibleState: TreeItemCollapsibleState.None`

<img width="337" alt="image" src="https://user-images.githubusercontent.com/12476526/160034518-8533ef31-dd1c-43bc-9b1e-f0be62397532.png">
