### PR TITLE
Remove container app resource types from resolvers

### DIFF
--- a/src/azureExtensions.ts
+++ b/src/azureExtensions.ts
@@ -85,8 +85,8 @@ export const azureExtensions: IAzExtMetadata[] = [
         name: 'vscode-azurecontainerapps',
         label: 'Container Apps',
         resourceTypes: [
-            'microsoft.app/containerapps',
-            'microsoft.app/managedenvironments'
+            //'microsoft.app/containerapps',
+            //'microsoft.app/managedenvironments'
         ],
         reportIssueCommandId: 'containerApps.reportIssue'
     }


### PR DESCRIPTION
The version bot better shut up on this one 😠 

Just commenting out the azureExtension part of it.  The icons/labels will still be in there. Shouldn't be an issue, makes it look better but it's also only seen if the hiddenStacks is enabled anyway.