### PR TITLE
Fix resource groups

### DIFF
--- a/src/tree/AppResourceTreeItem.ts
+++ b/src/tree/AppResourceTreeItem.ts
@@ -95,11 +95,11 @@ export class AppResourceTreeItem extends ResolvableTreeItemBase implements Group
         ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
     }
 
-    public async mapSubGroupConfigTree(context: IActionContext, groupBySetting: string, resourceGroups: Promise<ResourceGroup[]>): Promise<void> {
+    public mapSubGroupConfigTree(context: IActionContext, groupBySetting: string, resourceGroups: Promise<ResourceGroup[]>): void {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         let subGroupTreeItem = (<SubscriptionTreeItem>this.rootGroupTreeItem).getSubConfigGroupTreeItem(this.groupConfig[groupBySetting].id)
         if (!subGroupTreeItem) {
-            subGroupTreeItem = await this.createSubGroupTreeItem(context, groupBySetting, resourceGroups);
+            subGroupTreeItem = this.createSubGroupTreeItem(context, groupBySetting, resourceGroups);
             (<SubscriptionTreeItem>this.rootGroupTreeItem).setSubConfigGroupTreeItem(this.groupConfig[groupBySetting].id, subGroupTreeItem)
         }
 
@@ -109,7 +109,7 @@ export class AppResourceTreeItem extends ResolvableTreeItemBase implements Group
         void subGroupTreeItem.refresh(context);
     }
 
-    public async createSubGroupTreeItem(_context: IActionContext, groupBySetting: string, resourceGroups: Promise<ResourceGroup[]>): Promise<GroupTreeItemBase> {
+    public createSubGroupTreeItem(_context: IActionContext, groupBySetting: string, resourceGroups: Promise<ResourceGroup[]>): GroupTreeItemBase {
         switch (groupBySetting) {
             // TODO: Use ResovableTreeItem here
             case 'resourceGroup':

--- a/src/tree/AppResourceTreeItem.ts
+++ b/src/tree/AppResourceTreeItem.ts
@@ -95,11 +95,11 @@ export class AppResourceTreeItem extends ResolvableTreeItemBase implements Group
         ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
     }
 
-    public mapSubGroupConfigTree(context: IActionContext, groupBySetting: string, resourceGroups: Promise<ResourceGroup[]>): void {
+    public mapSubGroupConfigTree(context: IActionContext, groupBySetting: string, getResourceGroup: (resourceGroup: string) => Promise<ResourceGroup | undefined>): void {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         let subGroupTreeItem = (<SubscriptionTreeItem>this.rootGroupTreeItem).getSubConfigGroupTreeItem(this.groupConfig[groupBySetting].id)
         if (!subGroupTreeItem) {
-            subGroupTreeItem = this.createSubGroupTreeItem(context, groupBySetting, resourceGroups);
+            subGroupTreeItem = this.createSubGroupTreeItem(context, groupBySetting, getResourceGroup);
             (<SubscriptionTreeItem>this.rootGroupTreeItem).setSubConfigGroupTreeItem(this.groupConfig[groupBySetting].id, subGroupTreeItem)
         }
 
@@ -109,11 +109,11 @@ export class AppResourceTreeItem extends ResolvableTreeItemBase implements Group
         void subGroupTreeItem.refresh(context);
     }
 
-    public createSubGroupTreeItem(_context: IActionContext, groupBySetting: string, resourceGroups: Promise<ResourceGroup[]>): GroupTreeItemBase {
+    public createSubGroupTreeItem(_context: IActionContext, groupBySetting: string, getResourceGroup: (resourceGroup: string) => Promise<ResourceGroup | undefined>): GroupTreeItemBase {
         switch (groupBySetting) {
             // TODO: Use ResovableTreeItem here
             case 'resourceGroup':
-                return new ResourceGroupTreeItem(this.rootGroupTreeItem, this.groupConfig.resourceGroup, resourceGroups);
+                return new ResourceGroupTreeItem(this.rootGroupTreeItem, this.groupConfig.resourceGroup, getResourceGroup);
             default:
                 return new GroupTreeItemBase(this.rootGroupTreeItem, this.groupConfig[groupBySetting]);
         }

--- a/src/tree/AppResourceTreeItem.ts
+++ b/src/tree/AppResourceTreeItem.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ResourceGroup } from "@azure/arm-resources";
 import { AzExtParentTreeItem, AzExtTreeItem, IActionContext, nonNullProp, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { FileChangeType } from "vscode";
 import { AppResource, GroupableResource, GroupingConfig, GroupNodeConfiguration } from "../api";
@@ -10,6 +11,7 @@ import { ext } from "../extensionVariables";
 import { createGroupConfigFromResource, getIconPath } from "../utils/azureUtils";
 import { GroupTreeItemBase } from "./GroupTreeItemBase";
 import { ResolvableTreeItemBase } from "./ResolvableTreeItemBase";
+import { ResourceGroupTreeItem } from "./ResourceGroupTreeItem";
 import { SubscriptionTreeItem } from "./SubscriptionTreeItem";
 
 export class AppResourceTreeItem extends ResolvableTreeItemBase implements GroupableResource {
@@ -93,11 +95,11 @@ export class AppResourceTreeItem extends ResolvableTreeItemBase implements Group
         ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
     }
 
-    public mapSubGroupConfigTree(context: IActionContext, groupBySetting: string): void {
+    public async mapSubGroupConfigTree(context: IActionContext, groupBySetting: string, resourceGroups: Promise<ResourceGroup[]>): Promise<void> {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         let subGroupTreeItem = (<SubscriptionTreeItem>this.rootGroupTreeItem).getSubConfigGroupTreeItem(this.groupConfig[groupBySetting].id)
         if (!subGroupTreeItem) {
-            subGroupTreeItem = this.createSubGroupTreeItem(context, groupBySetting);
+            subGroupTreeItem = await this.createSubGroupTreeItem(context, groupBySetting, resourceGroups);
             (<SubscriptionTreeItem>this.rootGroupTreeItem).setSubConfigGroupTreeItem(this.groupConfig[groupBySetting].id, subGroupTreeItem)
         }
 
@@ -107,12 +109,11 @@ export class AppResourceTreeItem extends ResolvableTreeItemBase implements Group
         void subGroupTreeItem.refresh(context);
     }
 
-    public createSubGroupTreeItem(_context: IActionContext, groupBySetting: string): GroupTreeItemBase {
-        // const client = await createResourceClient([context, this.rootGroupTreeItem.subscription]);
-
+    public async createSubGroupTreeItem(_context: IActionContext, groupBySetting: string, resourceGroups: Promise<ResourceGroup[]>): Promise<GroupTreeItemBase> {
         switch (groupBySetting) {
             // TODO: Use ResovableTreeItem here
             case 'resourceGroup':
+                return new ResourceGroupTreeItem(this.rootGroupTreeItem, this.groupConfig.resourceGroup, resourceGroups);
             default:
                 return new GroupTreeItemBase(this.rootGroupTreeItem, this.groupConfig[groupBySetting]);
         }

--- a/src/tree/ResourceGroupTreeItem.ts
+++ b/src/tree/ResourceGroupTreeItem.ts
@@ -16,18 +16,18 @@ import { GroupTreeItemBase } from "./GroupTreeItemBase";
 export class ResourceGroupTreeItem extends GroupTreeItemBase {
     public static contextValue: string = 'azureResourceGroup';
 
-    public data?: ResourceGroup;
+    public async getData(): Promise<ResourceGroup | undefined> {
+        return await this.getResourceGroup(this.name);
+    }
 
-    constructor(parent: AzExtParentTreeItem, config: GroupNodeConfiguration, data?: ResourceGroup | Promise<ResourceGroup[]>) {
+    private data?: ResourceGroup;
+
+    constructor(parent: AzExtParentTreeItem, config: GroupNodeConfiguration, private readonly getResourceGroup: (resourceGroup: string) => Promise<ResourceGroup | undefined>) {
         super(parent, config);
 
-        if (data instanceof Promise) {
-            data?.then((rg) => {
-                this.data = rg.find((rg) => rg.name === this.name);
-            });
-        } else {
-            this.data = data;
-        }
+        void this.getResourceGroup(this.name).then((rg) => {
+            this.data = rg;
+        });
 
         ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
     }

--- a/src/tree/ResourceGroupTreeItem.ts
+++ b/src/tree/ResourceGroupTreeItem.ts
@@ -16,19 +16,20 @@ import { GroupTreeItemBase } from "./GroupTreeItemBase";
 export class ResourceGroupTreeItem extends GroupTreeItemBase {
     public static contextValue: string = 'azureResourceGroup';
 
-    constructor(parent: AzExtParentTreeItem, config: GroupNodeConfiguration, data: ResourceGroup) {
+    public data?: ResourceGroup;
+
+    constructor(parent: AzExtParentTreeItem, config: GroupNodeConfiguration, data?: ResourceGroup | Promise<ResourceGroup[]>) {
         super(parent, config);
-        this.data = data;
+
+        if (data instanceof Promise) {
+            data?.then((rg) => {
+                this.data = rg.find((rg) => rg.name === this.name);
+            });
+        } else {
+            this.data = data;
+        }
 
         ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
-    }
-
-    public get data(): ResourceGroup | undefined {
-        return this.data;
-    }
-
-    public set data(data: ResourceGroup | undefined) {
-        this.data = data;
     }
 
     public get contextValue(): string {
@@ -41,11 +42,6 @@ export class ResourceGroupTreeItem extends GroupTreeItemBase {
 
     public get name(): string {
         return this.label;
-    }
-
-    public get description(): string | undefined {
-        const state: string | undefined = this.data?.properties?.provisioningState;
-        return state?.toLowerCase() === 'succeeded' ? `${Object.keys(this.treeMap).length} resources` : state;
     }
 
     public get iconPath(): TreeItemIconPath {
@@ -66,6 +62,7 @@ export class ResourceGroupTreeItem extends GroupTreeItemBase {
     public async refreshImpl(context: IActionContext): Promise<void> {
         const client: ResourceManagementClient = await createResourceClient([context, this]);
         this.data = await client.resourceGroups.get(this.name);
+
         ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
         this.mTime = Date.now();
     }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -3,13 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IResourceGroupWizardContext, LocationListStep, ResourceGroupCreateStep, ResourceGroupNameStep, SubscriptionTreeItemBase } from '@microsoft/vscode-azext-azureutils';
+import { ResourceManagementClient } from '@azure/arm-resources';
+import { IResourceGroupWizardContext, LocationListStep, ResourceGroupCreateStep, ResourceGroupNameStep, SubscriptionTreeItemBase, uiUtils } from '@microsoft/vscode-azext-azureutils';
 import { AzExtParentTreeItem, AzExtTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, ICreateChildImplContext, ISubscriptionContext, nonNullOrEmptyValue, nonNullProp, registerEvent } from '@microsoft/vscode-azext-utils';
 import { ConfigurationChangeEvent, workspace } from 'vscode';
 import { AppResource, AppResourceResolver, GroupableResource } from '../api';
 import { applicationResourceProviders } from '../api/registerApplicationResourceProvider';
 import { azureResourceProviderId } from '../constants';
 import { ext } from '../extensionVariables';
+import { createResourceClient } from '../utils/azureClients';
 import { localize } from '../utils/localize';
 import { settingUtils } from '../utils/settingUtils';
 import { AppResourceTreeItem } from './AppResourceTreeItem';
@@ -99,8 +101,11 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         this._treeMap = {};
         const groupBySetting = <string>settingUtils.getGlobalSetting<string>('groupBy');
 
-        for (const rgTree of this._items) {
-            (<AppResourceTreeItem>rgTree).mapSubGroupConfigTree(context, groupBySetting);
+        const client: ResourceManagementClient = await createResourceClient([context, this]);
+        const resourceGroups = uiUtils.listAllIterator(client.resourceGroups.list());
+
+        for await (const rgTree of this._items) {
+            await (<AppResourceTreeItem>rgTree).mapSubGroupConfigTree(context, groupBySetting, resourceGroups);
         }
     }
 

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -108,7 +108,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         const resourceGroups = uiUtils.listAllIterator(client.resourceGroups.list());
 
         for await (const rgTree of this._items) {
-            await (<AppResourceTreeItem>rgTree).mapSubGroupConfigTree(context, groupBySetting, resourceGroups);
+            (<AppResourceTreeItem>rgTree).mapSubGroupConfigTree(context, groupBySetting, resourceGroups);
         }
     }
 


### PR DESCRIPTION
Fetches ResourceGroup data using the SDK to enable all the commands on resource group group tree items.

![image](https://user-images.githubusercontent.com/12476526/163068681-16912884-0e4d-4f3b-97bd-624da3ccb1df.png)

The implementation isn't the prettiest, but I made it as fast as we can until we add a something like a global resource cache. As of now, we fetch a list of all resource groups when the subscription is refreshed. Since I never await the promise, it seems to have a very minimal (if any), impact on the tree performance.