### PR TITLE
Fix resource groups only having 1 child

### DIFF
--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -134,7 +134,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
     }
 
     public getSubConfigGroupTreeItem(id: string): GroupTreeItemBase {
-        return this._treeMap[id];
+        return this._treeMap[id.toLowerCase()];
     }
 
     public setSubConfigGroupTreeItem(id: string, treeItem: GroupTreeItemBase): void {


### PR DESCRIPTION
All resource groups only showed 1 child, if any