### PR TITLE
Call refreshUIOnly after setting cached children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureresourcegroups",
-    "version": "0.5.1-alpha.1",
+    "version": "0.5.1-alpha.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureresourcegroups",
-            "version": "0.5.1-alpha.1",
+            "version": "0.5.1-alpha.2",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-resources": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azureresourcegroups",
     "displayName": "Azure Resources",
     "description": "%azureResourceGroups.description%",
-    "version": "0.5.1-alpha.1",
+    "version": "0.5.1-alpha.2",
     "publisher": "ms-azuretools",
     "icon": "resources/resourceGroup.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -211,7 +211,10 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         const thisUnknown = this as unknown as { _cachedChildren: AzExtTreeItem[] };
         thisUnknown._cachedChildren = childrenToSet;
         thisUnknown._cachedChildren = childrenToSet.sort((ti1, ti2) => this.compareChildrenImpl(ti1, ti2));
-        this.treeDataProvider.refreshUIOnly(this);
+
+        // To prevent "Element with id {0} is already registered" errors, we must
+        // clear VS Code's internal cache by passing `undefined` to refresh the whole tree
+        this.treeDataProvider.refreshUIOnly(undefined);
     }
 
     private async tryGetFocusGroupTreeItem(): Promise<GroupTreeItemBase | undefined> {


### PR DESCRIPTION
Fixes #284 

When we set the cached children, we must make sure that we clear the entire VS Code internal tree item cache. [VS Code won't clear their entire cache if you don't pass `undefined`](https://github.dev/microsoft/vscode/blob/d891b49fc0f8fc5e00591657ca225975952b09ca/src/vs/workbench/api/common/extHostTreeViews.ts#L617).

I think tree items we were setting onto the focused group node cache weren't being completely removed from VS Code's cache, thus causing the error.