### PR TITLE
Expose and implement "Open in Portal" for application resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
                 },
                 {
                     "command": "azureResourceGroups.openInPortal",
-                    "when": "view == azureResourceGroups && viewItem =~ /azureResource(?!Type)/",
+                    "when": "view == azureResourceGroups && viewItem =~ /azureResource/",
                     "group": "9@2"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
                 },
                 {
                     "command": "azureResourceGroups.openInPortal",
-                    "when": "view == azureResourceGroups && viewItem =~ /azureResource/",
+                    "when": "view == azureResourceGroups && viewItem =~ /hasPortalUrl/",
                     "group": "9@2"
                 },
                 {

--- a/src/api/v2/v2AzureResourcesApi.ts
+++ b/src/api/v2/v2AzureResourcesApi.ts
@@ -132,7 +132,7 @@ export interface ApplicationSubscription {
     /**
      * The tenant to which this subscription belongs or undefined, if not associated with a specific tenant.
      */
-    readonly tenantId?: string;
+    readonly tenantId: string;
 }
 
 /**

--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -3,15 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { openInPortal as uiOpenInPortal } from '@microsoft/vscode-azext-azureutils';
-import { AzExtTreeItem, IActionContext, nonNullProp } from '@microsoft/vscode-azext-utils';
-import { pickAppResource } from '../api/pickAppResource';
-import { AppResourceTreeItem } from '../tree/AppResourceTreeItem';
+import { AzExtTreeItem, IActionContext, openUrl } from '@microsoft/vscode-azext-utils';
+import { BranchDataProviderItem } from '../tree/v2/BranchDataProviderItem';
+import { localize } from '../utils/localize';
 
-export async function openInPortal(context: IActionContext, node?: AzExtTreeItem): Promise<void> {
+export async function openInPortal(_context: IActionContext, node?: AzExtTreeItem): Promise<void> {
     if (!node) {
-        node = await pickAppResource<AppResourceTreeItem>(context);
+        // TODO: Reenable this once we have a way to pick resources.
+        // node = await pickAppResource<AppResourceTreeItem>(context);
+
+        throw new Error(localize('commands.openInPortal.noSelectedResource', 'A resource must be selected.'));
     }
 
-    await uiOpenInPortal(node, nonNullProp(node, 'id'));
+    if (node instanceof BranchDataProviderItem && node.portalUrl) {
+        // NOTE: VS Code's URI type agressively encodes fragments heavily used in Portal URLs, but which the Portal doesn't understand, so skip encoding here.
+        return await openUrl(node.portalUrl.toString(/* skipEncoding: */ true));
+    }
+
+    throw new Error(localize('commands.openInPortal.noPortalLocation', 'The selected resource is not associated with location within the Azure portal.'));
 }

--- a/src/tree/v2/BranchDataProviderItem.ts
+++ b/src/tree/v2/BranchDataProviderItem.ts
@@ -12,6 +12,7 @@ import { ResourceGroupsItemCache } from './ResourceGroupsItemCache';
 export type BranchDataItemOptions = {
     defaultId?: string;
     defaults?: vscode.TreeItem;
+    portalUrl?: vscode.Uri | undefined;
 };
 
 /**
@@ -34,6 +35,8 @@ export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResour
     }
 
     readonly id: string = this.branchItem.id ?? this?.options?.defaultId ?? randomUUID();
+
+    readonly portalUrl: vscode.Uri | undefined = this.options?.portalUrl;
 
     async getChildren(): Promise<ResourceGroupsItem[] | undefined> {
         const children = await this.branchDataProvider.getChildren(this.branchItem);

--- a/src/tree/v2/BranchDataProviderItem.ts
+++ b/src/tree/v2/BranchDataProviderItem.ts
@@ -10,9 +10,10 @@ import { ResourceGroupsItem } from './ResourceGroupsItem';
 import { ResourceGroupsItemCache } from './ResourceGroupsItemCache';
 
 export type BranchDataItemOptions = {
+    contextValues?: string[];
     defaultId?: string;
     defaults?: vscode.TreeItem;
-    portalUrl?: vscode.Uri | undefined;
+    portalUrl?: vscode.Uri;
 };
 
 /**
@@ -23,6 +24,14 @@ export type BranchDataItemOptions = {
      * Unwraps the resource, returning the underlying branch data provider resource model.
      */
     unwrap<T extends ResourceModelBase>(): T | undefined;
