### PR TITLE
When sub or group is refreshed, refresh the children as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -332,14 +332,19 @@
                     "group": "9@1"
                 },
                 {
+                    "command": "azureResourceGroups.refresh",
+                    "when": "view == azureResourceGroups && viewItem =~ /group/",
+                    "group": "inline@1"
+                },
+                {
                     "command": "azureResourceGroups.focusGroup",
                     "when": "view == azureResourceGroups && viewItem =~ /(group).*(unfocused)/",
-                    "group": "inline"
+                    "group": "inline@2"
                 },
                 {
                     "command": "azureResourceGroups.unfocusGroup",
                     "when": "view == azureResourceGroups && viewItem =~ /(focused).*(group)/",
-                    "group": "inline"
+                    "group": "inline@2"
                 }
             ],
             "commandPalette": [

--- a/src/tree/GroupTreeItemBase.ts
+++ b/src/tree/GroupTreeItemBase.ts
@@ -126,7 +126,7 @@ export class GroupTreeItemBase extends AzExtParentTreeItem {
 
     public async refreshImpl(context: IActionContext): Promise<void> {
         await Promise.all(
-            Object.values(this.treeMap).map(async resolvable => resolvable.resolve(true, context))
+            Object.values(this.treeMap).map(async ti => await ti.refresh(context))
         );
     }
 

--- a/src/tree/GroupTreeItemBase.ts
+++ b/src/tree/GroupTreeItemBase.ts
@@ -126,7 +126,7 @@ export class GroupTreeItemBase extends AzExtParentTreeItem {
 
     public async refreshImpl(context: IActionContext): Promise<void> {
         await Promise.all(
-            Object.values(this.treeMap).map(async ti => await ti.refresh(context))
+            Object.values(this.treeMap).map(async ti => ti.refresh(context))
         );
     }
 

--- a/src/tree/ResourceGroupTreeItem.ts
+++ b/src/tree/ResourceGroupTreeItem.ts
@@ -68,6 +68,7 @@ export class ResourceGroupTreeItem extends GroupTreeItemBase {
         this.data = await client.resourceGroups.get(this.name);
         this.mTime = Date.now();
         ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
+        await super.refreshImpl(context);
     }
 
     public async deleteTreeItemImpl(context: IActionContext): Promise<void> {

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -147,6 +147,12 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         return Object.values(this.treeMap);
     }
 
+    public async refreshImpl(context: IActionContext): Promise<void> {
+        for (const ti of Object.values(this.treeMap)) {
+            void ti.refresh(context);
+        }
+    }
+
 
     public async createChildImpl(context: ICreateChildImplContext): Promise<ResourceGroupTreeItem> {
         const wizardContext: IResourceGroupWizardContext & ExecuteActivityContext = {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurestorage/issues/1096

When "refresh" is triggered on the root or a parent, it will only call its refresh, and then call `loadMoreChildren` on itself.  However, because `loadMoreChildrenImpl` doesn't actually create new tree items (since we are caching all of the `AppResourceTreeItems`), refreshing the root, the subscription, and the groups didn't actually do anything.

By adding `refreshImpl` to `SubscriptionTreeItem` and `GroupTreeItemBase`, the `AppResourceTreeItems` will actually get refreshed now and it'll be a meaningful refresh.

I can't fix the root level refresh without affecting performance because if I call refresh in `SubscriptionTreeItem.loadMoreChildrenImpl`, it will activate all of the extensions at once. 

The root level refresh only works for subscription filtering so I would almost opt to get rid of the refresh button on the ribbon and add it to the groups themselves. It would looks like this:

![image](https://user-images.githubusercontent.com/5290572/180106074-ffc3240f-8ae5-40b6-90f1-059d176fe5d4.png)
