### PR TITLE
Implement pickAppResource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@azure/arm-resources": "5.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
                 "@microsoft/vscode-azext-azureutils": "^0.2.0",
-                "@microsoft/vscode-azext-utils": "^0.2.0",
+                "@microsoft/vscode-azext-utils": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.2.2.tgz",
                 "fs-extra": "^8.1.0",
                 "jsonc-parser": "^2.2.1",
                 "open": "^8.0.4",
@@ -660,9 +660,10 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.2.0.tgz",
-            "integrity": "sha512-ME3Or0HxJ7uForUYdkWvUzuCSOPvuHQtiTRspmuKPJGqEbKWw820hyRdUyR5gw+B4MBADnwQhaaHW1rOu/ghCA==",
+            "version": "0.2.2",
+            "resolved": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.2.2.tgz",
+            "integrity": "sha512-enPiuR1M05+lV9roAclMbSK37uO79AWI/B2jBs15dEzlxtp6123mDG1l2103d3ghaRgbURzKh/N9tU85xX3kxg==",
+            "license": "MIT",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.4.7",
                 "dayjs": "^1.9.3",
@@ -12525,9 +12526,8 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.2.0.tgz",
-            "integrity": "sha512-ME3Or0HxJ7uForUYdkWvUzuCSOPvuHQtiTRspmuKPJGqEbKWw820hyRdUyR5gw+B4MBADnwQhaaHW1rOu/ghCA==",
+            "version": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.2.2.tgz",
+            "integrity": "sha512-enPiuR1M05+lV9roAclMbSK37uO79AWI/B2jBs15dEzlxtp6123mDG1l2103d3ghaRgbURzKh/N9tU85xX3kxg==",
             "requires": {
                 "@vscode/extension-telemetry": "^0.4.7",
                 "dayjs": "^1.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@azure/arm-resources": "5.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
                 "@microsoft/vscode-azext-azureutils": "^0.2.0",
-                "@microsoft/vscode-azext-utils": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.2.2.tgz",
+                "@microsoft/vscode-azext-utils": "^0.2.3",
                 "fs-extra": "^8.1.0",
                 "jsonc-parser": "^2.2.1",
                 "open": "^8.0.4",
@@ -660,10 +660,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.2.2",
-            "resolved": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.2.2.tgz",
-            "integrity": "sha512-enPiuR1M05+lV9roAclMbSK37uO79AWI/B2jBs15dEzlxtp6123mDG1l2103d3ghaRgbURzKh/N9tU85xX3kxg==",
-            "license": "MIT",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.2.3.tgz",
+            "integrity": "sha512-KGu1mAvctdNS5GKGPmakI0SAszXJQlnerw+T3ok3CLY03PGtjcKrx+AcW/n/3tbFUHGMvfGvAT6PaJld6ofzjw==",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.4.7",
                 "dayjs": "^1.9.3",
@@ -12526,8 +12525,9 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.2.2.tgz",
-            "integrity": "sha512-enPiuR1M05+lV9roAclMbSK37uO79AWI/B2jBs15dEzlxtp6123mDG1l2103d3ghaRgbURzKh/N9tU85xX3kxg==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.2.3.tgz",
+            "integrity": "sha512-KGu1mAvctdNS5GKGPmakI0SAszXJQlnerw+T3ok3CLY03PGtjcKrx+AcW/n/3tbFUHGMvfGvAT6PaJld6ofzjw==",
             "requires": {
                 "@vscode/extension-telemetry": "^0.4.7",
                 "dayjs": "^1.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureresourcegroups",
-    "version": "0.4.1-alpha.8",
+    "version": "0.4.1-alpha.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureresourcegroups",
-            "version": "0.4.1-alpha.8",
+            "version": "0.4.1-alpha.9",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-resources": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azureresourcegroups",
     "displayName": "Azure Resources",
     "description": "%azureResourceGroups.description%",
-    "version": "0.4.1-alpha.8",
+    "version": "0.4.1-alpha.9",
     "publisher": "ms-azuretools",
     "icon": "resources/resourceGroup.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/package.json
+++ b/package.json
@@ -476,7 +476,7 @@
         "@azure/arm-resources": "5.0.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
         "@microsoft/vscode-azext-azureutils": "^0.2.0",
-        "@microsoft/vscode-azext-utils": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.2.2.tgz",
+        "@microsoft/vscode-azext-utils": "^0.2.3",
         "fs-extra": "^8.1.0",
         "jsonc-parser": "^2.2.1",
         "open": "^8.0.4",

--- a/package.json
+++ b/package.json
@@ -476,7 +476,7 @@
         "@azure/arm-resources": "5.0.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
         "@microsoft/vscode-azext-azureutils": "^0.2.0",
-        "@microsoft/vscode-azext-utils": "^0.2.0",
+        "@microsoft/vscode-azext-utils": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-0.2.2.tgz",
         "fs-extra": "^8.1.0",
         "jsonc-parser": "^2.2.1",
         "open": "^8.0.4",

--- a/src/api/AzureResourceGroupsExtensionApi.ts
+++ b/src/api/AzureResourceGroupsExtensionApi.ts
@@ -19,7 +19,6 @@ export class InternalAzureResourceGroupsExtensionApi implements AzureHostExtensi
     #registerActivity: (activity: Activity) => Promise<void>;
     #pickAppResource: <T extends AzExtTreeItem>(context: IActionContext, options?: PickAppResourceOptions) => Promise<T>;
 
-
     // This `Omit` is here because the interface expects those keys to be defined, but in this object they will not be
     // They are replaced with functions defined on this class that merely wrap the newly-named keys
     // TODO: when `tree`, `treeView`, and `registerLocalResourceProvider` are removed from the interface, this `Omit` can be removed

--- a/src/api/AzureResourceGroupsExtensionApi.ts
+++ b/src/api/AzureResourceGroupsExtensionApi.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtTreeDataProvider, AzExtTreeItem, IActionContext } from '@microsoft/vscode-azext-utils';
+import { AzExtTreeDataProvider, AzExtTreeItem, ITreeItemPickerContext } from '@microsoft/vscode-azext-utils';
 import { Activity, AppResourceResolver, AzureHostExtensionApi, AzureResourceGroupsExtensionApi, LocalResourceProvider, PickAppResourceOptions, WorkspaceResourceProvider } from '@microsoft/vscode-azext-utils/hostapi';
 import { Disposable, TreeView } from 'vscode';
 
@@ -17,7 +17,7 @@ export class InternalAzureResourceGroupsExtensionApi implements AzureHostExtensi
     #registerApplicationResourceResolver: (id: string, resolver: AppResourceResolver) => Disposable;
     #registerWorkspaceResourceProvider: (id: string, resolver: WorkspaceResourceProvider) => Disposable;
     #registerActivity: (activity: Activity) => Promise<void>;
-    #pickAppResource: <T extends AzExtTreeItem>(context: IActionContext, options?: PickAppResourceOptions) => Promise<T>;
+    #pickAppResource: <T extends AzExtTreeItem>(context: ITreeItemPickerContext, options?: PickAppResourceOptions) => Promise<T>;
 
     // This `Omit` is here because the interface expects those keys to be defined, but in this object they will not be
     // They are replaced with functions defined on this class that merely wrap the newly-named keys
@@ -59,7 +59,7 @@ export class InternalAzureResourceGroupsExtensionApi implements AzureHostExtensi
         return await this.#revealTreeItem(resourceId);
     }
 
