### PR TITLE
Update 'PickAppResource' to allow retrieval of local workspace resources

### DIFF
--- a/src/api/pickAppResource.ts
+++ b/src/api/pickAppResource.ts
@@ -5,16 +5,48 @@
 
 import { AzExtTreeItem, ITreeItemPickerContext } from "@microsoft/vscode-azext-utils";
 import { PickAppResourceOptions } from "@microsoft/vscode-azext-utils/hostapi";
+import { QuickPickItem } from "vscode";
+import { ResourceLocation } from "../constants";
 import { ext } from "../extensionVariables";
 import { SubscriptionTreeItem } from "../tree/SubscriptionTreeItem";
+import { WorkspaceTreeItem } from "../tree/WorkspaceTreeItem";
+import { localize } from "../utils/localize";
 
 export async function pickAppResource<T extends AzExtTreeItem>(context: ITreeItemPickerContext, options?: PickAppResourceOptions): Promise<T> {
+    let resourceLocation: string;
+
+    if (options?.expectedWorkspaceContextValue && options?.expectedChildContextValue) {
+        const placeHolder = localize('pickLocalOrRemote', 'Choose between local and remote locations.');
+        const locationQuickPicks: QuickPickItem[] = [{ label: ResourceLocation.Local }, { label: ResourceLocation.Remote }];
+        resourceLocation = (await context.ui.showQuickPick(locationQuickPicks, { placeHolder })).label;
+    } else if (options?.expectedWorkspaceContextValue) {
+        resourceLocation = ResourceLocation.Local;
+    } else {
+        resourceLocation = ResourceLocation.Remote;
+    }
+
+    if (resourceLocation === ResourceLocation.Local) {
+        return await pickLocalResource<T>(context, options);
+    } else {
+        return await pickRemoteResource<T>(context, options);
+    }
+}
+
+async function pickRemoteResource<T extends AzExtTreeItem>(context: ITreeItemPickerContext, options?: PickAppResourceOptions): Promise<T> {
     const subscription: SubscriptionTreeItem = await ext.appResourceTree.showTreeItemPicker(SubscriptionTreeItem.contextValue, context);
     const appResource = await subscription.pickAppResource(context, options);
-
     if (options?.expectedChildContextValue) {
-        return ext.appResourceTree.showTreeItemPicker(options.expectedChildContextValue, context, appResource);
+        return await ext.appResourceTree.showTreeItemPicker(options.expectedChildContextValue, context, appResource);
     } else {
         return appResource as unknown as T;
+    }
+}
+
+async function pickLocalResource<T extends AzExtTreeItem>(context: ITreeItemPickerContext, options?: PickAppResourceOptions): Promise<T> {
+    const workspaceResource: WorkspaceTreeItem = await ext.workspaceTree.showTreeItemPicker(options?.workspaceRootContextValue ?? WorkspaceTreeItem.contextValue, context);
+    if (options?.expectedWorkspaceContextValue) {
+        return await ext.workspaceTree.showTreeItemPicker(options.expectedWorkspaceContextValue, context, workspaceResource);
+    } else {
+        return workspaceResource as unknown as T;
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,4 +6,9 @@
 export const azureResourceProviderId: string = 'vscode-azureresourcegroups.azureResourceProvider';
 export const contributesKey = 'x-azResources';
 // every group id has a groupBySetting/value format, so just following it
-export const ungroupedId = 'group/ungrouped'
+export const ungroupedId = 'group/ungrouped';
+
+export enum ResourceLocation {
+    Remote = 'remote',
+    Local = 'local'
+}

--- a/src/tree/WorkspaceTreeItem.ts
+++ b/src/tree/WorkspaceTreeItem.ts
@@ -12,6 +12,7 @@ export class WorkspaceTreeItem extends AzExtParentTreeItem {
     public contextValue: string = WorkspaceTreeItem.contextValue;
 
     public label: string = localize('workspace', 'Workspace');
+    public childTypeLabel: string = localize('attachedAccount', 'Attached Account');
 
     constructor() {
         super(undefined);

--- a/src/tree/WorkspaceTreeItem.ts
+++ b/src/tree/WorkspaceTreeItem.ts
@@ -8,8 +8,10 @@ import { workspaceResourceProviders } from '../api/registerWorkspaceResourceProv
 import { localize } from '../utils/localize';
 
 export class WorkspaceTreeItem extends AzExtParentTreeItem {
+    public static contextValue: string = 'azureWorkspace';
+    public contextValue: string = WorkspaceTreeItem.contextValue;
+
     public label: string = localize('workspace', 'Workspace');
-    public contextValue: string = 'azureWorkspace';
 
     constructor() {
         super(undefined);


### PR DESCRIPTION
I added an update to `pickAppResource` to support this [Storage commit](https://github.com/microsoft/vscode-azurestorage/pull/1126) which also involved changes in [AzureTools](https://github.com/microsoft/vscode-azuretools/pull/1228).  The idea was to add two additional fields under `PickAppResourceOptions` which would allow for a way to choose between traversing the workspace vs. the remote tree.

I decided to make the change this way because I felt it was one of the least invasive routes in that we would not have to refactor any of our existing code and adding the support to any future command would involve only changing one or two fields.  I could add it as a completely separate command if that seems like a better representation, let me know!