### PR TITLE
Remove dependency on fs-extra.

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { gulp_installAzureAccount, gulp_webpack } from '@microsoft/vscode-azext-dev';
-import * as fse from 'fs-extra';
+import * as fs from 'fs/promises';
 import * as gulp from 'gulp';
 import * as path from 'path';
 
@@ -12,23 +12,23 @@ declare let exports: { [key: string]: unknown };
 
 async function prepareForWebpack(): Promise<void> {
     const mainJsPath: string = path.join(__dirname, 'main.js');
-    let contents: string = (await fse.readFile(mainJsPath)).toString();
+    let contents: string = (await fs.readFile(mainJsPath)).toString();
     contents = contents
         .replace('out/src/extension', 'dist/extension.bundle')
         .replace(', true /* ignoreBundle */', '');
-    await fse.writeFile(mainJsPath, contents);
+    await fs.writeFile(mainJsPath, contents);
 }
 
 async function listIcons(): Promise<void> {
     const rootPath: string = path.join(__dirname, 'resources', 'providers');
-    const subDirs: string[] = (await fse.readdir(rootPath)).filter(dir => dir.startsWith('microsoft.'));
+    const subDirs: string[] = (await fs.readdir(rootPath)).filter(dir => dir.startsWith('microsoft.'));
     while (true) {
         const subDir: string | undefined = subDirs.pop();
         if (!subDir) {
             break;
         } else {
             const subDirPath: string = path.join(rootPath, subDir);
-            const paths: string[] = await fse.readdir(subDirPath);
+            const paths: string[] = await fs.readdir(subDirPath);
             for (const p of paths) {
                 const subPath: string = path.posix.join(subDir, p);
                 if (subPath.endsWith('.svg')) {
@@ -43,9 +43,9 @@ async function listIcons(): Promise<void> {
 
 async function cleanReadme(): Promise<void> {
     const readmePath: string = path.join(__dirname, 'README.md');
-    let data: string = (await fse.readFile(readmePath)).toString();
+    let data: string = (await fs.readFile(readmePath)).toString();
     data = data.replace(/<!-- region exclude-from-marketplace -->.*?<!-- endregion exclude-from-marketplace -->/gis, '');
-    await fse.writeFile(readmePath, data);
+    await fs.writeFile(readmePath, data);
 }
 
 exports['webpack-dev'] = gulp.series(prepareForWebpack, () => gulp_webpack('development'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
                 "@microsoft/vscode-azext-azureutils": "^0.3.4",
                 "@microsoft/vscode-azext-utils": "^0.3.14",
-                "fs-extra": "^8.1.0",
                 "jsonc-parser": "^2.2.1",
                 "open": "^8.0.4",
                 "semver": "^7.3.7",
@@ -22,7 +21,6 @@
             "devDependencies": {
                 "@microsoft/eslint-config-azuretools": "^0.1.0",
                 "@microsoft/vscode-azext-dev": "^0.1.4",
-                "@types/fs-extra": "^8.0.1",
                 "@types/gulp": "^4.0.6",
                 "@types/mocha": "^7.0.2",
                 "@types/node": "^14.0.0",
@@ -954,15 +952,6 @@
             "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
             "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
             "dev": true
-        },
-        "node_modules/@types/fs-extra": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.1.tgz",
-            "integrity": "sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/glob": {
             "version": "7.1.3",
@@ -4805,6 +4794,7 @@
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
             "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^4.0.0",
@@ -5408,7 +5398,8 @@
         "node_modules/graceful-fs": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+            "dev": true
         },
         "node_modules/growl": {
             "version": "1.10.5",
@@ -6476,6 +6467,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -10845,6 +10837,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -12943,15 +12936,6 @@
             "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
             "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
             "dev": true
-        },
-        "@types/fs-extra": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.1.tgz",
-            "integrity": "sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
         },
         "@types/glob": {
             "version": "7.1.3",
@@ -15983,6 +15967,7 @@
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
             "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^4.0.0",
@@ -16471,7 +16456,8 @@
         "graceful-fs": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+            "dev": true
         },
         "growl": {
             "version": "1.10.5",
@@ -17261,6 +17247,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.6"
             }
@@ -20713,7 +20700,8 @@
         "universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
         },
         "unset-value": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -575,7 +575,6 @@
     "devDependencies": {
         "@microsoft/eslint-config-azuretools": "^0.1.0",
         "@microsoft/vscode-azext-dev": "^0.1.4",
-        "@types/fs-extra": "^8.0.1",
         "@types/gulp": "^4.0.6",
         "@types/mocha": "^7.0.2",
         "@types/node": "^14.0.0",
@@ -601,7 +600,6 @@
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
         "@microsoft/vscode-azext-azureutils": "^0.3.4",
         "@microsoft/vscode-azext-utils": "^0.3.14",
-        "fs-extra": "^8.1.0",
         "jsonc-parser": "^2.2.1",
         "open": "^8.0.4",
         "semver": "^7.3.7",


### PR DESCRIPTION
In the spirit of web-ifying the extension, this removes the dependency on `fs-extra`.  (In actuality it was only used by the build process, so could just be switched to a dev-dependency but, in any case, is easily replaced by built-in runtime APIs.)