### PR TITLE
Use normalized resource types for registration

### DIFF
--- a/src/api/v2/DefaultApplicationResourceProvider.ts
+++ b/src/api/v2/DefaultApplicationResourceProvider.ts
@@ -60,7 +60,7 @@ export class DefaultApplicationResourceProvider implements ApplicationResourcePr
             },
             resourceGroup: getResourceGroupFromId(resourceId),
             location: resource.location,
-            azExtResourceType: getAzExtResourceType({
+            resourceType: getAzExtResourceType({
                 type: nonNullProp(resource, 'type'),
                 kind: resource.kind
             })

--- a/src/api/v2/DefaultApplicationResourceProvider.ts
+++ b/src/api/v2/DefaultApplicationResourceProvider.ts
@@ -40,7 +40,7 @@ export class DefaultApplicationResourceProvider implements ApplicationResourcePr
             subscription,
             id: nonNullProp(resourceGroup, 'id'),
             name: nonNullProp(resourceGroup, 'name'),
-            type: {
+            azureResourceType: {
                 type: nonNullProp(resourceGroup, 'type').toLowerCase()
             }
         };
@@ -54,7 +54,7 @@ export class DefaultApplicationResourceProvider implements ApplicationResourcePr
             subscription,
             id: resourceId,
             name: nonNullProp(resource, 'name'),
-            type: {
+            azureResourceType: {
                 type: nonNullProp(resource, 'type').toLowerCase(),
                 kinds: resource.kind?.split(',')?.map(kind => kind.toLowerCase()),
             },

--- a/src/api/v2/ResourceGroupsExtensionManager.ts
+++ b/src/api/v2/ResourceGroupsExtensionManager.ts
@@ -44,12 +44,10 @@ function getInactiveExtensions(): vscode.Extension<unknown>[] {
 
 export class ResourceGroupsExtensionManager {
     async activateApplicationResourceBranchDataProvider(type: AzExtResourceType): Promise<void> {
-        const normalizedType = type.toLowerCase();
-
         const extensionAndContributions =
             getInactiveExtensions()
-                .map(extension => ({ extension, contributions: getV2ResourceContributions(extension)?.application?.branches?.map(resource => resource.type.toLowerCase()) ?? [] }))
-                .find(extensionAndContributions => extensionAndContributions.contributions.find(contribution => contribution === normalizedType) !== undefined);
+                .map(extension => ({ extension, contributions: getV2ResourceContributions(extension)?.application?.branches?.map(resource => resource.type) ?? [] }))
+                .find(extensionAndContributions => extensionAndContributions.contributions.find(contribution => contribution === type) !== undefined);
 
         if (extensionAndContributions) {
             await extensionAndContributions.extension.activate();
@@ -73,11 +71,9 @@ export class ResourceGroupsExtensionManager {
     }
 
     async activateWorkspaceResourceBranchDataProvider(type: string): Promise<void> {
-        type = type.toLowerCase();
-
         const extensionAndContributions =
             getInactiveExtensions()
-                .map(extension => ({ extension, contributions: getV2ResourceContributions(extension)?.workspace?.branches?.map(resources => resources.type.toLowerCase()) ?? [] }))
+                .map(extension => ({ extension, contributions: getV2ResourceContributions(extension)?.workspace?.branches?.map(resources => resources.type) ?? [] }))
                 .find(extensionAndContributions => extensionAndContributions.contributions.find(contribution => contribution === type) !== undefined);
 
         if (extensionAndContributions) {

--- a/src/api/v2/v2AzureResourcesApi.ts
+++ b/src/api/v2/v2AzureResourcesApi.ts
@@ -39,7 +39,7 @@ export interface AzureResourceType {
  */
 export interface ApplicationResource extends ResourceBase {
     readonly subscription: ApplicationSubscription;
-    readonly type: AzureResourceType;
+    readonly azureResourceType: AzureResourceType;
     readonly resourceType?: AzExtResourceType;
     readonly location?: string;
     readonly resourceGroup?: string;
@@ -199,28 +199,28 @@ export interface V2AzureResourcesApi extends AzureResourcesApiBase {
      * @param id The provider ID . Must be unique.
      * @param provider The provider.
      */
-    registerApplicationResourceProvider(id: string, provider: ApplicationResourceProvider): vscode.Disposable;
+    registerApplicationResourceProvider(provider: ApplicationResourceProvider): vscode.Disposable;
 
     /**
-     * Registers an application resource tree data provider factory
-     * @param id The resolver ID. Must be unique.
-     * @param resolver The resolver
+     * Registers an application resource branch data provider.
+     * @param type The Azure application resource type associated with the provider. Must be unique.
+     * @param resolver The branch data provider for the resource type.
      */
-    registerApplicationResourceBranchDataProvider<T extends ResourceModelBase>(id: string, provider: BranchDataProvider<ApplicationResource, T>): vscode.Disposable;
+    registerApplicationResourceBranchDataProvider<T extends ResourceModelBase>(type: AzExtResourceType, provider: BranchDataProvider<ApplicationResource, T>): vscode.Disposable;
 
     /**
-     * Registers a workspace resource provider
+     * Registers a workspace resource provider.
      * @param id The provider ID. Must be unique.
      * @param provider The provider
      */
-    registerWorkspaceResourceProvider(id: string, provider: WorkspaceResourceProvider): vscode.Disposable;
+    registerWorkspaceResourceProvider(provider: WorkspaceResourceProvider): vscode.Disposable;
 
     /**
-     * Registers an application resource tree data provider factory
-     * @param id The resolver ID. Must be unique.
-     * @param resolver The resolver
+     * Registers a workspace resource branch data provider.
+     * @param type The workspace resource type assocaited with the provider. Must be unique.
+     * @param provider The branch data provider for the resource type.
      */
-    registerWorkspaceResourceBranchDataProvider<T extends ResourceModelBase>(id: string, provider: BranchDataProvider<WorkspaceResource, T>): vscode.Disposable;
+    registerWorkspaceResourceBranchDataProvider<T extends ResourceModelBase>(type: string, provider: BranchDataProvider<WorkspaceResource, T>): vscode.Disposable;
 }
 
 export interface AzureResourcesApiBase {

--- a/src/api/v2/v2AzureResourcesApi.ts
+++ b/src/api/v2/v2AzureResourcesApi.ts
@@ -28,7 +28,7 @@ export interface ResourceBase {
     readonly name: string;
 }
 
-export interface ApplicationResourceType {
+export interface AzureResourceType {
     readonly type: string;
     readonly kinds?: string[];
 }
@@ -39,8 +39,8 @@ export interface ApplicationResourceType {
  */
 export interface ApplicationResource extends ResourceBase {
     readonly subscription: ApplicationSubscription;
-    readonly type: ApplicationResourceType;
-    readonly azExtResourceType?: AzExtResourceType;
+    readonly type: AzureResourceType;
+    readonly resourceType?: AzExtResourceType;
     readonly location?: string;
     readonly resourceGroup?: string;
     /** Resource tags */

--- a/src/api/v2/v2AzureResourcesApi.ts
+++ b/src/api/v2/v2AzureResourcesApi.ts
@@ -195,9 +195,8 @@ export interface V2AzureResourcesApi extends AzureResourcesApiBase {
     revealResource(resourceId: string): Promise<void>;
 
     /**
-     * Registers an application provider.
-     * @param id The provider ID . Must be unique.
-     * @param provider The provider.
+     * Registers a provider of application resources.
+     * @param provider The resource provider.
      */
     registerApplicationResourceProvider(provider: ApplicationResourceProvider): vscode.Disposable;
 
@@ -209,15 +208,14 @@ export interface V2AzureResourcesApi extends AzureResourcesApiBase {
     registerApplicationResourceBranchDataProvider<T extends ResourceModelBase>(type: AzExtResourceType, provider: BranchDataProvider<ApplicationResource, T>): vscode.Disposable;
 
     /**
-     * Registers a workspace resource provider.
-     * @param id The provider ID. Must be unique.
-     * @param provider The provider
+     * Registers a provider of workspace resources.
+     * @param provider The resource provider.
      */
     registerWorkspaceResourceProvider(provider: WorkspaceResourceProvider): vscode.Disposable;
 
     /**
      * Registers a workspace resource branch data provider.
-     * @param type The workspace resource type assocaited with the provider. Must be unique.
+     * @param type The workspace resource type associated with the provider. Must be unique.
      * @param provider The branch data provider for the resource type.
      */
     registerWorkspaceResourceBranchDataProvider<T extends ResourceModelBase>(type: string, provider: BranchDataProvider<WorkspaceResource, T>): vscode.Disposable;

--- a/src/api/v2/v2AzureResourcesApiImplementation.ts
+++ b/src/api/v2/v2AzureResourcesApiImplementation.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzExtResourceType } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ApplicationResourceBranchDataProviderManager } from '../../tree/v2/application/ApplicationResourceBranchDataProviderManager';
 import { WorkspaceResourceBranchDataProviderManager } from '../../tree/v2/workspace/WorkspaceResourceBranchDataProviderManager';
@@ -31,19 +32,19 @@ export class V2AzureResourcesApiImplementation implements V2AzureResourcesApi {
         throw new Error("Method not implemented.");
     }
 
-    registerApplicationResourceProvider(_id: string, provider: ApplicationResourceProvider): vscode.Disposable {
+    registerApplicationResourceProvider(provider: ApplicationResourceProvider): vscode.Disposable {
         this.applicationResourceProviderManager.addResourceProvider(provider);
 
         return new vscode.Disposable(() => this.applicationResourceProviderManager.removeResourceProvider(provider));
     }
 
-    registerApplicationResourceBranchDataProvider<T extends ResourceModelBase>(id: string, provider: BranchDataProvider<ApplicationResource, T>): vscode.Disposable {
-        this.applicationResourceBranchDataProviderManager.addProvider(id, provider);
+    registerApplicationResourceBranchDataProvider<T extends ResourceModelBase>(type: AzExtResourceType, provider: BranchDataProvider<ApplicationResource, T>): vscode.Disposable {
+        this.applicationResourceBranchDataProviderManager.addProvider(type, provider);
 
-        return new vscode.Disposable(() => this.applicationResourceBranchDataProviderManager.removeProvider(id));
+        return new vscode.Disposable(() => this.applicationResourceBranchDataProviderManager.removeProvider(type));
     }
 
-    registerWorkspaceResourceProvider(_id: string, provider: WorkspaceResourceProvider): vscode.Disposable {
+    registerWorkspaceResourceProvider(provider: WorkspaceResourceProvider): vscode.Disposable {
         this.workspaceResourceProviderManager.addResourceProvider(provider);
 
         return new vscode.Disposable(() => this.workspaceResourceProviderManager.removeResourceProvider(provider));

--- a/src/api/v2/v2AzureResourcesApiWrapper.ts
+++ b/src/api/v2/v2AzureResourcesApiWrapper.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { callWithTelemetryAndErrorHandling, callWithTelemetryAndErrorHandlingSync } from '@microsoft/vscode-azext-utils';
+import { AzExtResourceType, callWithTelemetryAndErrorHandling, callWithTelemetryAndErrorHandlingSync } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ApplicationResource, ApplicationResourceProvider, BranchDataProvider, ResourceModelBase, ResourcePickOptions, V2AzureResourcesApi, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
 
@@ -25,16 +25,16 @@ export class V2AzureResourcesApiWrapper implements V2AzureResourcesApi {
         return this.callWithTelemetryAndErrorHandling('v2.revealResource', async () => await this.api.revealResource(resourceId));
     }
 
-    registerApplicationResourceProvider(id: string, provider: ApplicationResourceProvider): vscode.Disposable {
-        return this.callWithTelemetryAndErrorHandlingSync('v2.registerApplicationResourceProvider', () => this.api.registerApplicationResourceProvider(id, provider));
+    registerApplicationResourceProvider(provider: ApplicationResourceProvider): vscode.Disposable {
+        return this.callWithTelemetryAndErrorHandlingSync('v2.registerApplicationResourceProvider', () => this.api.registerApplicationResourceProvider(provider));
     }
 
-    registerApplicationResourceBranchDataProvider<T extends ResourceModelBase>(id: string, provider: BranchDataProvider<ApplicationResource, T>): vscode.Disposable {
-        return this.callWithTelemetryAndErrorHandlingSync('v2.registerApplicationResourceBranchDataProvider', () => this.api.registerApplicationResourceBranchDataProvider(id, provider));
+    registerApplicationResourceBranchDataProvider<T extends ResourceModelBase>(type: AzExtResourceType, provider: BranchDataProvider<ApplicationResource, T>): vscode.Disposable {
+        return this.callWithTelemetryAndErrorHandlingSync('v2.registerApplicationResourceBranchDataProvider', () => this.api.registerApplicationResourceBranchDataProvider(type, provider));
     }
 
-    registerWorkspaceResourceProvider(id: string, provider: WorkspaceResourceProvider): vscode.Disposable {
-        return this.callWithTelemetryAndErrorHandlingSync('v2.registerWorkspaceResourceProvider', () => this.api.registerWorkspaceResourceProvider(id, provider));
+    registerWorkspaceResourceProvider(provider: WorkspaceResourceProvider): vscode.Disposable {
+        return this.callWithTelemetryAndErrorHandlingSync('v2.registerWorkspaceResourceProvider', () => this.api.registerWorkspaceResourceProvider(provider));
     }
 
     registerWorkspaceResourceBranchDataProvider<T extends ResourceModelBase>(id: string, provider: BranchDataProvider<WorkspaceResource, T>): vscode.Disposable {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,4 @@ export const azureResourceProviderId: string = 'vscode-azureresourcegroups.azure
 export const contributesKey = 'x-azResources';
 // every group id has a groupBySetting/value format, so just following it
 export const ungroupedId = 'group/ungrouped'
+export const showHiddenTypesSettingKey = 'showHiddenTypes';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,7 +122,10 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
 
     context.subscriptions.push(branchDataProviderManager);
 
-    const resourceProviderManager = new ApplicationResourceProviderManager(() => extensionManager.activateApplicationResourceProviders());
+    const applicationResourceProviderManager = new ApplicationResourceProviderManager(() => extensionManager.activateApplicationResourceProviders());
+
+    applicationResourceProviderManager.addResourceProvider(new DefaultApplicationResourceProvider());
+
     const workspaceResourceBranchDataProviderManager = new WorkspaceResourceBranchDataProviderManager(
         new WorkspaceDefaultBranchDataProvider(),
         type => void extensionManager.activateWorkspaceResourceBranchDataProvider(type));
@@ -132,7 +135,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         context,
         branchDataProviderManager,
         refreshEventEmitter.event,
-        resourceProviderManager);
+        applicationResourceProviderManager);
 
     registerWorkspaceTreeV2(
         workspaceResourceBranchDataProviderManager,
@@ -143,12 +146,10 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
     const v2ApiFactory = () => {
         if (v2Api === undefined) {
             v2Api = new V2AzureResourcesApiImplementation(
-                resourceProviderManager,
+                applicationResourceProviderManager,
                 branchDataProviderManager,
                 workspaceResourceProviderManager,
                 workspaceResourceBranchDataProviderManager);
-
-            context.subscriptions.push(v2Api.registerApplicationResourceProvider(new DefaultApplicationResourceProvider()));
         }
 
         return v2Api;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -148,7 +148,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                 workspaceResourceProviderManager,
                 workspaceResourceBranchDataProviderManager);
 
-            context.subscriptions.push(v2Api.registerApplicationResourceProvider('TODO: is ID useful?', new DefaultApplicationResourceProvider()));
+            context.subscriptions.push(v2Api.registerApplicationResourceProvider(new DefaultApplicationResourceProvider()));
         }
 
         return v2Api;

--- a/src/tree/GroupTreeItemBase.ts
+++ b/src/tree/GroupTreeItemBase.ts
@@ -5,6 +5,7 @@
 
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem, IActionContext, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { GroupNodeConfiguration } from "@microsoft/vscode-azext-utils/hostapi";
+import { showHiddenTypesSettingKey } from "../constants";
 import { ext } from "../extensionVariables";
 import { localize } from "../utils/localize";
 import { settingUtils } from "../utils/settingUtils";
@@ -65,7 +66,7 @@ export class GroupTreeItemBase extends AzExtParentTreeItem {
         let resources = Object.values(this.treeMap) as AzExtTreeItem[];
         const allResources = Object.values(this.treeMap) as AzExtTreeItem[];
 
-        const showHiddenTypes = settingUtils.getWorkspaceSetting('showHiddenTypes') as boolean;
+        const showHiddenTypes = settingUtils.getWorkspaceSetting(showHiddenTypesSettingKey) as boolean;
         if (!showHiddenTypes) {
             if (!this._showAllResources) {
                 resources = GroupTreeItemBase.filterResources(resources as AppResourceTreeItem[]);
@@ -92,7 +93,7 @@ export class GroupTreeItemBase extends AzExtParentTreeItem {
     }
 
     public compareChildrenImpl(item1: AppResourceTreeItem, item2: AppResourceTreeItem): number {
-        const showHiddenTypes = settingUtils.getWorkspaceSetting('showHiddenTypes') as boolean;
+        const showHiddenTypes = settingUtils.getWorkspaceSetting(showHiddenTypesSettingKey) as boolean;
         // if showHiddenTypes is off, then these should be pushed below toggleShowAllResourcesTreeItem
         if (!showHiddenTypes) {
             if (item1.isHidden && item2.isHidden) {

--- a/src/tree/ResourceCache.ts
+++ b/src/tree/ResourceCache.ts
@@ -9,7 +9,7 @@ import { AppResource } from "@microsoft/vscode-azext-utils/hostapi";
 import { ThemeIcon } from "vscode";
 import { azureExtensions } from "../azureExtensions";
 import { GroupBySettings } from "../commands/explorer/groupBy";
-import { ungroupedId } from "../constants";
+import { showHiddenTypesSettingKey, ungroupedId } from "../constants";
 import { createAzureExtensionsGroupConfig } from "../utils/azureUtils";
 import { localize } from "../utils/localize";
 import { settingUtils } from "../utils/settingUtils";
@@ -92,7 +92,7 @@ export class ResourceCache {
                 }
 
                 // delete groups that aren't supported by Azure extensions
-                if (!settingUtils.getWorkspaceSetting('showHiddenTypes')) {
+                if (!settingUtils.getWorkspaceSetting(showHiddenTypesSettingKey)) {
                     for (const id in treeMap) {
                         if (!azExtGroupConfigs.some(config => config.id === id)) {
                             delete treeMap[id];

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -196,7 +196,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             context.telemetry.properties.isActivationEvent = 'true';
 
             if (e.affectsConfiguration(`${ext.prefix}.groupBy`) ||
-                e.affectsConfiguration(`${ext.prefix}.showHiddenTypes`)) {
+                e.affectsConfiguration(`${ext.prefix}.${showHiddenTypesSettingKey}`)) {
                 // reset the focusedGroup since it won't exist in this grouping
                 await ext.context.workspaceState.update('focusedGroup', '');
                 await this.refresh(context);

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -10,7 +10,7 @@ import { AppResourceFilter, PickAppResourceOptions } from '@microsoft/vscode-aze
 import { ConfigurationChangeEvent, workspace } from 'vscode';
 import { applicationResourceProviders } from '../api/registerApplicationResourceProvider';
 import { GroupBySettings } from '../commands/explorer/groupBy';
-import { azureResourceProviderId, ungroupedId } from '../constants';
+import { azureResourceProviderId, showHiddenTypesSettingKey, ungroupedId } from '../constants';
 import { ext } from '../extensionVariables';
 import { createActivityContext } from '../utils/activityUtils';
 import { createResourceClient } from '../utils/azureClients';
@@ -37,7 +37,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         await this.getCachedChildren(context);
 
         let appResources = this.cache.appResources;
-        const showHiddenTypes = settingUtils.getWorkspaceSetting<boolean>('showHiddenTypes');
+        const showHiddenTypes = settingUtils.getWorkspaceSetting<boolean>(showHiddenTypesSettingKey);
         if (!showHiddenTypes) {
             appResources = GroupTreeItemBase.filterResources(this.cache.appResources);
         }

--- a/src/tree/v2/ResourceBranchDataProviderManagerBase.ts
+++ b/src/tree/v2/ResourceBranchDataProviderManagerBase.ts
@@ -6,13 +6,13 @@
 import * as vscode from 'vscode';
 import { BranchDataProvider, ResourceBase, ResourceModelBase } from '../../api/v2/v2AzureResourcesApi';
 
-export abstract class ResourceBranchDataProviderManagerBase<TBranchDataProvider extends BranchDataProvider<ResourceBase, ResourceModelBase>> extends vscode.Disposable {
-    private readonly branchDataProviderMap = new Map<string, { provider: TBranchDataProvider, listener: vscode.Disposable | undefined }>();
+export abstract class ResourceBranchDataProviderManagerBase<TResourceType, TBranchDataProvider extends BranchDataProvider<ResourceBase, ResourceModelBase>> extends vscode.Disposable {
+    private readonly branchDataProviderMap = new Map<TResourceType, { provider: TBranchDataProvider, listener: vscode.Disposable | undefined }>();
     private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<void | ResourceModelBase | ResourceModelBase[] | undefined | null>();
 
     constructor(
         private readonly defaultProvider: TBranchDataProvider,
-        private readonly extensionActivator: (type: string) => void
+        private readonly extensionActivator: (type: TResourceType) => void
     ) {
         super(
             () => {
@@ -26,9 +26,7 @@ export abstract class ResourceBranchDataProviderManagerBase<TBranchDataProvider 
 
     public readonly onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
 
-    addProvider(type: string, provider: TBranchDataProvider): void {
-        type = this.normalizeType(type);
-
+    addProvider(type: TResourceType, provider: TBranchDataProvider): void {
         this.branchDataProviderMap.set(
             type,
             {
@@ -40,27 +38,24 @@ export abstract class ResourceBranchDataProviderManagerBase<TBranchDataProvider 
         this.onDidChangeTreeDataEmitter.fire();
     }
 
-    // TODO: We may need to allow for a more complicated type/kind mapping.
-    getProvider(type: string): TBranchDataProvider {
-        type = this.normalizeType(type);
+    getProvider(type: TResourceType | undefined): TBranchDataProvider {
+        if (type) {
+            const providerContext = this.branchDataProviderMap.get(type);
 
-        const providerContext = this.branchDataProviderMap.get(type);
+            if (providerContext) {
+                return providerContext.provider;
+            }
 
-        if (providerContext) {
-            return providerContext.provider;
+            // NOTE: The default branch data provider will be returned until the extension is loaded.
+            //       The extension will then register its branch data providers, resulting in a change event.
+            //       The tree will then be refreshed, resulting in this method being called again.
+            this.extensionActivator(type);
         }
-
-        // NOTE: The default branch data provider will be returned until the extension is loaded.
-        //       The extension will then register its branch data providers, resulting in a change event.
-        //       The tree will then be refreshed, resulting in this method being called again.
-        this.extensionActivator(type);
 
         return this.defaultProvider;
     }
 
-    removeProvider(type: string): void {
-        type = this.normalizeType(type);
-
+    removeProvider(type: TResourceType): void {
         const providerContext = this.branchDataProviderMap.get(type);
 
         if (providerContext) {
@@ -70,9 +65,5 @@ export abstract class ResourceBranchDataProviderManagerBase<TBranchDataProvider 
 
             this.onDidChangeTreeDataEmitter.fire();
         }
-    }
-
-    private normalizeType(type: string): string {
-        return type.toLowerCase();
     }
 }

--- a/src/tree/v2/application/ApplicationResourceBranchDataProviderManager.ts
+++ b/src/tree/v2/application/ApplicationResourceBranchDataProviderManager.ts
@@ -3,13 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzExtResourceType } from "@microsoft/vscode-azext-utils";
 import { ApplicationResource, BranchDataProvider, ResourceModelBase } from "../../../api/v2/v2AzureResourcesApi";
 import { ResourceBranchDataProviderManagerBase } from '../ResourceBranchDataProviderManagerBase';
 
-export class ApplicationResourceBranchDataProviderManager extends ResourceBranchDataProviderManagerBase<BranchDataProvider<ApplicationResource, ResourceModelBase>>{
+export class ApplicationResourceBranchDataProviderManager extends ResourceBranchDataProviderManagerBase<AzExtResourceType, BranchDataProvider<ApplicationResource, ResourceModelBase>>{
     constructor(
         defaultProvider: BranchDataProvider<ApplicationResource, ResourceModelBase>,
-        extensionActivator: (type: string) => void
+        extensionActivator: (type: AzExtResourceType) => void
     ) {
         super(
             defaultProvider,

--- a/src/tree/v2/application/ApplicationResourceGroupingManager.ts
+++ b/src/tree/v2/application/ApplicationResourceGroupingManager.ts
@@ -116,7 +116,7 @@ export class ApplicationResourceGroupingManager extends vscode.Disposable {
         const resourceGroups: ApplicationResource[] = [];
         const nonResourceGroups: ApplicationResource[] = [];
 
-        resources.forEach(resource => resource.type.type === 'microsoft.resources/resourcegroups' ? resourceGroups.push(resource) : nonResourceGroups.push(resource));
+        resources.forEach(resource => resource.azureResourceType.type === 'microsoft.resources/resourcegroups' ? resourceGroups.push(resource) : nonResourceGroups.push(resource));
 
         const keySelector: (resource: ApplicationResource) => string = resource => resource.resourceGroup?.toLowerCase() ?? unknownLabel; // TODO: Is resource group ever undefined? Should resource group be normalized on creation?
 
@@ -144,7 +144,7 @@ export class ApplicationResourceGroupingManager extends vscode.Disposable {
         return this.groupBy(
             context,
             resources,
-            resource => resource.resourceType ?? resource.type.type, // TODO: Is resource type ever undefined?
+            resource => resource.resourceType ?? resource.azureResourceType.type, // TODO: Is resource type ever undefined?
             key => getName(key as AzExtResourceType) ?? key,
             key => getIconPath(key as AzExtResourceType)); // TODO: What's the default icon for a resource type?
     }

--- a/src/tree/v2/application/ApplicationResourceGroupingManager.ts
+++ b/src/tree/v2/application/ApplicationResourceGroupingManager.ts
@@ -16,7 +16,7 @@ import { treeUtils } from '../../../utils/treeUtils';
 import { ResourceGroupsTreeContext } from '../ResourceGroupsTreeContext';
 import { GroupingItem, GroupingItemFactory } from './GroupingItem';
 
-const unknownLabel = localize('unknown', 'unknown');
+const unknownLabel = localize('unknown', 'Unknown');
 
 export class ApplicationResourceGroupingManager extends vscode.Disposable {
     private readonly onDidChangeGroupingEmitter = new vscode.EventEmitter<void>();
@@ -151,10 +151,13 @@ export class ApplicationResourceGroupingManager extends vscode.Disposable {
             });
         });
 
+        // Exclude resource groups...
+        resources = resources.filter(resource => resource.azureResourceType.type !== 'microsoft.resources/resourcegroups');
+
         return this.groupBy(
             context,
             resources,
-            resource => resource.resourceType ?? resource.azureResourceType.type, // TODO: Is resource type ever undefined?
+            resource => resource.resourceType ?? unknownLabel, // TODO: Is resource type ever undefined?
             key => getName(key as AzExtResourceType) ?? key,
             key => getIconPath(key as AzExtResourceType),  // TODO: What's the default icon for a resource type?
             initialGrouping);

--- a/src/tree/v2/application/ApplicationResourceGroupingManager.ts
+++ b/src/tree/v2/application/ApplicationResourceGroupingManager.ts
@@ -6,6 +6,7 @@
 import { AzExtResourceType, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ApplicationResource } from '../../../api/v2/v2AzureResourcesApi';
+import { azureExtensions } from '../../../azureExtensions';
 import { GroupBySettings } from '../../../commands/explorer/groupBy';
 import { ext } from '../../../extensionVariables';
 import { getIconPath, getName } from '../../../utils/azureUtils';
@@ -141,11 +142,21 @@ export class ApplicationResourceGroupingManager extends vscode.Disposable {
     }
 
     private groupByResourceType(context: ResourceGroupsTreeContext, resources: ApplicationResource[]): GroupingItem[] {
+        const initialGrouping = {};
+
+        // Pre-populate the initial grouping with the supported resource types...
+        azureExtensions.forEach(extension => {
+            extension.resourceTypes.forEach(resourceType => {
+                initialGrouping[resourceType] = [];
+            });
+        });
+
         return this.groupBy(
             context,
             resources,
             resource => resource.resourceType ?? resource.azureResourceType.type, // TODO: Is resource type ever undefined?
             key => getName(key as AzExtResourceType) ?? key,
-            key => getIconPath(key as AzExtResourceType)); // TODO: What's the default icon for a resource type?
+            key => getIconPath(key as AzExtResourceType),  // TODO: What's the default icon for a resource type?
+            initialGrouping);
     }
 }

--- a/src/tree/v2/application/ApplicationResourceGroupingManager.ts
+++ b/src/tree/v2/application/ApplicationResourceGroupingManager.ts
@@ -12,8 +12,8 @@ import { getIconPath, getName } from '../../../utils/azureUtils';
 import { localize } from "../../../utils/localize";
 import { settingUtils } from '../../../utils/settingUtils';
 import { treeUtils } from '../../../utils/treeUtils';
-import { GroupingItem, GroupingItemFactory } from './GroupingItem';
 import { ResourceGroupsTreeContext } from '../ResourceGroupsTreeContext';
+import { GroupingItem, GroupingItemFactory } from './GroupingItem';
 
 const unknownLabel = localize('unknown', 'unknown');
 
@@ -144,7 +144,7 @@ export class ApplicationResourceGroupingManager extends vscode.Disposable {
         return this.groupBy(
             context,
             resources,
-            resource => resource.azExtResourceType ?? resource.type.type, // TODO: Is resource type ever undefined?
+            resource => resource.resourceType ?? resource.type.type, // TODO: Is resource type ever undefined?
             key => getName(key as AzExtResourceType) ?? key,
             key => getIconPath(key as AzExtResourceType)); // TODO: What's the default icon for a resource type?
     }

--- a/src/tree/v2/application/DefaultApplicationResourceItem.ts
+++ b/src/tree/v2/application/DefaultApplicationResourceItem.ts
@@ -19,7 +19,7 @@ export class DefaultApplicationResourceItem implements ResourceGroupsItem {
     getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem> {
         const treeItem = new vscode.TreeItem(this.resource.name ?? 'Unnamed Resource');
 
-        treeItem.iconPath = getIconPath(this.resource.azExtResourceType);
+        treeItem.iconPath = getIconPath(this.resource.resourceType);
 
         return treeItem;
     }

--- a/src/tree/v2/application/GroupingItem.ts
+++ b/src/tree/v2/application/GroupingItem.ts
@@ -8,9 +8,9 @@ import * as vscode from 'vscode';
 import { ApplicationResource, BranchDataProvider, ResourceModelBase } from '../../../api/v2/v2AzureResourcesApi';
 import { getIconPath } from '../../../utils/azureUtils';
 import { BranchDataItemFactory } from '../BranchDataProviderItem';
-import { BranchDataProviderFactory } from './ApplicationResourceBranchDataProviderManager';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { ResourceGroupsTreeContext } from '../ResourceGroupsTreeContext';
+import { BranchDataProviderFactory } from './ApplicationResourceBranchDataProviderManager';
 
 export class GroupingItem implements ResourceGroupsItem {
     private description: string | undefined;
@@ -33,7 +33,7 @@ export class GroupingItem implements ResourceGroupsItem {
 
                 const options = {
                     defaults: {
-                        iconPath: getIconPath(resource.azExtResourceType)
+                        iconPath: getIconPath(resource.resourceType)
                     }
                 };
 

--- a/src/tree/v2/application/GroupingItem.ts
+++ b/src/tree/v2/application/GroupingItem.ts
@@ -26,7 +26,8 @@ export class GroupingItem implements ResourceGroupsItem {
     }
 
     async getChildren(): Promise<ResourceGroupsItem[] | undefined> {
-        const resourceItems = await Promise.all(this.resources.map(
+        const sortedResources = this.resources.sort((a, b) => a.name.localeCompare(b.name));
+        const resourceItems = await Promise.all(sortedResources.map(
             async resource => {
                 const branchDataProvider = this.branchDataProviderFactory(resource);
                 const resourceItem = await branchDataProvider.getResourceItem(resource);

--- a/src/tree/v2/application/SubscriptionItem.ts
+++ b/src/tree/v2/application/SubscriptionItem.ts
@@ -8,6 +8,7 @@ import * as vscode from "vscode";
 import { ApplicationResourceProviderManager } from "../../../api/v2/ResourceProviderManagers";
 import { ApplicationSubscription } from "../../../api/v2/v2AzureResourcesApi";
 import { azureExtensions } from "../../../azureExtensions";
+import { showHiddenTypesSettingKey } from "../../../constants";
 import { settingUtils } from "../../../utils/settingUtils";
 import { treeUtils } from "../../../utils/treeUtils";
 import { ResourceGroupsItem } from "../ResourceGroupsItem";
@@ -30,7 +31,7 @@ export class SubscriptionItem implements ResourceGroupsItem {
     async getChildren(): Promise<ResourceGroupsItem[]> {
         let resources = await this.resourceProviderManager.getResources(this.subscription);
 
-        const showHiddenTypes = settingUtils.getWorkspaceSetting('showHiddenTypes') as boolean;
+        const showHiddenTypes = settingUtils.getWorkspaceSetting<boolean>(showHiddenTypesSettingKey);
 
         if (!showHiddenTypes) {
             resources = resources.filter(resource => resource.resourceType && supportedResourceTypes.find(type => type === resource.resourceType));

--- a/src/tree/v2/application/SubscriptionItem.ts
+++ b/src/tree/v2/application/SubscriptionItem.ts
@@ -3,13 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzExtResourceType } from "@microsoft/vscode-azext-utils";
 import * as vscode from "vscode";
 import { ApplicationResourceProviderManager } from "../../../api/v2/ResourceProviderManagers";
 import { ApplicationSubscription } from "../../../api/v2/v2AzureResourcesApi";
+import { azureExtensions } from "../../../azureExtensions";
+import { settingUtils } from "../../../utils/settingUtils";
 import { treeUtils } from "../../../utils/treeUtils";
 import { ResourceGroupsItem } from "../ResourceGroupsItem";
 import { ResourceGroupsTreeContext } from "../ResourceGroupsTreeContext";
 import { ApplicationResourceGroupingManager } from "./ApplicationResourceGroupingManager";
+
+const supportedResourceTypes: AzExtResourceType[] =
+    azureExtensions
+        .map(e => e.resourceTypes)
+        .reduce((a, b) => a.concat(...b), []);
 
 export class SubscriptionItem implements ResourceGroupsItem {
     constructor(
@@ -20,7 +28,13 @@ export class SubscriptionItem implements ResourceGroupsItem {
     }
 
     async getChildren(): Promise<ResourceGroupsItem[]> {
-        const resources = await this.resourceProviderManager.getResources(this.subscription);
+        let resources = await this.resourceProviderManager.getResources(this.subscription);
+
+        const showHiddenTypes = settingUtils.getWorkspaceSetting('showHiddenTypes') as boolean;
+
+        if (!showHiddenTypes) {
+            resources = resources.filter(resource => resource.resourceType && supportedResourceTypes.find(type => type === resource.resourceType));
+        }
 
         return this.resourceGroupingManager.groupResources(this.context, resources ?? []).sort((a, b) => a.label.localeCompare(b.label));
     }

--- a/src/tree/v2/application/SubscriptionItem.ts
+++ b/src/tree/v2/application/SubscriptionItem.ts
@@ -34,7 +34,7 @@ export class SubscriptionItem implements ResourceGroupsItem {
         const showHiddenTypes = settingUtils.getWorkspaceSetting<boolean>(showHiddenTypesSettingKey);
 
         if (!showHiddenTypes) {
-            resources = resources.filter(resource => resource.resourceType && supportedResourceTypes.find(type => type === resource.resourceType));
+            resources = resources.filter(resource => resource.azureResourceType.type === 'microsoft.resources/resourcegroups' || (resource.resourceType && supportedResourceTypes.find(type => type === resource.resourceType)));
         }
 
         return this.resourceGroupingManager.groupResources(this.context, resources ?? []).sort((a, b) => a.label.localeCompare(b.label));

--- a/src/tree/v2/application/registerResourceGroupsTreeV2.ts
+++ b/src/tree/v2/application/registerResourceGroupsTreeV2.ts
@@ -20,7 +20,7 @@ export function registerResourceGroupsTreeV2(
     resourceProviderManager: ApplicationResourceProviderManager): void {
     const itemCache = new ResourceGroupsItemCache();
     const branchDataItemFactory = createBranchDataItemFactory(itemCache);
-    const groupingItemFactory = createGroupingItemFactory(branchDataItemFactory, resource => branchDataProviderManager.getProvider(resource.type.type));
+    const groupingItemFactory = createGroupingItemFactory(branchDataItemFactory, resource => branchDataProviderManager.getProvider(resource.resourceType));
     const resourceGroupingManager = new ApplicationResourceGroupingManager(groupingItemFactory);
 
     context.subscriptions.push(resourceGroupingManager);

--- a/src/tree/v2/workspace/WorkspaceResourceBranchDataProviderManager.ts
+++ b/src/tree/v2/workspace/WorkspaceResourceBranchDataProviderManager.ts
@@ -6,7 +6,7 @@
 import { BranchDataProvider, ResourceModelBase, WorkspaceResource } from '../../../api/v2/v2AzureResourcesApi';
 import { ResourceBranchDataProviderManagerBase } from '../ResourceBranchDataProviderManagerBase';
 
-export class WorkspaceResourceBranchDataProviderManager extends ResourceBranchDataProviderManagerBase<BranchDataProvider<WorkspaceResource, ResourceModelBase>> {
+export class WorkspaceResourceBranchDataProviderManager extends ResourceBranchDataProviderManagerBase<string, BranchDataProvider<WorkspaceResource, ResourceModelBase>> {
     constructor(
         defaultProvider: BranchDataProvider<WorkspaceResource, ResourceModelBase>,
         extensionActivator: (type: string) => void


### PR DESCRIPTION
Updates the V2 API and implementation to use "normalized" resource types (i.e. `AzExtResourceType`) for branch data provider registration (which follows how V1 currently operates). Previously, the Azure resource type was used which is not ideal as both type and kind(s) are needed to totally distinguish between Azure resources.

Also updates the grouping logic to better replicate the existing V1 behavior in terms of hidden types, static resource type groups, and sorting.

Also removes the notion of IDs when registering resource providers, as they weren't used.  Extensions can now indicate that they contribute application/workspace resources using a `"resources": true` property within the `application` or `workspace` property.  (The thinking was that, in the future, if we need more complex registration, the `resources` property could be expanded to allow both a `boolean` as well as array of objects.

```json
{
    "contributes": {
        "x-azResourcesV2": {
            "application": {
                "branches": [
                    {
                        "type": "StorageAccounts"
                    }
                ]
            },
            "workspace": {
                "resources": true,
                "branches": [
                    {
                        "type": "ms-azuretools.vscode-azurestorage"
                    }
                ]
            }
        }
    }
}
```