+}
+
+function appendContextValues(originalValues: string | undefined, newValues: string[]): string {
+    const set = new Set<string>(originalValues?.split(' ') ?? []);
+
+    newValues?.forEach(value => set.add(value));
+
+    return Array.from(set).join(' ');
 }
 
 export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResourceModel {
@@ -49,10 +58,16 @@ export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResour
     async getTreeItem(): Promise<vscode.TreeItem> {
         const treeItem = await this.branchDataProvider.getTreeItem(this.branchItem);
 
-        return {
+        const realTreeItem = {
             ...this.options?.defaults ?? {},
             ...treeItem
+        };
+
+        if (this.options?.contextValues && this.options.contextValues.length > 0) {
+            realTreeItem.contextValue = appendContextValues(realTreeItem.contextValue, this.options.contextValues);
         }
+
+        return realTreeItem;
     }
 
     unwrap<T extends ResourceModelBase>(): T | undefined {

--- a/src/tree/v2/application/ApplicationResourceTreeDataProvider.ts
+++ b/src/tree/v2/application/ApplicationResourceTreeDataProvider.ts
@@ -103,6 +103,7 @@ export class ApplicationResourceTreeDataProvider extends ResourceTreeDataProvide
                                     environment: subscription.session.environment,
                                     isCustomCloud: subscription.session.environment.name === 'AzureCustomCloud',
                                     subscriptionId: subscription.subscription.subscriptionId || 'TODO: ever undefined?',
+                                    tenantId: subscription.session.tenantId
                                 }));
                     }
                 } else if (api.status === 'LoggedOut') {

--- a/src/tree/v2/application/GroupingItem.ts
+++ b/src/tree/v2/application/GroupingItem.ts
@@ -44,9 +44,9 @@ export class GroupingItem implements ResourceGroupsItem {
                 const resourceItem = await branchDataProvider.getResourceItem(resource);
 
                 const options = {
+                    contextValues: [ 'azureResource' ],
                     defaultId: resource.id,
                     defaults: {
-                        contextValue: 'azureResource',
                         iconPath: getIconPath(resource.resourceType)
                     },
                     portalUrl: resourceItem.portalUrl ?? createPortalUrl(resource.subscription, resource.id)

--- a/src/tree/v2/application/GroupingItem.ts
+++ b/src/tree/v2/application/GroupingItem.ts
@@ -3,14 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { OpenInPortalOptions } from '@microsoft/vscode-azext-azureutils';
 import { TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
-import { ApplicationResource, BranchDataProvider, ResourceModelBase } from '../../../api/v2/v2AzureResourcesApi';
+import { ApplicationResource, ApplicationResourceBranchDataProvider, ApplicationResourceModel, ApplicationSubscription } from '../../../api/v2/v2AzureResourcesApi';
 import { getIconPath } from '../../../utils/azureUtils';
 import { BranchDataItemFactory } from '../BranchDataProviderItem';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { ResourceGroupsTreeContext } from '../ResourceGroupsTreeContext';
 import { BranchDataProviderFactory } from './ApplicationResourceBranchDataProviderManager';
+
+// TODO: This should be moved to the common library, for use by other extensions.
+function createPortalUrl(subscription: ApplicationSubscription, id: string, options?: OpenInPortalOptions): vscode.Uri {
+    const queryPrefix: string = (options && options.queryPrefix) ? `?${options.queryPrefix}` : '';
+    const url: string = `${subscription.environment.portalUrl}/${queryPrefix}#@${subscription.tenantId}/resource${id}`;
+
+    return vscode.Uri.parse(url);
+}
 
 export class GroupingItem implements ResourceGroupsItem {
     private description: string | undefined;
@@ -18,7 +27,7 @@ export class GroupingItem implements ResourceGroupsItem {
     constructor(
         public readonly context: ResourceGroupsTreeContext,
         private readonly branchDataItemFactory: BranchDataItemFactory,
-        private readonly branchDataProviderFactory: (ApplicationResource) => BranchDataProvider<ApplicationResource, ResourceModelBase>,
+        private readonly branchDataProviderFactory: (ApplicationResource) => ApplicationResourceBranchDataProvider<ApplicationResourceModel>,
         private readonly contextValues: string[] | undefined,
         private readonly iconPath: TreeItemIconPath | undefined,
         public readonly label: string,
@@ -37,8 +46,10 @@ export class GroupingItem implements ResourceGroupsItem {
                 const options = {
                     defaultId: resource.id,
                     defaults: {
+                        contextValue: 'azureResource',
                         iconPath: getIconPath(resource.resourceType)
-                    }
+                    },
+                    portalUrl: resourceItem.portalUrl ?? createPortalUrl(resource.subscription, resource.id)
                 };
 
                 return this.branchDataItemFactory(resourceItem, branchDataProvider, options);

--- a/src/utils/v2/credentialsUtils.ts
+++ b/src/utils/v2/credentialsUtils.ts
@@ -41,7 +41,6 @@ export function createSubscriptionContext(subscription: ApplicationSubscription)
     return {
         subscriptionDisplayName: '',
         subscriptionPath: '',
-        tenantId: '',
         userId: '',
         ...subscription,
         credentials: createCredential(subscription.authentication.getSession)


### PR DESCRIPTION
The Resource Groups extension now exposes an "Open in Portal" command for all application resources.  BranchDataProvider's have the option to override that portal URL.  The command is also exposed if any child of an application resource sets the optional `ApplicationResourceModel.portalUrl` property.

Command for application resources without a registered BDP:

<img width="406" alt="Screenshot 2022-11-01 at 15 49 08" src="https://user-images.githubusercontent.com/6402946/199357347-3a327f4c-8c26-407b-b224-9fa90204d5d8.png">

Command for application resources with a registered BDP:

<img width="470" alt="Screenshot 2022-11-01 at 15 49 35" src="https://user-images.githubusercontent.com/6402946/199357344-ae5f6c61-4948-4c58-8943-a01f17b8171a.png">

Command for arbitrary children that expose the `portalUrl` property:

<img width="397" alt="Screenshot 2022-11-01 at 15 50 08" src="https://user-images.githubusercontent.com/6402946/199357340-826f778b-fd3f-4975-899d-16994685063a.png">
