### PR TITLE
Actually refresh whole tree

### DIFF
--- a/src/tree/v2/ResourceTreeDataProviderBase.ts
+++ b/src/tree/v2/ResourceTreeDataProviderBase.ts
@@ -46,13 +46,13 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
                             rgItems.push(rgItem);
                         }
                     }
+                    this.onDidChangeTreeDataEmitter.fire(rgItems)
                 } else {
                     // e was null/undefined/void
                     // Translate it to fire on all elements for this branch data provider
                     // TODO
+                    this.onDidChangeTreeDataEmitter.fire();
                 }
-
-                this.onDidChangeTreeDataEmitter.fire(rgItems)
             });
 
         this.refreshSubscription = onRefresh(() => this.onDidChangeTreeDataEmitter.fire());


### PR DESCRIPTION
Calling `this.onDidChangeTreeDataEmitter.fire([])` with an empty array doesn't actually refresh the whole tree.