### PR TITLE
Refresh UI only to prevent extra calls to refreshImpl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureresourcegroups",
-    "version": "0.4.1-alpha.23",
+    "version": "0.4.1-alpha.24",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureresourcegroups",
-            "version": "0.4.1-alpha.23",
+            "version": "0.4.1-alpha.24",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-resources": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azureresourcegroups",
     "displayName": "Azure Resources",
     "description": "%azureResourceGroups.description%",
-    "version": "0.4.1-alpha.23",
+    "version": "0.4.1-alpha.24",
     "publisher": "ms-azuretools",
     "icon": "resources/resourceGroup.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/tree/AppResourceTreeItem.ts
+++ b/src/tree/AppResourceTreeItem.ts
@@ -147,7 +147,7 @@ export class AppResourceTreeItem extends ResolvableTreeItemBase implements Group
 
         subGroupTreeItem.treeMap[this.id] = this;
         // this should actually be "resolve"
-        void subGroupTreeItem.refresh(context);
+        void ext.appResourceTree.refreshUIOnly(subGroupTreeItem);
     }
 
     public createSubGroupTreeItem(_context: IActionContext, groupBySetting: string, getResourceGroup: (resourceGroup: string) => Promise<ResourceGroup | undefined>): GroupTreeItemBase {

--- a/src/tree/AppResourceTreeItem.ts
+++ b/src/tree/AppResourceTreeItem.ts
@@ -146,7 +146,6 @@ export class AppResourceTreeItem extends ResolvableTreeItemBase implements Group
         }
 
         subGroupTreeItem.treeMap[this.id] = this;
-        // this should actually be "resolve"
         void ext.appResourceTree.refreshUIOnly(subGroupTreeItem);
     }
 


### PR DESCRIPTION
This prevents `GroupTreeItem.refreshImpl` from being called every time it gets created. I don't believe this is expected behavior.

I'm also unsure if the `this should actually be "resolve"` comment still holds up