### PR TITLE
Improve install extension experience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7113,9 +7113,9 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "node_modules/minipass": {
             "version": "3.1.3",
@@ -17607,9 +17607,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "minipass": {
             "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -289,6 +289,10 @@
                 {
                     "command": "azureResourceGroups.revealResource",
                     "when": "never"
+                },
+                {
+                    "command": "azureResourceGroups.installExtension",
+                    "when": "never"
                 }
             ],
             "azureResourceGroups.groupBy": [

--- a/package.json
+++ b/package.json
@@ -63,6 +63,12 @@
                 "category": "Azure Resource Groups"
             },
             {
+                "command": "azureResourceGroups.installExtension",
+                "title": "Install Azure extension",
+                "icon": "$(extensions)",
+                "category": "Azure Resource Groups"
+            },
+            {
                 "command": "azureResourceGroups.createResource",
                 "title": "Create Resource...",
                 "category": "Azure Resource Groups",

--- a/src/commands/installExtension.ts
+++ b/src/commands/installExtension.ts
@@ -3,33 +3,10 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { DialogResponses, IActionContext } from "@microsoft/vscode-azext-utils";
-import { commands, MessageItem, window } from "vscode";
-import { getAzureExtensions } from "../AzExtWrapper";
-import { ext } from "../extensionVariables";
-import { localize } from "../utils/localize";
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { commands } from "vscode";
 
 export async function installExtension(context: IActionContext, extensionId: string): Promise<void> {
     context.telemetry.properties.extensionId = extensionId;
     await commands.executeCommand('extension.open', extensionId);
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const extension = getAzureExtensions().find(azExt => azExt.id === extensionId)!;
-    const installMessageItem: MessageItem = {
-        title: localize('installExtension', 'Install extension')
-    }
-    // Use extension-specific message later
-    const result = await window.showInformationMessage(localize('installExtension', "Install the '{0}' extension to enable additional features?", extension.label), {
-        modal: true
-    }, installMessageItem, DialogResponses.cancel);
-
-    if (result === installMessageItem) {
-        context.errorHandling.suppressDisplay = true;
-        // Will prompt if settings sync is enabled
-        await commands.executeCommand('workbench.extensions.installExtension', extensionId);
-        context.telemetry.properties.result = 'Succeeded';
-        void ext.tree.refresh(context);
-    } else {
-        context.telemetry.properties.result = 'Canceled';
-    }
 }

--- a/src/commands/installExtension.ts
+++ b/src/commands/installExtension.ts
@@ -6,7 +6,10 @@
 import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { commands } from "vscode";
 
-export async function installExtension(_context: IActionContext, extensionId: string): Promise<void> {
+export async function installExtension(context: IActionContext, extensionId: string): Promise<void> {
+    context.errorHandling.suppressDisplay = true;
+    context.telemetry.properties.extensionId = extensionId;
     void commands.executeCommand('extension.open', extensionId);
-    void commands.executeCommand('workbench.extensions.installExtension', extensionId);
+    await commands.executeCommand('workbench.extensions.installExtension', extensionId);
+    context.telemetry.properties.result = 'Succeeded';
 }

--- a/src/commands/installExtension.ts
+++ b/src/commands/installExtension.ts
@@ -3,13 +3,33 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { commands } from "vscode";
+import { DialogResponses, IActionContext } from "@microsoft/vscode-azext-utils";
+import { commands, MessageItem, window } from "vscode";
+import { getAzureExtensions } from "../AzExtWrapper";
+import { ext } from "../extensionVariables";
+import { localize } from "../utils/localize";
 
 export async function installExtension(context: IActionContext, extensionId: string): Promise<void> {
-    context.errorHandling.suppressDisplay = true;
     context.telemetry.properties.extensionId = extensionId;
-    void commands.executeCommand('extension.open', extensionId);
-    await commands.executeCommand('workbench.extensions.installExtension', extensionId);
-    context.telemetry.properties.result = 'Succeeded';
+    await commands.executeCommand('extension.open', extensionId);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const extension = getAzureExtensions().find(azExt => azExt.id === extensionId)!;
+    const installMessageItem: MessageItem = {
+        title: localize('installExtension', 'Install extension')
+    }
+    // Use extension-specific message later
+    const result = await window.showInformationMessage(localize('installExtension', "Install the '{0}' extension to enable additional features?", extension.label), {
+        modal: true
+    }, installMessageItem, DialogResponses.cancel);
+
+    if (result === installMessageItem) {
+        context.errorHandling.suppressDisplay = true;
+        // Will prompt if settings sync is enabled
+        await commands.executeCommand('workbench.extensions.installExtension', extensionId);
+        context.telemetry.properties.result = 'Succeeded';
+        void ext.tree.refresh(context);
+    } else {
+        context.telemetry.properties.result = 'Canceled';
+    }
 }

--- a/src/commands/installExtension.ts
+++ b/src/commands/installExtension.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { commands } from "vscode";
+
+export async function installExtension(_context: IActionContext, extensionId: string): Promise<void> {
+    void commands.executeCommand('extension.open', extensionId);
+    void commands.executeCommand('workbench.extensions.installExtension', extensionId);
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -13,6 +13,7 @@ import { buildGroupByCommand } from './explorer/groupBy';
 import { getStarted } from './helpAndFeedback/getStarted';
 import { reportIssue } from './helpAndFeedback/reportIssue';
 import { reviewIssues } from './helpAndFeedback/reviewIssues';
+import { installExtension } from './installExtension';
 import { openInPortal } from './openInPortal';
 import { revealResource } from './revealResource';
 import { editTags } from './tags/editTags';
@@ -43,4 +44,6 @@ export function registerCommands(): void {
     registerCommand('azureResourceGroups.groupBy.resourceGroup', buildGroupByCommand('resourceGroup'));
     registerCommand('azureResourceGroups.groupBy.resourceType', buildGroupByCommand('resourceType'));
     registerCommand('azureResourceGroups.groupBy.location', buildGroupByCommand('location'));
+
+    registerCommand('azureResourceGroups.installExtension', installExtension);
 }

--- a/src/resolvers/InstallableAppResourceResolver.ts
+++ b/src/resolvers/InstallableAppResourceResolver.ts
@@ -26,7 +26,7 @@ class InstallableAppResourceResolver implements AppResourceResolver, BuiltinReso
             loadMoreChildrenImpl: async () => {
                 const ti = new GenericTreeItem(undefined, {
                     contextValue: 'installExtension',
-                    label: localize('installExtension', 'Install {0} extension...', extension.label),
+                    label: localize('installExtensionToEnableFeatures', 'Install extension to enable additional features...'),
                     commandId: 'azureResourceGroups.installExtension',
                     iconPath: new ThemeIcon('extensions'),
                 });

--- a/src/resolvers/InstallableAppResourceResolver.ts
+++ b/src/resolvers/InstallableAppResourceResolver.ts
@@ -3,9 +3,11 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { ISubscriptionContext } from "@microsoft/vscode-azext-utils";
+import { GenericTreeItem, ISubscriptionContext } from "@microsoft/vscode-azext-utils";
+import { ThemeIcon } from "vscode";
 import { AppResource, AppResourceResolver, ResolvedAppResourceBase } from "../api";
 import { getAzureExtensions } from "../AzExtWrapper";
+import { localize } from "../utils/localize";
 import { BuiltinResolver } from "./BuiltinResolver";
 
 /**
@@ -18,11 +20,20 @@ class InstallableAppResourceResolver implements AppResourceResolver, BuiltinReso
     public resolveResource(_subContext: ISubscriptionContext, resource: AppResource): ResolvedAppResourceBase {
         // We know the extension is known but uninstalled, or else it would not have passed the `isApplicable` check below
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const extensionId = getAzureExtensions().find(azExt => azExt.matchesResourceType(resource))!.id;
+        const extension = getAzureExtensions().find(azExt => azExt.matchesResourceType(resource))!;
 
         return {
-            commandId: 'extension.open',
-            commandArgs: [extensionId],
+            loadMoreChildrenImpl: async () => {
+                const ti = new GenericTreeItem(undefined, {
+                    contextValue: 'installExtension',
+                    label: localize('installExtension', 'Install {0} extension...', extension.label),
+                    commandId: 'azureResourceGroups.installExtension',
+                    iconPath: new ThemeIcon('extensions'),
+                });
+                ti.commandArgs = [extension.id];
+
+                return [ti];
+            }
         };
     }
 


### PR DESCRIPTION
Edited `InstallableAppResourceResolver` to improve the installation UX. Now it returns a node with a single child instructing users to install the associated extension.

![image](https://user-images.githubusercontent.com/12476526/160508994-861d07f9-b99f-4adb-b6d1-190d56e1f58c.png)


To handle install, I'm calling `extension.open` and `workbench.extensions.installExtension` so that the marketplace page and the installation modal open together. I think opening both is better than opening one or the other.

![installextension](https://user-images.githubusercontent.com/12476526/160508801-4a2b1ff3-f702-431b-af0c-874b4a3e4aeb.gif)

We might need to add more logic later to handle if an extension is installed but disabled.