### PR TITLE
Expose `TreeDataProvider`s in API

### DIFF
--- a/src/api/pickAppResource.ts
+++ b/src/api/pickAppResource.ts
@@ -8,7 +8,7 @@ import { PickAppResourceOptions } from "@microsoft/vscode-azext-utils/hostapi";
 import { ext } from "../extensionVariables";
 
 export async function pickAppResource<T extends AzExtTreeItem>(context: ITreeItemPickerContext, options?: PickAppResourceOptions): Promise<T> {
-    return await compatibilityPickAppResourceExperience<T>(context, ext.v2.resourceGroupsTreeDataProvider, {
+    return await compatibilityPickAppResourceExperience<T>(context, ext.v2.applicationResourceTreeDataProvider, {
         resourceTypes: convertAppResourceFilterToAzExtResourceType(options?.filter),
         childItemFilter: convertExpectedChildContextValueToContextValueFilter(options?.expectedChildContextValue)
     });

--- a/src/api/v2/v2AzureResourcesApi.ts
+++ b/src/api/v2/v2AzureResourcesApi.ts
@@ -179,6 +179,10 @@ export interface ResourcePickOptions {
  * The current (v2) Azure Resources extension API.
  */
 export interface V2AzureResourcesApi extends AzureResourcesApiBase {
+
+    applicationResourceTreeDataProvider: vscode.TreeDataProvider<unknown>;
+    workspaceResourceTreeDataProvider: vscode.TreeDataProvider<unknown>;
+
     /**
      * Reveals an item in the application/workspace resource tree
      * @param resourceId The ID of the resource to reveal.

--- a/src/api/v2/v2AzureResourcesApi.ts
+++ b/src/api/v2/v2AzureResourcesApi.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { Environment } from '@azure/ms-rest-azure-env';
-import { AzExtResourceType, FindableByIdTreeNodeV2 } from '@microsoft/vscode-azext-utils';
+import { AzExtResourceType, FindableByIdTreeNodeV2, ResourceGroupsItem } from '@microsoft/vscode-azext-utils';
 import { AppResourceFilter } from '@microsoft/vscode-azext-utils/hostapi';
 import * as vscode from 'vscode';
 
@@ -180,8 +180,8 @@ export interface ResourcePickOptions {
  */
 export interface V2AzureResourcesApi extends AzureResourcesApiBase {
 
-    applicationResourceTreeDataProvider: vscode.TreeDataProvider<unknown>;
-    workspaceResourceTreeDataProvider: vscode.TreeDataProvider<unknown>;
+    applicationResourceTreeDataProvider: vscode.TreeDataProvider<ResourceGroupsItem>;
+    workspaceResourceTreeDataProvider: vscode.TreeDataProvider<ResourceGroupsItem>;
 
     /**
      * Reveals an item in the application/workspace resource tree

--- a/src/api/v2/v2AzureResourcesApiImplementation.ts
+++ b/src/api/v2/v2AzureResourcesApiImplementation.ts
@@ -5,7 +5,9 @@
 
 import * as vscode from 'vscode';
 import { ApplicationResourceBranchDataProviderManager } from '../../tree/v2/application/ApplicationResourceBranchDataProviderManager';
+import { ApplicationResourceTreeDataProvider } from '../../tree/v2/application/ApplicationResourceTreeDataProvider';
 import { WorkspaceResourceBranchDataProviderManager } from '../../tree/v2/workspace/WorkspaceResourceBranchDataProviderManager';
+import { WorkspaceResourceTreeDataProvider } from '../../tree/v2/workspace/WorkspaceResourceTreeDataProvider';
 import { ApplicationResourceProviderManager, WorkspaceResourceProviderManager } from './ResourceProviderManagers';
 import { ApplicationResource, ApplicationResourceProvider, BranchDataProvider, ResourceModelBase, V2AzureResourcesApi, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
 
@@ -16,8 +18,10 @@ export class V2AzureResourcesApiImplementation implements V2AzureResourcesApi {
         private readonly applicationResourceProviderManager: ApplicationResourceProviderManager,
         private readonly applicationResourceBranchDataProviderManager: ApplicationResourceBranchDataProviderManager,
         private readonly workspaceResourceProviderManager: WorkspaceResourceProviderManager,
-        private readonly workspaceResourceBranchDataProviderManager: WorkspaceResourceBranchDataProviderManager) {
-    }
+        private readonly workspaceResourceBranchDataProviderManager: WorkspaceResourceBranchDataProviderManager,
+        public readonly applicationResourceTreeDataProvider: ApplicationResourceTreeDataProvider,
+        public readonly workspaceResourceTreeDataProvider: WorkspaceResourceTreeDataProvider,
+    ) { }
 
     get apiVersion(): string {
         return V2AzureResourcesApiImplementation.apiVersion;

--- a/src/api/v2/v2AzureResourcesApiWrapper.ts
+++ b/src/api/v2/v2AzureResourcesApiWrapper.ts
@@ -18,11 +18,11 @@ export class V2AzureResourcesApiWrapper implements V2AzureResourcesApi {
     }
 
     get applicationResourceTreeDataProvider(): vscode.TreeDataProvider<unknown> {
-        return this.callWithTelemetryAndErrorHandlingSync('v2.getApplicationResourceTreeDataProvider', () => this.api.applicationResourceTreeDataProvider);
+        return this.api.applicationResourceTreeDataProvider;
     }
 
     get workspaceResourceTreeDataProvider(): vscode.TreeDataProvider<unknown> {
-        return this.callWithTelemetryAndErrorHandlingSync('v2.getWorkspaceResourceTreeDataProvider', () => this.api.workspaceResourceTreeDataProvider);
+        return this.api.workspaceResourceTreeDataProvider;
     }
 
     revealResource(resourceId: string): Promise<void> {

--- a/src/api/v2/v2AzureResourcesApiWrapper.ts
+++ b/src/api/v2/v2AzureResourcesApiWrapper.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtResourceType, callWithTelemetryAndErrorHandling, callWithTelemetryAndErrorHandlingSync } from '@microsoft/vscode-azext-utils';
+import { AzExtResourceType, callWithTelemetryAndErrorHandling, callWithTelemetryAndErrorHandlingSync, ResourceGroupsItem } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ApplicationResource, ApplicationResourceProvider, BranchDataProvider, ResourceModelBase, V2AzureResourcesApi, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
 
@@ -17,11 +17,11 @@ export class V2AzureResourcesApiWrapper implements V2AzureResourcesApi {
         return this.api.apiVersion;
     }
 
-    get applicationResourceTreeDataProvider(): vscode.TreeDataProvider<unknown> {
+    get applicationResourceTreeDataProvider(): vscode.TreeDataProvider<ResourceGroupsItem> {
         return this.api.applicationResourceTreeDataProvider;
     }
 
-    get workspaceResourceTreeDataProvider(): vscode.TreeDataProvider<unknown> {
+    get workspaceResourceTreeDataProvider(): vscode.TreeDataProvider<ResourceGroupsItem> {
         return this.api.workspaceResourceTreeDataProvider;
     }
 

--- a/src/api/v2/v2AzureResourcesApiWrapper.ts
+++ b/src/api/v2/v2AzureResourcesApiWrapper.ts
@@ -17,6 +17,14 @@ export class V2AzureResourcesApiWrapper implements V2AzureResourcesApi {
         return this.api.apiVersion;
     }
 
+    get applicationResourceTreeDataProvider(): vscode.TreeDataProvider<unknown> {
+        return this.callWithTelemetryAndErrorHandlingSync('v2.getApplicationResourceTreeDataProvider', () => this.api.applicationResourceTreeDataProvider);
+    }
+
+    get workspaceResourceTreeDataProvider(): vscode.TreeDataProvider<unknown> {
+        return this.callWithTelemetryAndErrorHandlingSync('v2.getWorkspaceResourceTreeDataProvider', () => this.api.workspaceResourceTreeDataProvider);
+    }
+
     revealResource(resourceId: string): Promise<void> {
         return this.callWithTelemetryAndErrorHandling('v2.revealResource', async () => await this.api.revealResource(resourceId));
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,8 +33,8 @@ import { GroupTreeItemBase } from './tree/GroupTreeItemBase';
 import { HelpTreeItem } from './tree/HelpTreeItem';
 import { ApplicationResourceBranchDataProviderManager } from './tree/v2/application/ApplicationResourceBranchDataProviderManager';
 import { DefaultApplicationResourceBranchDataProvider } from './tree/v2/application/DefaultApplicationResourceBranchDataProvider';
-import { registerResourceGroupsTreeV2 } from './tree/v2/application/registerResourceGroupsTreeV2';
-import { registerWorkspaceTreeV2 } from './tree/v2/workspace/registerWorkspaceTreeV2';
+import { registerApplicationTree } from './tree/v2/application/registerResourceGroupsTreeV2';
+import { registerWorkspaceTree } from './tree/v2/workspace/registerWorkspaceTreeV2';
 import { WorkspaceDefaultBranchDataProvider } from './tree/v2/workspace/WorkspaceDefaultBranchDataProvider';
 import { WorkspaceResourceBranchDataProviderManager } from './tree/v2/workspace/WorkspaceResourceBranchDataProviderManager';
 import { WorkspaceTreeItem } from './tree/WorkspaceTreeItem';
@@ -122,17 +122,17 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         type => void extensionManager.activateWorkspaceResourceBranchDataProvider(type));
     const workspaceResourceProviderManager = new WorkspaceResourceProviderManager(() => extensionManager.activateWorkspaceResourceProviders());
 
-    registerResourceGroupsTreeV2(
-        context,
+    const { applicationResourceTreeDataProvider } = registerApplicationTree(context, {
         branchDataProviderManager,
-        refreshEventEmitter.event,
-        resourceProviderManager);
+        resourceProviderManager,
+        refreshEvent: refreshEventEmitter.event,
+    });
 
-    registerWorkspaceTreeV2(
-        workspaceResourceBranchDataProviderManager,
-        context,
-        refreshWorkspaceEmitter.event,
-        workspaceResourceProviderManager);
+    const { workspaceResourceTreeDataProvider } = registerWorkspaceTree(context, {
+        branchDataProviderManager: workspaceResourceBranchDataProviderManager,
+        workspaceResourceProviderManager,
+        refreshEvent: refreshWorkspaceEmitter.event,
+    });
 
     const v2ApiFactory = () => {
         if (v2Api === undefined) {
@@ -140,7 +140,10 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                 resourceProviderManager,
                 branchDataProviderManager,
                 workspaceResourceProviderManager,
-                workspaceResourceBranchDataProviderManager);
+                workspaceResourceBranchDataProviderManager,
+                applicationResourceTreeDataProvider,
+                workspaceResourceTreeDataProvider
+            );
 
             context.subscriptions.push(v2Api.registerApplicationResourceProvider('TODO: is ID useful?', new DefaultApplicationResourceProvider()));
         }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -51,6 +51,6 @@ export namespace ext {
 
     export namespace v2 {
         export let api: V2AzureResourcesApi;
-        export let resourceGroupsTreeDataProvider: TreeDataProvider<ResourceGroupsItem>;
+        export let applicationResourceTreeDataProvider: TreeDataProvider<ResourceGroupsItem>;
     }
 }

--- a/src/tree/v2/workspace/registerWorkspaceTreeV2.ts
+++ b/src/tree/v2/workspace/registerWorkspaceTreeV2.ts
@@ -9,27 +9,39 @@ import { localize } from './../../../utils/localize';
 import { WorkspaceResourceBranchDataProviderManager } from './WorkspaceResourceBranchDataProviderManager';
 import { WorkspaceResourceTreeDataProvider } from './WorkspaceResourceTreeDataProvider';
 
-export function registerWorkspaceTreeV2(
+interface RegisterWorkspaceTreeOptions {
     branchDataProviderManager: WorkspaceResourceBranchDataProviderManager,
-    context: vscode.ExtensionContext,
     refreshEvent: vscode.Event<void>,
-    workspaceResourceProviderManager: WorkspaceResourceProviderManager): void {
-    const treeDataProvider = new WorkspaceResourceTreeDataProvider(
+    workspaceResourceProviderManager: WorkspaceResourceProviderManager
+}
+
+interface RegisterWorkspaceTreeResult {
+    workspaceResourceTreeDataProvider: WorkspaceResourceTreeDataProvider;
+}
+
+export function registerWorkspaceTree(context: vscode.ExtensionContext, options: RegisterWorkspaceTreeOptions): RegisterWorkspaceTreeResult {
+    const { branchDataProviderManager, refreshEvent, workspaceResourceProviderManager } = options;
+
+    const workspaceResourceTreeDataProvider = new WorkspaceResourceTreeDataProvider(
         branchDataProviderManager,
         refreshEvent,
         workspaceResourceProviderManager);
 
-    context.subscriptions.push(treeDataProvider);
+    context.subscriptions.push(workspaceResourceTreeDataProvider);
 
     const treeView = vscode.window.createTreeView(
         'azureWorkspaceV2',
         {
             canSelectMany: true,
             showCollapseAll: true,
-            treeDataProvider
+            treeDataProvider: workspaceResourceTreeDataProvider
         });
 
     treeView.description = localize('local', 'Local');
 
     context.subscriptions.push(treeView);
+
+    return {
+        workspaceResourceTreeDataProvider
+    }
 }


### PR DESCRIPTION
* Exposing the workspace and application tree data providers so they can be used by client extensions.
* Some cleanup and renaming around the registration functions