-    public async pickAppResource<T extends AzExtTreeItem>(context: IActionContext, options?: PickAppResourceOptions): Promise<T> {
+    public async pickAppResource<T extends AzExtTreeItem>(context: ITreeItemPickerContext, options?: PickAppResourceOptions): Promise<T> {
         return this.#pickAppResource(context, options);
     }
 

--- a/src/api/AzureResourceGroupsExtensionApi.ts
+++ b/src/api/AzureResourceGroupsExtensionApi.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtTreeDataProvider, AzExtTreeItem } from '@microsoft/vscode-azext-utils';
-import { Activity, AppResourceResolver, AzureHostExtensionApi, AzureResourceGroupsExtensionApi, LocalResourceProvider, WorkspaceResourceProvider } from '@microsoft/vscode-azext-utils/hostapi';
+import { AzExtTreeDataProvider, AzExtTreeItem, IActionContext } from '@microsoft/vscode-azext-utils';
+import { Activity, AppResourceResolver, AzureHostExtensionApi, AzureResourceGroupsExtensionApi, LocalResourceProvider, PickAppResourceOptions, WorkspaceResourceProvider } from '@microsoft/vscode-azext-utils/hostapi';
 import { Disposable, TreeView } from 'vscode';
 
 export class InternalAzureResourceGroupsExtensionApi implements AzureHostExtensionApi, AzureResourceGroupsExtensionApi {
@@ -17,6 +17,8 @@ export class InternalAzureResourceGroupsExtensionApi implements AzureHostExtensi
     #registerApplicationResourceResolver: (id: string, resolver: AppResourceResolver) => Disposable;
     #registerWorkspaceResourceProvider: (id: string, resolver: WorkspaceResourceProvider) => Disposable;
     #registerActivity: (activity: Activity) => Promise<void>;
+    #pickAppResource: <T extends AzExtTreeItem>(context: IActionContext, options?: PickAppResourceOptions) => Promise<T>;
+
 
     // This `Omit` is here because the interface expects those keys to be defined, but in this object they will not be
     // They are replaced with functions defined on this class that merely wrap the newly-named keys
@@ -31,6 +33,7 @@ export class InternalAzureResourceGroupsExtensionApi implements AzureHostExtensi
         this.#registerApplicationResourceResolver = options.registerApplicationResourceResolver;
         this.#registerWorkspaceResourceProvider = options.registerWorkspaceResourceProvider;
         this.#registerActivity = options.registerActivity;
+        this.#pickAppResource = options.pickAppResource;
     }
 
     public get appResourceTree(): AzExtTreeDataProvider {
@@ -55,6 +58,10 @@ export class InternalAzureResourceGroupsExtensionApi implements AzureHostExtensi
 
     public async revealTreeItem(resourceId: string): Promise<void> {
         return await this.#revealTreeItem(resourceId);
+    }
+
+    public async pickAppResource<T extends AzExtTreeItem>(context: IActionContext, options?: PickAppResourceOptions): Promise<T> {
+        return this.#pickAppResource(context, options);
     }
 
     public registerApplicationResourceResolver(id: string, resolver: AppResourceResolver): Disposable {

--- a/src/api/pickAppResource.ts
+++ b/src/api/pickAppResource.ts
@@ -3,16 +3,19 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
+import { AzExtTreeItem, ITreeItemPickerContext } from "@microsoft/vscode-azext-utils";
 import { PickAppResourceOptions } from "@microsoft/vscode-azext-utils/hostapi";
 import { ext } from "../extensionVariables";
 import { SubscriptionTreeItem } from "../tree/SubscriptionTreeItem";
 
-export async function pickAppResource<T extends AzExtTreeItem>(context: IActionContext, options?: PickAppResourceOptions): Promise<T> {
+export async function pickAppResource<T extends AzExtTreeItem>(context: ITreeItemPickerContext, options?: PickAppResourceOptions): Promise<T> {
     const subscription: SubscriptionTreeItem = await ext.appResourceTree.showTreeItemPicker(SubscriptionTreeItem.contextValue, context);
     const appResource = await subscription.pickAppResource(context, options);
 
     if (options?.expectedChildContextValue) {
+        if (!appResource.resolveResult) {
+            await appResource.resolve(true, context);
+        }
         return ext.appResourceTree.showTreeItemPicker(options.expectedChildContextValue, context, appResource);
     } else {
         return appResource as unknown as T;

--- a/src/api/pickAppResource.ts
+++ b/src/api/pickAppResource.ts
@@ -12,10 +12,11 @@ export async function pickAppResource<T extends AzExtTreeItem>(context: ITreeIte
     const subscription: SubscriptionTreeItem = await ext.appResourceTree.showTreeItemPicker(SubscriptionTreeItem.contextValue, context);
     const appResource = await subscription.pickAppResource(context, options);
 
+    if (!appResource.resolveResult) {
+        await appResource.resolve(true, context);
+    }
+
     if (options?.expectedChildContextValue) {
-        if (!appResource.resolveResult) {
-            await appResource.resolve(true, context);
-        }
         return ext.appResourceTree.showTreeItemPicker(options.expectedChildContextValue, context, appResource);
     } else {
         return appResource as unknown as T;

--- a/src/api/pickAppResource.ts
+++ b/src/api/pickAppResource.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { AzExtTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
+import { PickAppResourceOptions } from "@microsoft/vscode-azext-utils/hostapi";
+import { ext } from "../extensionVariables";
+import { SubscriptionTreeItem } from "../tree/SubscriptionTreeItem";
+
+export async function pickAppResource<T extends AzExtTreeItem>(context: IActionContext, options?: PickAppResourceOptions): Promise<T> {
+    const subscription: SubscriptionTreeItem = await ext.appResourceTree.showTreeItemPicker(SubscriptionTreeItem.contextValue, context);
+    const appResource = await subscription.pickAppResource(context, options);
+
+    if (options?.expectedChildContextValue) {
+        return ext.appResourceTree.showTreeItemPicker(options.expectedChildContextValue, context, appResource);
+    } else {
+        return appResource as unknown as T;
+    }
+}

--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -3,27 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ResourceGroup } from '@azure/arm-resources';
 import { openInPortal as uiOpenInPortal } from '@microsoft/vscode-azext-azureutils';
 import { AzExtTreeItem, IActionContext, nonNullProp } from '@microsoft/vscode-azext-utils';
-import { AppResource } from '@microsoft/vscode-azext-utils/hostapi';
 import { pickAppResource } from '../api/pickAppResource';
 import { AppResourceTreeItem } from '../tree/AppResourceTreeItem';
-import { ResourceGroupTreeItem } from '../tree/ResourceGroupTreeItem';
-
-export async function getDataFromNode(node: ResourceGroupTreeItem | AppResourceTreeItem): Promise<AppResource | ResourceGroup | undefined> {
-    if (node instanceof ResourceGroupTreeItem) {
-        return (await node.getData());
-    }
-    return node.data;
-}
 
 export async function openInPortal(context: IActionContext, node?: AzExtTreeItem): Promise<void> {
-
-
     if (!node) {
-        node = await pickAppResource(context) as AppResourceTreeItem;
-        // node = await ext.appResourceTree.showTreeItemPicker<ResourceGroupTreeItem>(ResourceGroupTreeItem.contextValue, context);
+        node = await pickAppResource<AppResourceTreeItem>(context);
     }
 
     await uiOpenInPortal(node, nonNullProp(node, 'id'));

--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -5,9 +5,9 @@
 
 import { ResourceGroup } from '@azure/arm-resources';
 import { openInPortal as uiOpenInPortal } from '@microsoft/vscode-azext-azureutils';
-import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { AzExtTreeItem, IActionContext, nonNullProp } from '@microsoft/vscode-azext-utils';
 import { AppResource } from '@microsoft/vscode-azext-utils/hostapi';
-import { ext } from '../extensionVariables';
+import { pickAppResource } from '../api/pickAppResource';
 import { AppResourceTreeItem } from '../tree/AppResourceTreeItem';
 import { ResourceGroupTreeItem } from '../tree/ResourceGroupTreeItem';
 
@@ -18,10 +18,13 @@ export async function getDataFromNode(node: ResourceGroupTreeItem | AppResourceT
     return node.data;
 }
 
-export async function openInPortal(context: IActionContext, node?: ResourceGroupTreeItem | AppResourceTreeItem): Promise<void> {
+export async function openInPortal(context: IActionContext, node?: AzExtTreeItem): Promise<void> {
+
+
     if (!node) {
-        node = await ext.appResourceTree.showTreeItemPicker<ResourceGroupTreeItem>(ResourceGroupTreeItem.contextValue, context);
+        node = await pickAppResource(context) as AppResourceTreeItem;
+        // node = await ext.appResourceTree.showTreeItemPicker<ResourceGroupTreeItem>(ResourceGroupTreeItem.contextValue, context);
     }
 
-    await uiOpenInPortal(node, (await getDataFromNode(node))?.id ?? node.fullId);
+    await uiOpenInPortal(node, nonNullProp(node, 'id'));
 }

--- a/src/commands/tags/editTags.ts
+++ b/src/commands/tags/editTags.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from "@microsoft/vscode-azext-utils";
+import { pickAppResource } from "../../api/pickAppResource";
 import { ext } from "../../extensionVariables";
 import { AppResourceTreeItem } from "../../tree/AppResourceTreeItem";
-import { ResourceGroupTreeItem } from "../../tree/ResourceGroupTreeItem";
 
-export async function editTags(context: IActionContext, node?: ResourceGroupTreeItem | AppResourceTreeItem): Promise<void> {
+export async function editTags(context: IActionContext, node?: AppResourceTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.appResourceTree.showTreeItemPicker<ResourceGroupTreeItem>(ResourceGroupTreeItem.contextValue, context);
+        node = await pickAppResource<AppResourceTreeItem>(context);
     }
 
     await ext.tagFS.showTextDocument(node);

--- a/src/commands/viewProperties.ts
+++ b/src/commands/viewProperties.ts
@@ -4,15 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, openReadOnlyJson } from '@microsoft/vscode-azext-utils';
-import { ext } from '../extensionVariables';
+import { pickAppResource } from '../api/pickAppResource';
 import { AppResourceTreeItem } from '../tree/AppResourceTreeItem';
-import { ResourceGroupTreeItem } from '../tree/ResourceGroupTreeItem';
-import { getDataFromNode } from './openInPortal';
 
-export async function viewProperties(context: IActionContext, node?: ResourceGroupTreeItem | AppResourceTreeItem): Promise<void> {
+export async function viewProperties(context: IActionContext, node?: AppResourceTreeItem): Promise<void> {
     if (!node) {
-        node = await ext.appResourceTree.showTreeItemPicker<ResourceGroupTreeItem>(ResourceGroupTreeItem.contextValue, context);
+        node = await pickAppResource<AppResourceTreeItem>(context);
     }
 
-    await openReadOnlyJson(node, (await getDataFromNode(node)) || {});
+    await openReadOnlyJson(node, node.data);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import * as vscode from 'vscode';
 import { ActivityLogTreeItem } from './activityLog/ActivityLogsTreeItem';
 import { registerActivity } from './activityLog/registerActivity';
 import { InternalAzureResourceGroupsExtensionApi } from './api/AzureResourceGroupsExtensionApi';
+import { pickAppResource } from './api/pickAppResource';
 import { registerApplicationResourceProvider } from './api/registerApplicationResourceProvider';
 import { registerApplicationResourceResolver } from './api/registerApplicationResourceResolver';
 import { registerWorkspaceResourceProvider } from './api/registerWorkspaceResourceProvider';
@@ -87,6 +88,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
             registerApplicationResourceResolver,
             registerWorkspaceResourceProvider,
             registerActivity,
+            pickAppResource,
         })
     ]);
 }

--- a/src/tree/GroupTreeItemBase.ts
+++ b/src/tree/GroupTreeItemBase.ts
@@ -75,7 +75,7 @@ export class GroupTreeItemBase extends AzExtParentTreeItem {
         const showHiddenTypes = settingUtils.getWorkspaceSetting('showHiddenTypes') as boolean;
         if (!showHiddenTypes) {
             if (!this._showAllResources) {
-                resources = this.filterResources(resources);
+                resources = GroupTreeItemBase.filterResources(resources as AppResourceTreeItem[]);
             }
 
             if (resources.length !== allResources.length || this._showAllResources) {
@@ -94,7 +94,7 @@ export class GroupTreeItemBase extends AzExtParentTreeItem {
         return !!Object.values(this.treeMap).length;
     }
 
-    public filterResources(resources: AzExtTreeItem[]): AzExtTreeItem[] {
+    public static filterResources(resources: AppResourceTreeItem[]): AppResourceTreeItem[] {
         return resources.filter(r =>
             azureExtensions.some(ext =>
                 ext.resourceTypes.some((type) => {

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -46,15 +46,16 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         if (!showHiddenTypes) {
             appResources = GroupTreeItemBase.filterResources(this.cache.appResources);
         }
-        if (options?.type) {
-            appResources = appResources.filter((appResource) => getResourceType(appResource.data.type, appResource.data.kind) === options?.type);
+        if (options?.filter) {
+            const filterType = getResourceType(options.filter.type, options.filter.kind);
+            appResources = appResources.filter((appResource) => getResourceType(appResource.data.type, appResource.data.kind) === filterType);
         }
 
         const picks = appResources.map((appResource) => ({ data: appResource, label: appResource.label, group: appResource.groupConfig.resourceType.label, description: appResource.groupConfig.resourceGroup.label }))
             .sort((a, b) => a.group.localeCompare(b.group));
 
         const quickPickOptions: IAzureQuickPickOptions = {
-            enableGrouping: !options?.type,
+            enableGrouping: !options?.filter,
             placeHolder: localize('selectResource', 'Select a resource'),
             ...options,
         };

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -40,10 +40,14 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
 
     public async pickAppResource(context: IActionContext, options?: PickAppResourceOptions): Promise<AppResourceTreeItem> {
         await this.getCachedChildren(context);
-        let appResources = GroupTreeItemBase.filterResources(this.cache.appResources);
 
+        let appResources = this.cache.appResources;
+        const showHiddenTypes = settingUtils.getWorkspaceSetting<boolean>('showHiddenTypes');
+        if (!showHiddenTypes) {
+            appResources = GroupTreeItemBase.filterResources(this.cache.appResources);
+        }
         if (options?.type) {
-            appResources = appResources.filter((appResource) => getResourceType(appResource.data.type, appResource.data.kind) === options.type);
+            appResources = appResources.filter((appResource) => getResourceType(appResource.data.type, appResource.data.kind) === options?.type);
         }
 
         const picks = appResources.map((appResource) => ({ data: appResource, label: appResource.label, group: appResource.groupConfig.resourceType.label, description: appResource.groupConfig.resourceGroup.label }))

--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -242,7 +242,7 @@ function getRelevantKind(type?: string, kind?: string): string | undefined {
     return undefined;
 }
 
-function getResourceType(type?: string, kind?: string): string {
+export function getResourceType(type?: string, kind?: string): string {
     const relevantKind = getRelevantKind(type, kind);
     return `${type?.toLowerCase()}${relevantKind ? `/${relevantKind}` : ''}`;
 }


### PR DESCRIPTION
This is a big step forward in terms of helping us solve all of the issues surrounding running commands from the palette. The design of showTreeItemPicker doesn't fit well into the new model, and so this is just a slight variation that skips a step.

Depends on https://github.com/microsoft/vscode-azuretools/pull/1141

There are a few options we can take advantage of here:

```ts
export interface PickAppResourceOptions extends IAzureQuickPickOptions {
    type?: string; // ex: 'microsoft.web/sites'
    expectedChildContextValue?: string | RegExp | (string | RegExp)[]; // ex: EnvironmentTreeItem.contextValue
}
```

If you pass in `type`, the picks are filtered based on that type. Passing a value for `expectedChildContextValue` enables us to select children of app resources, ex: an app setting tree item.

Example of selecting an app resource:

https://user-images.githubusercontent.com/12476526/165870763-9de237f8-114a-4832-9701-52fc8b693e20.mov