### PR TITLE
Add storage to legacy type map

### DIFF
--- a/src/azureExtensions.ts
+++ b/src/azureExtensions.ts
@@ -90,6 +90,7 @@ export const legacyTypeMap: Partial<Record<AzExtResourceType, string>> = {
     FunctionApp: 'microsoft.web/functionapp',
     AppServices: 'microsoft.web/sites',
     StaticWebApps: 'microsoft.web/staticsites',
+    StorageAccounts: 'microsoft.storage/storageaccounts',
     VirtualMachines: 'microsoft.compute/virtualmachines',
     AzureCosmosDb: 'microsoft.documentdb/databaseaccounts',
     PostgresqlServersStandard: 'microsoft.dbforpostgresql/servers',


### PR DESCRIPTION
This is needed since we won't be releasing RGs before storage, see https://github.com/microsoft/vscode-azurestorage/pull/1140/files.