### PR TITLE
Remove storage from legacy map and fix "Unknown" labels

### DIFF
--- a/src/azureExtensions.ts
+++ b/src/azureExtensions.ts
@@ -90,7 +90,6 @@ export const legacyTypeMap: Partial<Record<AzExtResourceType, string>> = {
     FunctionApp: 'microsoft.web/functionapp',
     AppServices: 'microsoft.web/sites',
     StaticWebApps: 'microsoft.web/staticsites',
-    StorageAccounts: 'microsoft.storage/storageaccounts',
     VirtualMachines: 'microsoft.compute/virtualmachines',
     AzureCosmosDb: 'microsoft.documentdb/databaseaccounts',
     PostgresqlServersStandard: 'microsoft.dbforpostgresql/servers',

--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -31,7 +31,7 @@ export function createGroupConfigFromResource(resource: AppResource, subscriptio
             contextValuesToAdd: ['azureResourceGroup']
         },
         resourceType: {
-            label: resource.azExtResourceType ? azExtDisplayInfo[resource.azExtResourceType ?? '']?.displayName ?? unknown : unknown,
+            label: resource.azExtResourceType ? azExtDisplayInfo[resource.azExtResourceType ?? '']?.displayName ?? resource.azExtResourceType : unknown,
             id: `${subscriptionId}/${resource.azExtResourceType}`,
             iconPath,
             contextValuesToAdd: ['azureResourceTypeGroup', ...(resource.azExtResourceType ? [resource.azExtResourceType, legacyTypeMap[resource.azExtResourceType] ?? ''] : [])]


### PR DESCRIPTION
Since we're releasing storage without the legacy context types, we can remove it from the legacy map.

The labels were messed up for a few resource group types. If a AzExtResourceType exists, but doesn't have a display name, just display the provider type. If it doesn't, then display the "unknown" label on the resource group.