### PR TITLE
V2 API Updates per Design Discussion Feedback

### DIFF
--- a/src/api/v2/DefaultApplicationResourceProvider.ts
+++ b/src/api/v2/DefaultApplicationResourceProvider.ts
@@ -9,12 +9,12 @@ import { callWithTelemetryAndErrorHandling, getAzExtResourceType, IActionContext
 import * as vscode from 'vscode';
 import { createResourceClient } from '../../utils/azureClients';
 import { createSubscriptionContext } from '../../utils/v2/credentialsUtils';
-import { ApplicationResource, ApplicationResourceProvider, ApplicationSubscription, ProvideResourceOptions } from './v2AzureResourcesApi';
+import { ApplicationResource, ApplicationResourceProvider, ApplicationSubscription } from './v2AzureResourcesApi';
 
 export class DefaultApplicationResourceProvider implements ApplicationResourceProvider {
     private readonly onDidChangeResourceEmitter = new vscode.EventEmitter<ApplicationResource | undefined>();
 
-    getResources(subscription: ApplicationSubscription, _options?: ProvideResourceOptions | undefined): Promise<ApplicationResource[] | undefined> {
+    getResources(subscription: ApplicationSubscription): Promise<ApplicationResource[] | undefined> {
         return callWithTelemetryAndErrorHandling(
             'provideResources',
             async (context: IActionContext) => {

--- a/src/api/v2/ResourceProviderManagers.ts
+++ b/src/api/v2/ResourceProviderManagers.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { ApplicationResource, ApplicationResourceProvider, ApplicationSubscription, ProvideResourceOptions, ResourceBase, ResourceProvider, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
+import { ApplicationResource, ApplicationResourceProvider, ApplicationSubscription, ResourceBase, ResourceProvider, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
 
 export function isArray<T>(maybeArray: T[] | null | undefined): maybeArray is T[] {
     return Array.isArray(maybeArray);
@@ -53,12 +53,12 @@ class ResourceProviderManager<TResourceSource, TResource extends ResourceBase, T
         }
     }
 
-    async getResources(source: TResourceSource, options?: ProvideResourceOptions): Promise<TResource[]> {
+    async getResources(source: TResourceSource): Promise<TResource[]> {
         await this.activateExtensions();
 
         const resourceProviders = Array.from(this.providers.keys());
 
-        const resources = await Promise.all(resourceProviders.map(resourceProvider => resourceProvider.getResources(source, options)));
+        const resources = await Promise.all(resourceProviders.map(resourceProvider => resourceProvider.getResources(source)));
 
         return resources.filter(isArray).reduce((acc, result) => acc?.concat(result ?? []), []);
     }

--- a/src/api/v2/v2AzureResourcesApi.ts
+++ b/src/api/v2/v2AzureResourcesApi.ts
@@ -7,123 +7,253 @@ import type { Environment } from '@azure/ms-rest-azure-env';
 import { AzExtResourceType } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 
-export interface ApplicationAuthentication {
-    getSession(scopes?: string[]): vscode.ProviderResult<vscode.AuthenticationSession>;
-}
-
 /**
- * Information specific to the Subscription
+ * Represents the base type for all application and workspace resources.
  */
-export interface ApplicationSubscription {
-    readonly authentication: ApplicationAuthentication;
-    readonly name: string;
-    readonly subscriptionId: string;
-    readonly environment: Environment;
-    readonly isCustomCloud: boolean;
-}
-
 export interface ResourceBase {
+    /**
+     * The ID of this resource.
+     *
+     * @remarks This value should be unique across all resources.
+     */
     readonly id: string;
+
+    /**
+     * The display name of this resource.
+     */
     readonly name: string;
 }
 
-export interface AzureResourceType {
-    readonly type: string;
-    readonly kinds?: string[];
+/**
+ * Represents the base type for models of resources and their child items.
+ */
+export interface ResourceModelBase {
+    /**
+     * The ID of this model.
+     *
+     * @remarks This value should be unique across all models of its type.
+     */
+    readonly id?: string;
 }
 
 /**
- * Represents an individual resource in Azure.
- * @remarks The `id` property is expected to be the Azure resource ID.
+ * The base interface for providers of application and workspace resources.
  */
-export interface ApplicationResource extends ResourceBase {
-    readonly subscription: ApplicationSubscription;
-    readonly azureResourceType: AzureResourceType;
-    readonly resourceType?: AzExtResourceType;
-    readonly location?: string;
-    readonly resourceGroup?: string;
-    readonly tags?: {
-        [propertyName: string]: string;
-    };
-}
-
-// TODO: Can this be not exported?
 export interface ResourceProvider<TResourceSource, TResource extends ResourceBase> {
+    /**
+     * Fired when the provider's resources have changed.
+     */
     readonly onDidChangeResource?: vscode.Event<TResource | undefined>;
 
     /**
-     * Called to supply the resources used as the basis for the resource group views.
+     * Called to supply the resources used as the basis for the resource views.
+     *
      * @param source The source from which resources should be generated.
+     *
+     * @returns The resources to be displayed in the resource view.
      */
     getResources(source: TResourceSource): vscode.ProviderResult<TResource[]>;
 }
 
-export type ApplicationResourceProvider = ResourceProvider<ApplicationSubscription, ApplicationResource>;
-
-// TODO: Can this be combined with `unknown`?
-export interface ResourceModelBase {
-    readonly id?: string;
-    readonly azureResourceId?: string;
-    readonly portalUrl?: string;
-}
-
-// TODO: Create application/workspace specific base model types.
-
 /**
- * Represents a branch data provider resource model as returned by a context menu command.
- * TODO: Do we use this internally?
- */
-export interface WrappedResourceModel {
-    /**
-     * Unwraps the resource, returning the underlying branch data provider resource model.
-     *
-     * @remarks TODO: Should this be an async method (which might be viral for existing command implementations)?
-     */
-    unwrap<T extends ResourceModelBase>(): T | undefined;
-}
-
-/**
- * The interface that resource resolvers must implement
+ * The base interface for visualizers of application and workspace resources.
  */
 export interface BranchDataProvider<TResource extends ResourceBase, TModel extends ResourceModelBase> extends vscode.TreeDataProvider<TModel> {
     /**
      * Get the children of `element`.
      *
-     * @param element The element from which the provider gets children. Unlike a traditional TreeDataProvider, this will never be `undefined`.
+     * @param element The element from which the provider gets children. Unlike a traditional tree data provider, this will never be `undefined`.
+     *
      * @return Children of `element`.
      */
     getChildren(element: TModel): vscode.ProviderResult<TModel[]>;
 
     /**
-     * A BranchDataProvider need not (and should not) implement this function.
+     * A branch data provider need not (and should not) implement this function.
+     *
+     * @remarks While VS Code would normally call this function on a tree data provider, it is not used by the Azure Resource extension as part of a branch data provider.
      */
     getParent?: never;
 
     /**
      * Called to get the provider's model element for a specific resource.
-     * @remarks getChildren() assumes that the provider passes a known <T> model item, or undefined when getting the root children.
-     *          However, we need to be able to pass a specific application resource which may not match the <T> model hierarchy used by the provider.
+     *
+     * @remarks getChildren() assumes that the provider passes a known (TModel) model item, or undefined when getting the "root" children.
+     *          However, branch data providers have no "root" so this function is called for each matching resource to obtain a starting branch item.
+     *
+     * @returns The provider's model element for `resource`.
      */
     getResourceItem(element: TResource): TModel | Thenable<TModel>;
 }
 
+/**
+ * Represents a means of obtaining authentication data for an application subscription.
+ */
+export interface ApplicationAuthentication {
+    /**
+     * Gets a VS Code authentication session for an application subscription.
+     *
+     * @param scopes The scopes for which the authentication is needed.
+     *
+     * @returns A VS Code authentication session or undefined, if none could be obtained.
+     */
+    getSession(scopes?: string[]): vscode.ProviderResult<vscode.AuthenticationSession>;
+}
+
+/**
+ * Represents an Azure subscription.
+ */
+export interface ApplicationSubscription {
+    /**
+     * Access to the authentication session associated with this subscription.
+     */
+    readonly authentication: ApplicationAuthentication;
+
+    /**
+     * The Azure environment to which this subscription belongs.
+     */
+    readonly environment: Environment;
+
+    /**
+     * Whether this subscription belongs to a custom cloud.
+     */
+    readonly isCustomCloud: boolean;
+
+    /**
+     * The display name of this subscription.
+     */
+    readonly name: string;
+
+    /**
+     * The ID of this subscription.
+     */
+    readonly subscriptionId: string;
+
+    /**
+     * The tenant to which this subscription belongs or undefined, if not associated with a specific tenant.
+     */
+    readonly tenantId?: string;
+}
+
+/**
+ * Represents a type of resource as designated by Azure.
+ */
+export interface AzureResourceType {
+    /**
+     * The kinds of resources that this type can represent.
+     */
+    readonly kinds?: string[];
+
+    /**
+     * The (general) type of resource.
+     */
+     readonly type: string;
+}
+
+/**
+ * Represents an individual resource in Azure.
+ */
+export interface ApplicationResource extends ResourceBase {
+    /**
+     * The Azure-designated type of this resource.
+     */
+    readonly azureResourceType: AzureResourceType;
+
+    /**
+     * The location in which this resource exists.
+     */
+    readonly location?: string;
+
+    /**
+     * The resource group to which this resource belongs.
+     */
+    readonly resourceGroup?: string;
+
+    /**
+     * The type of this resource.
+     *
+     * @remarks This value is used to map resources to their associated branch data provider.
+     */
+    readonly resourceType?: AzExtResourceType;
+
+    /**
+     * The Azure subscription to which this resource belongs.
+     */
+    readonly subscription: ApplicationSubscription;
+
+    /**
+     * The tags associated with this resource.
+     */
+    readonly tags?: {
+        [propertyName: string]: string;
+    };
+}
+
+/**
+ * Represents a model of an individual application resource or its child items.
+ */
+export interface ApplicationResourceModel extends ResourceModelBase {
+    /**
+     * The Azure ID of this resource.
+     *
+     * @remarks This property is expected to be implemented on "application-level" resources, but may also be applicable to its child items.
+     */
+    readonly azureResourceId?: string;
+
+    /**
+     * The URL of the area of Azure portal related to this item.
+     */
+    readonly portalUrl?: vscode.Uri;
+}
+
+/**
+ * A provider for supplying items for the application resource tree (e.g. Cosmos DB, Storage, etc.).
+ */
+export type ApplicationResourceProvider = ResourceProvider<ApplicationSubscription, ApplicationResource>;
+
+/**
+ * A provider for visualizing items in the application resource tree (e.g. Cosmos DB, Storage, etc.).
+ */
+export type ApplicationResourceBranchDataProvider<TModel extends ApplicationResourceModel> = BranchDataProvider<ApplicationResource, TModel>;
+
+/**
+ * Respresents a specific type of workspace resource.
+ *
+ * @remarks This value should be unique across all types of workspace resources.
+ */
 type WorkspaceResourceType = string;
 
 /**
- *
+ * An indivdual root resource for a workspace.
  */
 export interface WorkspaceResource extends ResourceBase {
-    readonly folder: vscode.WorkspaceFolder;
     /**
-     * Used to match to a branch data provider.
+     * The folder to which this resource belongs.
+     */
+    readonly folder: vscode.WorkspaceFolder;
+
+    /**
+     * The type of this resource.
+     *
+     * @remarks This value is used to map resources to their associated branch data provider.
      */
     readonly resourceType: WorkspaceResourceType;
 }
 
 /**
- * A provider for supplying items for the workspace resource tree (e.g., storage emulator, function apps in workspace, etc.)
+ * Represents a model of an individual workspace resource or its child items.
+ */
+export type WorkspaceResourceModel = ResourceModelBase;
+
+/**
+ * A provider for supplying items for the workspace resource tree (e.g., storage emulator, function apps in workspace, etc.).
  */
 export type WorkspaceResourceProvider = ResourceProvider<vscode.WorkspaceFolder, WorkspaceResource>;
+
+/**
+ * A provider for visualizing items in the workspace resource tree (e.g., storage emulator, function apps in workspace, etc.).
+ */
+export type WorkspaceResourceBranchDataProvider<TModel extends WorkspaceResourceModel> = BranchDataProvider<WorkspaceResource, TModel>;
 
 /**
  * The current (v2) Azure Resources extension API.
@@ -131,39 +261,62 @@ export type WorkspaceResourceProvider = ResourceProvider<vscode.WorkspaceFolder,
 export interface V2AzureResourcesApi extends AzureResourcesApiBase {
     /**
      * Registers a provider of application resources.
+     *
      * @param provider The resource provider.
+     *
+     * @returns A disposable that unregisters the provider when disposed.
      */
     registerApplicationResourceProvider(provider: ApplicationResourceProvider): vscode.Disposable;
 
     /**
      * Registers an application resource branch data provider.
+     *
      * @param type The Azure application resource type associated with the provider. Must be unique.
      * @param resolver The branch data provider for the resource type.
+     *
+     * @returns A disposable that unregisters the provider.
      */
-    registerApplicationResourceBranchDataProvider<T extends ResourceModelBase>(type: AzExtResourceType, provider: BranchDataProvider<ApplicationResource, T>): vscode.Disposable;
+    registerApplicationResourceBranchDataProvider<TModel extends ApplicationResourceModel>(type: AzExtResourceType, provider: ApplicationResourceBranchDataProvider<TModel>): vscode.Disposable;
 
     /**
      * Registers a provider of workspace resources.
+     *
      * @param provider The resource provider.
+     *
+     * @returns A disposable that unregisters the provider.
      */
     registerWorkspaceResourceProvider(provider: WorkspaceResourceProvider): vscode.Disposable;
 
     /**
      * Registers a workspace resource branch data provider.
+     *
      * @param type The workspace resource type associated with the provider. Must be unique.
      * @param provider The branch data provider for the resource type.
+     *
+     * @returns A disposable that unregisters the provider.
      */
-    registerWorkspaceResourceBranchDataProvider<T extends ResourceModelBase>(type: WorkspaceResourceType, provider: BranchDataProvider<WorkspaceResource, T>): vscode.Disposable;
+    registerWorkspaceResourceBranchDataProvider<TModel extends WorkspaceResourceModel>(type: WorkspaceResourceType, provider: WorkspaceResourceBranchDataProvider<TModel>): vscode.Disposable;
 }
 
+/**
+ * The base API for all versions of Azure Resources extension APIs.
+ */
 export interface AzureResourcesApiBase {
+    /**
+     * The version of this Azure Resources extension API.
+     */
     readonly apiVersion: string;
 }
 
 /**
- *
+ * Options affecting the return of an Azure Resources extension API.
  */
 export interface GetApiOptions {
+    /**
+     * The ID of the extension requesting the API.
+     *
+     * @remarks This is used for telemetry purposes, to measure which extensions are using the API.
+     */
     readonly extensionId?: string;
 }
 
@@ -171,14 +324,13 @@ export interface GetApiOptions {
  * Exported object of the Azure Resources extension.
  */
 export interface AzureResourcesApiManager {
-
     /**
      * Gets a specific version of the Azure Resources extension API.
      *
-     * @typeparam T The type of the API.
-     * @param version The version of the API to return. Defaults to the latest version.
+     * @typeparam TApi The type of the API.
+     * @param versionRange The version of the API to return, specified as a potential (semver) range of versions.
      *
-     * @returns The requested API or undefined, if not available.
+     * @returns The requested API or undefined, if no version of the API matches the specified range.
      */
-    getApi<T extends AzureResourcesApiBase>(versionRange: string, options?: GetApiOptions): T | undefined
+    getApi<TApi extends AzureResourcesApiBase>(versionRange: string, options?: GetApiOptions): TApi | undefined
 }

--- a/src/api/v2/v2AzureResourcesApiImplementation.ts
+++ b/src/api/v2/v2AzureResourcesApiImplementation.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { ApplicationResourceBranchDataProviderManager } from '../../tree/v2/application/ApplicationResourceBranchDataProviderManager';
 import { WorkspaceResourceBranchDataProviderManager } from '../../tree/v2/workspace/WorkspaceResourceBranchDataProviderManager';
 import { ApplicationResourceProviderManager, WorkspaceResourceProviderManager } from './ResourceProviderManagers';
-import { ApplicationResource, ApplicationResourceProvider, BranchDataProvider, ResourceModelBase, ResourcePickOptions, V2AzureResourcesApi, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
+import { ApplicationResource, ApplicationResourceProvider, BranchDataProvider, ResourceModelBase, V2AzureResourcesApi, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
 
 export class V2AzureResourcesApiImplementation implements V2AzureResourcesApi {
     public static apiVersion: string = '2.0.0';
@@ -22,14 +22,6 @@ export class V2AzureResourcesApiImplementation implements V2AzureResourcesApi {
 
     get apiVersion(): string {
         return V2AzureResourcesApiImplementation.apiVersion;
-    }
-
-    pickResource<TModel>(_options?: ResourcePickOptions | undefined): vscode.ProviderResult<TModel> {
-        throw new Error("Method not implemented.");
-    }
-
-    revealResource(_resourceId: string): Promise<void> {
-        throw new Error("Method not implemented.");
     }
 
     registerApplicationResourceProvider(provider: ApplicationResourceProvider): vscode.Disposable {

--- a/src/api/v2/v2AzureResourcesApiWrapper.ts
+++ b/src/api/v2/v2AzureResourcesApiWrapper.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtResourceType, callWithTelemetryAndErrorHandling, callWithTelemetryAndErrorHandlingSync } from '@microsoft/vscode-azext-utils';
+import { AzExtResourceType, callWithTelemetryAndErrorHandlingSync } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
-import { ApplicationResource, ApplicationResourceProvider, BranchDataProvider, ResourceModelBase, ResourcePickOptions, V2AzureResourcesApi, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
+import { ApplicationResource, ApplicationResourceProvider, BranchDataProvider, ResourceModelBase, V2AzureResourcesApi, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
 
 export class V2AzureResourcesApiWrapper implements V2AzureResourcesApi {
     constructor(
@@ -15,14 +15,6 @@ export class V2AzureResourcesApiWrapper implements V2AzureResourcesApi {
 
     get apiVersion(): string {
         return this.api.apiVersion;
-    }
-
-    pickResource<TModel>(options?: ResourcePickOptions | undefined): vscode.ProviderResult<TModel> {
-        return this.callWithTelemetryAndErrorHandling('v2.pickResource', async () => await this.api.pickResource(options));
-    }
-
-    revealResource(resourceId: string): Promise<void> {
-        return this.callWithTelemetryAndErrorHandling('v2.revealResource', async () => await this.api.revealResource(resourceId));
     }
 
     registerApplicationResourceProvider(provider: ApplicationResourceProvider): vscode.Disposable {
@@ -39,22 +31,6 @@ export class V2AzureResourcesApiWrapper implements V2AzureResourcesApi {
 
     registerWorkspaceResourceBranchDataProvider<T extends ResourceModelBase>(id: string, provider: BranchDataProvider<WorkspaceResource, T>): vscode.Disposable {
         return this.callWithTelemetryAndErrorHandlingSync('v2.registerWorkspaceResourceBranchDataProvider', () => this.api.registerWorkspaceResourceBranchDataProvider<T>(id, provider));
-    }
-
-    private async callWithTelemetryAndErrorHandling<T>(callbackId: string, func: () => Promise<T>): Promise<T> {
-        const response = await callWithTelemetryAndErrorHandling(
-            callbackId,
-            async context => {
-                context.telemetry.properties.callingExtensionId = this.extensionId;
-                context.errorHandling.rethrow = true;
-                context.errorHandling.suppressDisplay = true;
-                context.errorHandling.suppressReportIssue = true;
-
-                return await func();
-            });
-
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return response!;
     }
 
     private callWithTelemetryAndErrorHandlingSync<T>(callbackId: string, func: () => T): T {

--- a/src/tree/v2/BranchDataProviderItem.ts
+++ b/src/tree/v2/BranchDataProviderItem.ts
@@ -5,7 +5,7 @@
 
 import { randomUUID } from 'crypto';
 import * as vscode from 'vscode';
-import { BranchDataProvider, ResourceBase, ResourceModelBase, WrappedResourceModel } from '../../api/v2/v2AzureResourcesApi';
+import { BranchDataProvider, ResourceBase, ResourceModelBase } from '../../api/v2/v2AzureResourcesApi';
 import { ResourceGroupsItem } from './ResourceGroupsItem';
 import { ResourceGroupsItemCache } from './ResourceGroupsItemCache';
 
@@ -13,6 +13,16 @@ export type BranchDataItemOptions = {
     defaultId?: string;
     defaults?: vscode.TreeItem;
 };
+
+/**
+ * Represents a branch data provider resource model as returned by a context menu command.
+ */
+ export interface WrappedResourceModel {
+    /**
+     * Unwraps the resource, returning the underlying branch data provider resource model.
+     */
+    unwrap<T extends ResourceModelBase>(): T | undefined;
+}
 
 export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResourceModel {
     constructor(

--- a/src/tree/v2/application/ApplicationResourceTreeDataProvider.ts
+++ b/src/tree/v2/application/ApplicationResourceTreeDataProvider.ts
@@ -99,7 +99,7 @@ export class ApplicationResourceTreeDataProvider extends ResourceTreeDataProvide
                                     authentication: {
                                         getSession: () => session
                                     },
-                                    displayName: subscription.subscription.displayName || 'TODO: ever undefined?',
+                                    name: subscription.subscription.displayName || 'TODO: ever undefined?',
                                     environment: subscription.session.environment,
                                     isCustomCloud: subscription.session.environment.name === 'AzureCustomCloud',
                                     subscriptionId: subscription.subscription.subscriptionId || 'TODO: ever undefined?',

--- a/src/tree/v2/application/SubscriptionItem.ts
+++ b/src/tree/v2/application/SubscriptionItem.ts
@@ -43,7 +43,7 @@ export class SubscriptionItem implements ResourceGroupsItem {
     }
 
     getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem> {
-        const treeItem = new vscode.TreeItem(this.subscription.displayName ?? 'Unnamed', vscode.TreeItemCollapsibleState.Collapsed);
+        const treeItem = new vscode.TreeItem(this.subscription.name ?? 'Unnamed', vscode.TreeItemCollapsibleState.Collapsed);
 
         treeItem.contextValue = 'azureextensionui.azureSubscription';
         treeItem.iconPath = treeUtils.getIconPath('azureSubscription');

--- a/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
+++ b/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
@@ -40,7 +40,7 @@ export class WorkspaceResourceTreeDataProvider extends ResourceTreeDataProviderB
     }
 
     private async getWorkspaceItemModel(resource: WorkspaceResource): Promise<ResourceGroupsItem> {
-        const branchDataProvider = this.branchDataProviderManager.getProvider(resource.type);
+        const branchDataProvider = this.branchDataProviderManager.getProvider(resource.resourceType);
 
         const resourceItem = await branchDataProvider.getResourceItem(resource);
 


### PR DESCRIPTION
Updates to the V2 API based on feedback from the design discussion.

Notes:

 - I experimented with allowing models to be `unknown`, but it cascades that uncertainty throughout the rest of the API and implementation. While allowing models to be simple types represents the ultimate in flexibility, I feel like extension developers would almost certainly *never* do this in practice.  As soon as any model needs to carry extra information along with it (or, say, want to conform to the optional properties of the API), moving from simple types to objects would likely be a significant refactor.  It simply makes sense for the models to be objects (even if simple ones).