### PR TITLE
WIP: (V2) Workspace Welcome Views

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,6 +252,16 @@
             {
                 "view": "azureActivityLog",
                 "contents": "View all of your recent activities and quickly access resources you've recently created. \n [Create an Azure resource](command:azureResourceGroups.createResource)"
+            },
+            {
+                "view": "azureWorkspace",
+                "contents": "No workspace has been opened.",
+                "when": "azureWorkspace.state == 'noWorkspace'"
+            },
+            {
+                "view": "azureWorkspace",
+                "contents": "No local workspace resources exist.",
+                "when": "azureWorkspace.state == 'noWorkspaceResources'"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -262,6 +262,11 @@
                 "view": "azureWorkspace",
                 "contents": "No local workspace resources exist.",
                 "when": "azureWorkspace.state == 'noWorkspaceResources'"
+            },
+            {
+                "view": "azureWorkspace",
+                "contents": "No local workspace resource providers exist.",
+                "when": "azureWorkspace.state == 'noWorkspaceResourceProviders'"
             }
         ],
         "menus": {

--- a/src/api/v2/ResourceProviderManagers.ts
+++ b/src/api/v2/ResourceProviderManagers.ts
@@ -18,6 +18,10 @@ class ResourceProviderManager<TResourceSource, TResource extends ResourceBase, T
 
     public readonly onDidChangeResourceChange: vscode.Event<TResource | undefined>;
 
+    get hasResourceProviders(): boolean {
+        return this.providers.size > 0;
+    }
+
     constructor(private readonly extensionActivator: () => Promise<void>) {
         super(
             () => {

--- a/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
+++ b/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
@@ -36,7 +36,7 @@ export class WorkspaceResourceTreeDataProvider extends ResourceTreeDataProviderB
                 const resources = await this.resourceProviderManager.getResources(vscode.workspace.workspaceFolders[0]);
 
                 if (resources.length === 0) {
-                    await vscode.commands.executeCommand('setContext', 'azureWorkspace.state', 'noWorkspaceResources');
+                    await vscode.commands.executeCommand('setContext', 'azureWorkspace.state', this.resourceProviderManager.hasResourceProviders ? 'noWorkspaceResources' : 'noWorkspaceResourceProviders');
                 } else {
                     return Promise.all(resources.map(resource => this.getWorkspaceItemModel(resource)));
                 }

--- a/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
+++ b/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
@@ -28,13 +28,23 @@ export class WorkspaceResourceTreeDataProvider extends ResourceTreeDataProviderB
         if (element) {
             return await element.getChildren();
         }
-        else if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-            const resources = await this.resourceProviderManager.getResources(vscode.workspace.workspaceFolders[0]);
+        else {
+            if (vscode.workspace.workspaceFolders === undefined || vscode.workspace.workspaceFolders.length === 0) {
+                await vscode.commands.executeCommand('setContext', 'azureWorkspace.state', 'noWorkspace');
+            }
+            else {
+                const resources = await this.resourceProviderManager.getResources(vscode.workspace.workspaceFolders[0]);
 
-            if (resources) {
-                return Promise.all(resources.map(resource => this.getWorkspaceItemModel(resource)));
+                if (resources.length === 0) {
+                    await vscode.commands.executeCommand('setContext', 'azureWorkspace.state', 'noWorkspaceResources');
+                } else {
+                    return Promise.all(resources.map(resource => this.getWorkspaceItemModel(resource)));
+                }
             }
         }
+
+        // NOTE: Returning zero children indicates to VS Code that is should display a "welcome view".
+        //       The one chosen for display depends on the context set above.
 
         return [];
     }


### PR DESCRIPTION
So, it bothers me when nothing is shown in the (V2) workspace view as I can never be sure it is intentional or not.  VS Code has the ability to show "welcome views" when tree views are otherwise empty.  This change adds welcome views for the workspace view that differ when:

- No workspace is open

<img width="1103" alt="Screenshot 2022-10-26 at 12 26 18" src="https://user-images.githubusercontent.com/6402946/198119958-d038d43d-0beb-4ff1-8a60-86539e6bc7ac.png">

- No workspace resources were enumerated

<img width="1099" alt="Screenshot 2022-10-26 at 12 27 30" src="https://user-images.githubusercontent.com/6402946/198119967-6702f2c1-4576-4a97-8c71-ca89adff37f8.png">

- No workspace resource providers are registered (i.e. no extension that registers a provider is installed)

<img width="1102" alt="Screenshot 2022-10-26 at 12 26 46" src="https://user-images.githubusercontent.com/6402946/198119970-5afb5fae-1f86-49bd-9636-b3d02da0612e.png">

- Resources were enumerated (i.e. the traditional view)

<img width="1101" alt="Screenshot 2022-10-26 at 12 29 05" src="https://user-images.githubusercontent.com/6402946/198119964-59e53d35-f84c-4c8c-9acd-fc631c645129.png">

The text content is mostly a placeholder at this point; I'd appreciate some "PM wordsmithing".  In particular, would it make sense to try to point users somewhere, for example, when no resource providers have been installed?