### PR TITLE
Fetch resources to get number of resources in RG

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureresourcegroups",
-    "version": "0.5.4-alpha.1",
+    "version": "0.5.4-alpha.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureresourcegroups",
-            "version": "0.5.4-alpha.1",
+            "version": "0.5.4-alpha.2",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-resources": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azureresourcegroups",
     "displayName": "Azure Resources",
     "description": "%azureResourceGroups.description%",
-    "version": "0.5.4-alpha.1",
+    "version": "0.5.4-alpha.2",
     "publisher": "ms-azuretools",
     "icon": "resources/resourceGroup.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/tree/ResourceGroupTreeItem.ts
+++ b/src/tree/ResourceGroupTreeItem.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ResourceGroup, ResourceManagementClient } from "@azure/arm-resources";
-import { uiUtils } from "@microsoft/vscode-azext-azureutils";
 import { AzExtParentTreeItem, AzureWizard, IActionContext, nonNullProp, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { GroupNodeConfiguration } from "@microsoft/vscode-azext-utils/hostapi";
 import { FileChangeType } from "vscode";
@@ -62,12 +61,6 @@ export class ResourceGroupTreeItem extends GroupTreeItemBase {
 
     public get iconPath(): TreeItemIconPath {
         return treeUtils.getIconPath('resourceGroup');
-    }
-
-    public async getNumOfResources(context: IActionContext): Promise<number> {
-        const client: ResourceManagementClient = await createResourceClient([context, this.subscription]);
-        const resources = await uiUtils.listAllIterator(client.resources.listByResourceGroup(this.name));
-        return resources.length;
     }
 
     public async refreshImpl(context: IActionContext): Promise<void> {

--- a/src/tree/ResourceGroupTreeItem.ts
+++ b/src/tree/ResourceGroupTreeItem.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ResourceGroup, ResourceManagementClient } from "@azure/arm-resources";
+import { uiUtils } from "@microsoft/vscode-azext-azureutils";
 import { AzExtParentTreeItem, AzureWizard, IActionContext, nonNullProp, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { GroupNodeConfiguration } from "@microsoft/vscode-azext-utils/hostapi";
 import { FileChangeType } from "vscode";
@@ -64,13 +65,8 @@ export class ResourceGroupTreeItem extends GroupTreeItemBase {
     }
 
     public async getNumOfResources(context: IActionContext): Promise<number> {
-        // load/retrieve the first batch to check if there are more children
-        let resources = await this.getCachedChildren(context);
-
-        if (this.hasMoreChildrenImpl()) {
-            resources = await this.loadAllChildren(context);
-        }
-
+        const client: ResourceManagementClient = await createResourceClient([context, this.subscription]);
+        const resources = await uiUtils.listAllIterator(client.resources.listByResourceGroup(this.name));
         return resources.length;
     }
 


### PR DESCRIPTION
Fixes #308 

Deriving the number of resources in a resource group from the cached children (or a similar source like the treeMap) results in the number being wrong unless view is grouped by resource group and the subscription tree item has been expanded.

It's much simpler to just fetch the list of resources and use that.