### PR TITLE
Model for providing branch data provider item IDs

### DIFF
--- a/src/api/v2/v2AzureResourcesApi.ts
+++ b/src/api/v2/v2AzureResourcesApi.ts
@@ -73,6 +73,8 @@ export interface ResourceQuickPickOptions {
 }
 
 export interface ResourceModelBase {
+    // TODO: Should IDs be optional?
+    readonly id?: string;
     readonly quickPickOptions?: ResourceQuickPickOptions;
     readonly azureResourceId?: string;
 }

--- a/src/tree/v2/BranchDataProviderItem.ts
+++ b/src/tree/v2/BranchDataProviderItem.ts
@@ -23,7 +23,7 @@ export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResour
         itemCache.addBranchItem(this.branchItem, this);
     }
 
-    readonly id: string = this?.options?.defaultId ?? this.branchItem.id ?? randomUUID();
+    readonly id: string = this.branchItem.id ?? this?.options?.defaultId ?? randomUUID();
 
     async getChildren(): Promise<ResourceGroupsItem[] | undefined> {
         const children = await this.branchDataProvider.getChildren(this.branchItem);

--- a/src/tree/v2/BranchDataProviderItem.ts
+++ b/src/tree/v2/BranchDataProviderItem.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { randomUUID } from 'crypto';
 import * as vscode from 'vscode';
 import { BranchDataProvider, ResourceBase, ResourceModelBase, WrappedResourceModel } from '../../api/v2/v2AzureResourcesApi';
 import { ResourceGroupsItem } from './ResourceGroupsItem';
@@ -20,6 +21,8 @@ export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResour
         private readonly options?: BranchDataItemOptions) {
         itemCache.addBranchItem(this.branchItem, this);
     }
+
+    readonly id: string = this.branchItem.id ?? randomUUID();
 
     async getChildren(): Promise<ResourceGroupsItem[] | undefined> {
         const children = await this.branchDataProvider.getChildren(this.branchItem);
@@ -41,10 +44,6 @@ export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResour
     unwrap<T extends ResourceModelBase>(): T | undefined {
         return this.branchItem as T;
     }
-
-    id: string;
-    name: string;
-    type: string;
 }
 
 export type BranchDataItemFactory = (branchItem: ResourceModelBase, branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>, options?: BranchDataItemOptions) => BranchDataProviderItem;

--- a/src/tree/v2/BranchDataProviderItem.ts
+++ b/src/tree/v2/BranchDataProviderItem.ts
@@ -10,6 +10,7 @@ import { ResourceGroupsItem } from './ResourceGroupsItem';
 import { ResourceGroupsItemCache } from './ResourceGroupsItemCache';
 
 export type BranchDataItemOptions = {
+    defaultId?: string;
     defaults?: vscode.TreeItem;
 };
 
@@ -22,7 +23,7 @@ export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResour
         itemCache.addBranchItem(this.branchItem, this);
     }
 
