### PR TITLE
Handle outdated extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureresourcegroups",
-    "version": "0.4.1-alpha.1",
+    "version": "0.4.1-alpha.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureresourcegroups",
-            "version": "0.4.1-alpha.1",
+            "version": "0.4.1-alpha.2",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-resources": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,9 @@
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
                 "@microsoft/vscode-azext-azureutils": "^0.2.0",
                 "@microsoft/vscode-azext-utils": "^0.2.0",
-                "@types/semver": "^7.3.9",
                 "fs-extra": "^8.1.0",
                 "jsonc-parser": "^2.2.1",
                 "open": "^8.0.4",
-                "semver": "^7.3.7",
                 "vscode-nls": "^4.1.1"
             },
             "devDependencies": {
@@ -875,11 +873,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
             "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==",
             "dev": true
-        },
-        "node_modules/@types/semver": {
-            "version": "7.3.9",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
-            "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
         },
         "node_modules/@types/source-list-map": {
             "version": "0.1.2",
@@ -6726,6 +6719,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -9144,6 +9138,7 @@
             "version": "7.3.7",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
             "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -11520,7 +11515,8 @@
         "node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         },
         "node_modules/yargs": {
             "version": "7.1.2",
@@ -12716,11 +12712,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
             "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==",
             "dev": true
-        },
-        "@types/semver": {
-            "version": "7.3.9",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
-            "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
         },
         "@types/source-list-map": {
             "version": "0.1.2",
@@ -17301,6 +17292,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
             "requires": {
                 "yallist": "^4.0.0"
             }
@@ -19173,6 +19165,7 @@
             "version": "7.3.7",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
             "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "dev": true,
             "requires": {
                 "lru-cache": "^6.0.0"
             }
@@ -21076,7 +21069,8 @@
         "yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         },
         "yargs": {
             "version": "7.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,11 @@
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
                 "@microsoft/vscode-azext-azureutils": "^0.2.0",
                 "@microsoft/vscode-azext-utils": "^0.2.0",
+                "@types/semver": "^7.3.9",
                 "fs-extra": "^8.1.0",
                 "jsonc-parser": "^2.2.1",
                 "open": "^8.0.4",
+                "semver": "^7.3.7",
                 "vscode-nls": "^4.1.1"
             },
             "devDependencies": {
@@ -873,6 +875,11 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
             "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==",
             "dev": true
+        },
+        "node_modules/@types/semver": {
+            "version": "7.3.9",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+            "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
         },
         "node_modules/@types/source-list-map": {
             "version": "0.1.2",
@@ -6719,7 +6726,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -9135,10 +9141,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -11515,8 +11520,7 @@
         "node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yargs": {
             "version": "7.1.2",
@@ -12712,6 +12716,11 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.9.tgz",
             "integrity": "sha512-CMjgRNsks27IDwI785YMY0KLt3co/c0cQ5foxHYv/shC2w8oOnVwz5Ubq1QG5KzrcW+AXk6gzdnxIkDnTvzu3g==",
             "dev": true
+        },
+        "@types/semver": {
+            "version": "7.3.9",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+            "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ=="
         },
         "@types/source-list-map": {
             "version": "0.1.2",
@@ -17292,7 +17301,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
             "requires": {
                 "yallist": "^4.0.0"
             }
@@ -19162,10 +19170,9 @@
             }
         },
         "semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "dev": true,
+            "version": "7.3.7",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
             "requires": {
                 "lru-cache": "^6.0.0"
             }
@@ -21069,8 +21076,7 @@
         "yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "yargs": {
             "version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -464,11 +464,9 @@
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
         "@microsoft/vscode-azext-azureutils": "^0.2.0",
         "@microsoft/vscode-azext-utils": "^0.2.0",
-        "@types/semver": "^7.3.9",
         "fs-extra": "^8.1.0",
         "jsonc-parser": "^2.2.1",
         "open": "^8.0.4",
-        "semver": "^7.3.7",
         "vscode-nls": "^4.1.1"
     },
     "extensionDependencies": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azureresourcegroups",
     "displayName": "Azure Resources",
     "description": "%azureResourceGroups.description%",
-    "version": "0.4.1-alpha.1",
+    "version": "0.4.1-alpha.2",
     "publisher": "ms-azuretools",
     "icon": "resources/resourceGroup.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/package.json
+++ b/package.json
@@ -464,9 +464,11 @@
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
         "@microsoft/vscode-azext-azureutils": "^0.2.0",
         "@microsoft/vscode-azext-utils": "^0.2.0",
+        "@types/semver": "^7.3.9",
         "fs-extra": "^8.1.0",
         "jsonc-parser": "^2.2.1",
         "open": "^8.0.4",
+        "semver": "^7.3.7",
         "vscode-nls": "^4.1.1"
     },
     "extensionDependencies": [

--- a/src/AzExtWrapper.ts
+++ b/src/AzExtWrapper.ts
@@ -87,6 +87,5 @@ export class AzExtWrapper {
     public meetsMinVersion(): boolean {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         return this.getCodeExtension()?.packageJSON?.contributes?.[contributesKey] !== undefined;
-        // return new SemVer(this._data.minVersion).compare((this.getCodeExtension()?.packageJSON)?.version as string) <= 0;
     }
 }

--- a/src/AzExtWrapper.ts
+++ b/src/AzExtWrapper.ts
@@ -8,6 +8,7 @@ import { IAzureQuickPickItem } from "@microsoft/vscode-azext-utils";
 import { AzureExtensionApiProvider } from "@microsoft/vscode-azext-utils/api";
 import { commands, Extension, extensions } from "vscode";
 import { azureExtensions, IAzExtMetadata, IAzExtResourceType, IAzExtTutorial } from "./azureExtensions";
+import { contributesKey } from "./constants";
 
 let wrappers: AzExtWrapper[] | undefined;
 export function getAzureExtensions(): AzExtWrapper[] {
@@ -81,5 +82,11 @@ export class AzExtWrapper {
 
     public isInstalled(): boolean {
         return !!this.getCodeExtension();
+    }
+
+    public meetsMinVersion(): boolean {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        return this.getCodeExtension()?.packageJSON?.contributes?.[contributesKey] !== undefined;
+        // return new SemVer(this._data.minVersion).compare((this.getCodeExtension()?.packageJSON)?.version as string) <= 0;
     }
 }

--- a/src/resolvers/OutdatedAppResourceResolver.ts
+++ b/src/resolvers/OutdatedAppResourceResolver.ts
@@ -18,7 +18,7 @@ class OutdatedAppResourceResolver implements AppResourceResolver, BuiltinResolve
     public readonly resolverKind = 'builtin';
 
     public resolveResource(_subContext: ISubscriptionContext, resource: AppResource): ResolvedAppResourceBase {
-        // We know the extension is known but uninstalled, or else it would not have passed the `isApplicable` check below
+        // We know the extension is known but outdated, or else it would not have passed the `isApplicable` check below
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const extension = getAzureExtensions().find(azExt => azExt.matchesResourceType(resource))!;
 
@@ -38,7 +38,7 @@ class OutdatedAppResourceResolver implements AppResourceResolver, BuiltinResolve
     }
 
     public matchesResource(resource: AppResource): boolean {
-        return getAzureExtensions().some(azExt => azExt.matchesResourceType(resource) && !azExt.meetsMinVersion());
+        return getAzureExtensions().some(azExt => azExt.matchesResourceType(resource) && azExt.isInstalled() && !azExt.meetsMinVersion());
     }
 }
 

--- a/src/resolvers/OutdatedAppResourceResolver.ts
+++ b/src/resolvers/OutdatedAppResourceResolver.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { GenericTreeItem, ISubscriptionContext } from "@microsoft/vscode-azext-utils";
+import { AppResource, AppResourceResolver, ResolvedAppResourceBase } from "@microsoft/vscode-azext-utils/hostapi";
+import { ThemeIcon } from "vscode";
+import { getAzureExtensions } from "../AzExtWrapper";
+import { localize } from "../utils/localize";
+import { BuiltinResolver } from "./BuiltinResolver";
+
+/**
+ * This resolver acts as a "placeholder" resolver when an extension is known for the resource type but not installed (or not enabled).
+ * Upon the resolved node being clicked, it will open the extension page on the marketplace to allow them to easily install (or enable).
+ */
+class OutdatedAppResourceResolver implements AppResourceResolver, BuiltinResolver {
+    public readonly resolverKind = 'builtin';
+
+    public resolveResource(_subContext: ISubscriptionContext, resource: AppResource): ResolvedAppResourceBase {
+        // We know the extension is known but uninstalled, or else it would not have passed the `isApplicable` check below
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const extension = getAzureExtensions().find(azExt => azExt.matchesResourceType(resource))!;
+
+        return {
+            loadMoreChildrenImpl: async () => {
+                const ti = new GenericTreeItem(undefined, {
+                    contextValue: 'updateExtension',
+                    label: localize('updateExtensionToEnableFeatures', 'Update extension to enable additional features...'),
+                    commandId: 'azureResourceGroups.installExtension',
+                    iconPath: new ThemeIcon('extensions'),
+                });
+                ti.commandArgs = [extension.id];
+
+                return [ti];
+            }
+        };
+    }
+
+    public matchesResource(resource: AppResource): boolean {
+        return getAzureExtensions().some(azExt => azExt.matchesResourceType(resource) && !azExt.meetsMinVersion());
+    }
+}
+
+export const outdatedAppResourceResolver = new OutdatedAppResourceResolver();

--- a/src/tree/ResolvableTreeItemBase.ts
+++ b/src/tree/ResolvableTreeItemBase.ts
@@ -10,6 +10,7 @@ import { ext } from "../extensionVariables";
 import { isBuiltinResolver } from "../resolvers/BuiltinResolver";
 import { installableAppResourceResolver } from "../resolvers/InstallableAppResourceResolver";
 import { noopResolver } from "../resolvers/NoopResolver";
+import { outdatedAppResourceResolver } from "../resolvers/OutdatedAppResourceResolver";
 import { shallowResourceResolver } from "../resolvers/ShallowResourceResolver";
 
 export abstract class ResolvableTreeItemBase extends AzExtParentTreeItem implements GroupableResource {
@@ -68,10 +69,12 @@ export abstract class ResolvableTreeItemBase extends AzExtParentTreeItem impleme
 
         if (resolver) {
             return resolver;
-        } else if (noopResolver.matchesResource(this.data)) {
-            return noopResolver;
+        } else if (outdatedAppResourceResolver.matchesResource(this.data)) {
+            return outdatedAppResourceResolver;
         } else if (installableAppResourceResolver.matchesResource(this.data)) {
             return installableAppResourceResolver;
+        } else if (noopResolver.matchesResource(this.data)) {
+            return noopResolver;
         } else {
             return shallowResourceResolver;
         }


### PR DESCRIPTION
I was going to do something fancier with semver, but I ended up just checking for the existence of the `x-azResources` key in the extension manifest. IMO this is way simpler and more fool-proof, and we can easily update the `meetsMinVersion()` function later if needed.

<img width="446" alt="image" src="https://user-images.githubusercontent.com/12476526/164510078-ee006ba1-f50a-400a-b824-fb9cc330e9f6.png">
