### PR TITLE
Select GroupTreeItem based off matching its ID to a RegExp

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,7 @@
             "runtimeExecutable": "${execPath}",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}",
-                "--extensionDevelopmentPath=${workspaceFolder}/../vscode-azurefunctions"
+                "--extensionDevelopmentPath=${workspaceFolder}/../vscode-azurestaticwebapps"
             ],
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,7 @@
             "runtimeExecutable": "${execPath}",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}",
-                "--extensionDevelopmentPath=${workspaceFolder}/../vscode-azurestaticwebapps"
+                "--extensionDevelopmentPath=${workspaceFolder}/../vscode-azurefunctions"
             ],
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -118,4 +118,18 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
 
         await Promise.all(childPromises);
     }
+
+    public async pickTreeItemImpl(expectedContextValues: (string | RegExp)[], context: IActionContext): Promise<AzExtTreeItem | undefined> {
+        for (const contextValue of expectedContextValues) {
+            // string or RegExp, re-create it because we want it to be case-insensitive
+            const regExp: RegExp = new RegExp(contextValue, 'gi');
+            const groupTreeItem = (await this.getCachedChildren(context)).find(group => regExp.test(nonNullProp(group, 'id')));
+
+            if (groupTreeItem) {
+                return groupTreeItem;
+            }
+        }
+
+        return undefined;
+    }
 }


### PR DESCRIPTION
The main use case scenario I see is for what we discussed offline: if we are running a Function command and it is grouped by resource type, then we'll skip the group tree node and display all Function Apps.

I wanted to go with this comparing ID approaches though because I thought it'd be more adaptable.  Or extensible seems like the hot word of the quarter 🤣 

If we did a mapping of context values to resource types, we'd be limited to just that map.  Any time we ever wanted to skip a group tree node, we'd have to add it to the mapping which doesn't seem very practical.

But if we made the context value something that is part of the group config's id, anybody plugging into the extension can define the group config however they want and then use the context values appropriately to skip the group node in the tree picker as well.

This means we'll have to change the context values for all of the extensions, but since we use the static value when we pass in contextValue, it's an easy 1-liner.

NOTE:  We should probably let users pass in what they want the child label to be.  They all default to "Select Resource" which looks kinda silly. 

![image](https://user-images.githubusercontent.com/5290572/161170334-ea87e659-1f38-4d01-8158-74eb61fab2c3.png)

![image](https://user-images.githubusercontent.com/5290572/161170521-bb508b6b-a845-4b41-82e8-e9f51907466d.png)
