### PR TITLE
Support legacy resource types

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,7 +48,8 @@
                 "--extensionDevelopmentPath=${workspaceFolder}/../vscode-azurefunctions",
                 "--extensionDevelopmentPath=${workspaceFolder}/../vscode-azurevirtualmachines",
                 "--extensionDevelopmentPath=${workspaceFolder}/../vscode-azureappservice",
-                "--extensionDevelopmentPath=${workspaceFolder}/../vscode-cosmosdb"
+                "--extensionDevelopmentPath=${workspaceFolder}/../vscode-cosmosdb",
+                "--extensionDevelopmentPath=${workspaceFolder}/../vscode-azurecontainerapps"
             ],
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"

--- a/src/azureExtensions.ts
+++ b/src/azureExtensions.ts
@@ -90,7 +90,6 @@ export const legacyTypeMap: Partial<Record<AzExtResourceType, string>> = {
     FunctionApp: 'microsoft.web/functionapp',
     AppServices: 'microsoft.web/sites',
     StaticWebApps: 'microsoft.web/staticsites',
-    StorageAccounts: 'microsoft.storage/storageaccounts',
     VirtualMachines: 'microsoft.compute/virtualmachines',
     AzureCosmosDb: 'microsoft.documentdb/databaseaccounts',
     PostgresqlServersStandard: 'microsoft.dbforpostgresql/servers',

--- a/src/azureExtensions.ts
+++ b/src/azureExtensions.ts
@@ -87,6 +87,17 @@ export const azureExtensions: IAzExtMetadata[] = [
     }
 ];
 
+export const legacyTypeMap: Partial<Record<AzExtResourceType, string>> = {
+    FunctionApp: 'microsoft.web/functionapp',
+    AppServices: 'microsoft.web/sites',
+    StaticWebApps: 'microsoft.web/staticsites',
+    StorageAccounts: 'microsoft.storage/storageaccounts',
+    VirtualMachines: 'microsoft.compute/virtualmachines',
+    AzureCosmosDb: 'microsoft.documentdb/databaseaccounts',
+    PostgresqlServersStandard: 'microsoft.dbforpostgresql/servers',
+    PostgresqlServersFlexible: 'microsoft.dbforpostgresql/flexibleservers'
+}
+
 export interface IAzExtMetadata {
     name: string;
     label: string;

--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -9,7 +9,7 @@ import { AzExtResourceType, IActionContext, nonNullProp, TreeItemIconPath } from
 import { AppResource, GroupingConfig, GroupNodeConfiguration } from '@microsoft/vscode-azext-utils/hostapi';
 import * as path from 'path';
 import { ThemeIcon } from 'vscode';
-import type { IAzExtMetadata } from '../azureExtensions';
+import { IAzExtMetadata, legacyTypeMap } from '../azureExtensions';
 import { ext } from '../extensionVariables';
 import { createResourceClient } from './azureClients';
 import { localize } from './localize';
@@ -28,7 +28,7 @@ export function createGroupConfigFromResource(resource: AppResource, subscriptio
             label: resource.azExtResourceType ? azExtDisplayInfo[resource.azExtResourceType ?? '']?.displayName ?? unknown : unknown,
             id: `${subscriptionId}/${resource.azExtResourceType}`,
             iconPath: getIconPath(resource.azExtResourceType),
-            contextValuesToAdd: ['azureResourceTypeGroup', ...(resource.azExtResourceType ? [resource.azExtResourceType] : [])]
+            contextValuesToAdd: ['azureResourceTypeGroup', ...(resource.azExtResourceType ? [resource.azExtResourceType] : []), ...(resource.azExtResourceType ? [legacyTypeMap[resource.azExtResourceType] ?? ''] : [])]
         },
         location: {
             id: `${subscriptionId}/location/${resource.location}` ?? 'unknown',
@@ -59,7 +59,7 @@ export function createAzureExtensionsGroupConfig(extensions: IAzExtMetadata[], s
                 label: azExtDisplayInfo[azExtResourceType]?.displayName ?? azExtResourceType,
                 id: `${subscriptionId}/${azExtResourceType}`.toLowerCase(),
                 iconPath: getIconPath(azExtResourceType),
-                contextValuesToAdd: ['azureResourceTypeGroup', azExtResourceType]
+                contextValuesToAdd: ['azureResourceTypeGroup', azExtResourceType, legacyTypeMap[azExtResourceType] ?? '']
             });
         }
     }

--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -34,7 +34,7 @@ export function createGroupConfigFromResource(resource: AppResource, subscriptio
             label: resource.azExtResourceType ? azExtDisplayInfo[resource.azExtResourceType ?? '']?.displayName ?? unknown : unknown,
             id: `${subscriptionId}/${resource.azExtResourceType}`,
             iconPath,
-            contextValuesToAdd: ['azureResourceTypeGroup', ...(resource.azExtResourceType ? [resource.azExtResourceType] : []), ...(resource.azExtResourceType ? [legacyTypeMap[resource.azExtResourceType] ?? ''] : [])]
+            contextValuesToAdd: ['azureResourceTypeGroup', ...(resource.azExtResourceType ? [resource.azExtResourceType] : [])]
         },
         location: {
             id: `${subscriptionId}/location/${resource.location}` ?? 'unknown',


### PR DESCRIPTION
Needed to make sure extensions that haven't updated to use the `AzExtResourceType` context value yet will still be able to add the proper context menus to the group tree items.

We made this change in https://github.com/microsoft/vscode-azureresourcegroups/pull/337, but forgot to consider this breaking change.