### PR TITLE
Fix a few small issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -328,6 +328,10 @@
                     "when": "never"
                 },
                 {
+                    "command": "azureResourceGroups.refreshWorkspace",
+                    "when": "never"
+                },
+                {
                     "command": "azureResourceGroups.loadMore",
                     "when": "never"
                 },

--- a/package.nls.json
+++ b/package.nls.json
@@ -7,6 +7,7 @@
     "azureResourceGroups.loadMore": "Load More",
     "azureResourceGroups.openInPortal": "Open in Portal",
     "azureResourceGroups.refresh": "Refresh",
+    "azureResourceGroups.refreshWorkspace": "Refresh Workspace",
     "azureResourceGroups.revealResource": "Reveal Resource",
     "azureResourceGroups.viewProperties": "View Properties",
     "azureResourceGroups.deleteConfirmation": "The behavior to use when confirming delete of a resource group.",

--- a/src/commands/deleteResourceGroup/deleteResourceGroup.ts
+++ b/src/commands/deleteResourceGroup/deleteResourceGroup.ts
@@ -14,7 +14,7 @@ export async function deleteResourceGroup(context: IActionContext, primaryNode?:
         if (primaryNode) {
             selectedNodes = [primaryNode];
         } else {
-            selectedNodes = await ext.appResourceTree.showTreeItemPicker<ResourceGroupTreeItem>(ResourceGroupTreeItem.contextValue, { ...context, canPickMany: true, suppressCreatePick: true });
+            selectedNodes = await ext.appResourceTree.showTreeItemPicker<ResourceGroupTreeItem>(new RegExp(ResourceGroupTreeItem.contextValue), { ...context, canPickMany: true, suppressCreatePick: true });
         }
     } else {
         selectedNodes = selectedNodes.filter(n => n instanceof ResourceGroupTreeItem);


### PR DESCRIPTION
Hiding the refresh workspace command from palette:
* Fixes #192

Delete resource group from command palette:
* Fixes #193 
* Fixes #194

Note: the delete resource group command will still fail when the groupBy setting != resourceGroup, I will file a new issue for this if needed. #199 