### PR TITLE
Add refresh capabilities to `CompatibleBranchDataProvider`

### DIFF
--- a/src/api/v2/compatibility/CompatibleBranchDataProvider.ts
+++ b/src/api/v2/compatibility/CompatibleBranchDataProvider.ts
@@ -15,8 +15,8 @@ import { CompatibleBranchDataProviderBase } from './CompatibleBranchDataProvider
  */
 export class CompatibleBranchDataProvider<TResource extends ApplicationResource, TModel extends AzExtTreeItem & ResourceModelBase> extends CompatibleBranchDataProviderBase<TResource, TModel> {
     public constructor(private readonly resolver: AppResourceResolver, loadMoreCommandId: string) {
-        // Using `{}` here so property assignment doesn't throw
         super(loadMoreCommandId);
+        resolver.onDidChangeTreeData?.((e) => this.overrideOnDidChangeTreeDataEmitter.fire(e as unknown as TModel | undefined));
     }
 
     public async getResourceItem(element: TResource): Promise<TModel> {

--- a/src/api/v2/compatibility/CompatibleBranchDataProviderBase.ts
+++ b/src/api/v2/compatibility/CompatibleBranchDataProviderBase.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { BranchDataProvider, ResourceBase, ResourceModelBase } from "../v2AzureResourcesApi";
 
 export class CompatibleBranchDataProviderBase<TResource extends ResourceBase, TModel extends AzExtTreeItem & ResourceModelBase> extends AzExtTreeDataProvider implements BranchDataProvider<TResource, TModel> {
-    private readonly overrideOnDidChangeTreeDataEmitter = new vscode.EventEmitter<TModel | undefined>();
+    protected readonly overrideOnDidChangeTreeDataEmitter = new vscode.EventEmitter<TModel | undefined>();
 
     public constructor(loadMoreCommandId: string) {
         // Using `{}` here so property assignment doesn't throw


### PR DESCRIPTION
Relies on https://github.com/microsoft/vscode-azuretools/pull/1254.

In order to no longer use `AzExtTreeDataProvider.refresh()` in the client extensions, we need to be able to signal a refresh to the branch data provider from the client extension resolvers.

This is working towards removing direct usages of the `AzExtTreeDataProvider` in the client extensions.