-    readonly id: string = this.branchItem.id ?? randomUUID();
+    readonly id: string = this?.options?.defaultId ?? this.branchItem.id ?? randomUUID();
 
     async getChildren(): Promise<ResourceGroupsItem[] | undefined> {
         const children = await this.branchDataProvider.getChildren(this.branchItem);

--- a/src/tree/v2/GenericItem.ts
+++ b/src/tree/v2/GenericItem.ts
@@ -18,6 +18,8 @@ export class GenericItem implements ResourceGroupsItem {
     constructor(public readonly label: string, private readonly options?: GenericItemOptions) {
     }
 
+    readonly id: string = this.label;
+
     getChildren(): vscode.ProviderResult<ResourceGroupsItem[]> {
         return this.options?.children;
     }

--- a/src/tree/v2/ResourceGroupsItem.ts
+++ b/src/tree/v2/ResourceGroupsItem.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { ResourceModelBase } from '../../api/v2/v2AzureResourcesApi';
 
-export interface ResourceGroupsItem extends ResourceModelBase{
+export interface ResourceGroupsItem {
+    readonly id: string;
+
     getChildren(): vscode.ProviderResult<ResourceGroupsItem[]>;
     getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem>;
 }

--- a/src/tree/v2/ResourceGroupsItemCache.ts
+++ b/src/tree/v2/ResourceGroupsItemCache.ts
@@ -76,6 +76,19 @@ export class ResourceGroupsItemCache {
         return this.itemToParentCache.get(item);
     }
 
+    getPathForItem(item: ResourceGroupsItem): string[] {
+        const path: string[] = [];
+
+        let currentItem: ResourceGroupsItem | undefined = item;
+
+        while (currentItem) {
+            path.push(currentItem.id);
+            currentItem = this.getParentForItem(currentItem);
+        }
+
+        return path.reverse();
+    }
+
     updateItemChildren(item: ResourceGroupsItem, children: ResourceGroupsItem[]): void {
         this.itemToChildrenCache.set(item, children);
         children.forEach(child => this.itemToParentCache.set(child, item));

--- a/src/tree/v2/ResourceTreeDataProviderBase.ts
+++ b/src/tree/v2/ResourceTreeDataProviderBase.ts
@@ -82,7 +82,7 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
             if (element) {
                 this.itemCache.updateItemChildren(element, children);
             } else {
-                children.forEach(child => this.itemCache.addItem(child, []));
+                children.forEach(child => this.itemCache.addRootItem(child, []));
             }
         }
 

--- a/src/tree/v2/application/DefaultApplicationResourceBranchDataProvider.ts
+++ b/src/tree/v2/application/DefaultApplicationResourceBranchDataProvider.ts
@@ -5,22 +5,21 @@
 
 import * as vscode from 'vscode';
 import { ApplicationResource, BranchDataProvider } from '../../../api/v2/v2AzureResourcesApi';
-import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { DefaultApplicationResourceItem } from './DefaultApplicationResourceItem';
 
-export class DefaultApplicationResourceBranchDataProvider implements BranchDataProvider<ApplicationResource, ResourceGroupsItem> {
-    getChildren(element: ResourceGroupsItem): vscode.ProviderResult<ResourceGroupsItem[]> {
+export class DefaultApplicationResourceBranchDataProvider implements BranchDataProvider<ApplicationResource, DefaultApplicationResourceItem> {
+    getChildren(element: DefaultApplicationResourceItem): vscode.ProviderResult<DefaultApplicationResourceItem[]> {
         return element.getChildren();
     }
 
-    getResourceItem(element: ApplicationResource): ResourceGroupsItem | Thenable<ResourceGroupsItem> {
+    getResourceItem(element: ApplicationResource): DefaultApplicationResourceItem | Thenable<DefaultApplicationResourceItem> {
         return new DefaultApplicationResourceItem(element);
     }
 
     // TODO: Implement change eventing.
     // onDidChangeTreeData?: vscode.Event<void | ResourceGroupsItem | null | undefined> | undefined;
 
-    getTreeItem(element: ResourceGroupsItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
+    getTreeItem(element: DefaultApplicationResourceItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
         return element.getTreeItem();
     }
 }

--- a/src/tree/v2/application/DefaultApplicationResourceItem.ts
+++ b/src/tree/v2/application/DefaultApplicationResourceItem.ts
@@ -4,15 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { ApplicationResource } from '../../../api/v2/v2AzureResourcesApi';
+import { ApplicationResource, ResourceModelBase } from '../../../api/v2/v2AzureResourcesApi';
 import { getIconPath } from '../../../utils/azureUtils';
-import { ResourceGroupsItem } from '../ResourceGroupsItem';
 
-export class DefaultApplicationResourceItem implements ResourceGroupsItem {
+export class DefaultApplicationResourceItem implements ResourceModelBase {
     constructor(private readonly resource: ApplicationResource) {
     }
 
-    getChildren(): vscode.ProviderResult<ResourceGroupsItem[]> {
+    public readonly id: string = this.resource.id;
+
+    getChildren(): vscode.ProviderResult<DefaultApplicationResourceItem[]> {
         return undefined;
     }
 
@@ -23,8 +24,4 @@ export class DefaultApplicationResourceItem implements ResourceGroupsItem {
 
         return treeItem;
     }
-
-    id: string;
-    name: string;
-    type: string;
 }

--- a/src/tree/v2/application/GroupingItem.ts
+++ b/src/tree/v2/application/GroupingItem.ts
@@ -25,6 +25,8 @@ export class GroupingItem implements ResourceGroupsItem {
         public readonly resources: ApplicationResource[]) {
     }
 
+    readonly id: string = this.label;
+
     async getChildren(): Promise<ResourceGroupsItem[] | undefined> {
         const sortedResources = this.resources.sort((a, b) => a.name.localeCompare(b.name));
         const resourceItems = await Promise.all(sortedResources.map(

--- a/src/tree/v2/application/GroupingItem.ts
+++ b/src/tree/v2/application/GroupingItem.ts
@@ -35,6 +35,7 @@ export class GroupingItem implements ResourceGroupsItem {
                 const resourceItem = await branchDataProvider.getResourceItem(resource);
 
                 const options = {
+                    defaultId: resource.id,
                     defaults: {
                         iconPath: getIconPath(resource.resourceType)
                     }

--- a/src/tree/v2/application/SubscriptionItem.ts
+++ b/src/tree/v2/application/SubscriptionItem.ts
@@ -28,6 +28,8 @@ export class SubscriptionItem implements ResourceGroupsItem {
         private readonly subscription: ApplicationSubscription) {
     }
 
+    public readonly id: string = this.subscription.subscriptionId;
+
     async getChildren(): Promise<ResourceGroupsItem[]> {
         let resources = await this.resourceProviderManager.getResources(this.subscription);
 
@@ -49,8 +51,4 @@ export class SubscriptionItem implements ResourceGroupsItem {
 
         return treeItem;
     }
-
-    id: string;
-    name: string;
-    type: string;
 }


### PR DESCRIPTION
Allow BDPs to provide an ID for their items, which can then be accumulated to represent a "path" through the tree.

Every application/workspace item will have an ID of some sort.  BDPs can provide IDs but, if omitted, reasonable default IDs will be chosen (e.g. application resource items will use their Azure resource IDs, generic items will use their label, all others will be assigned a unique ID.)

The `ResourceGroupsItemCache` can be used to generate item "paths" (an array that contains the IDs of each item in the tree, in order, from the root item to the item in question) via `getPathForItem()` or retrieve the item represented by a path via `getItemForPath()`.