### PR TITLE
Bring back suggested extension installation

### DIFF
--- a/src/AzExtWrapper.ts
+++ b/src/AzExtWrapper.ts
@@ -7,6 +7,7 @@ import { AzExtResourceType, IAzureQuickPickItem } from "@microsoft/vscode-azext-
 import { AzureExtensionApiProvider } from "@microsoft/vscode-azext-utils/api";
 import { AppResource } from "@microsoft/vscode-azext-utils/hostapi";
 import { commands, Extension, extensions } from "vscode";
+import { ApplicationResource } from './api/v2/v2AzureResourcesApi';
 import { azureExtensions, IAzExtMetadata, IAzExtTutorial } from "./azureExtensions";
 import { contributesKey } from "./constants";
 
@@ -56,6 +57,10 @@ export class AzExtWrapper {
 
     public matchesResourceType(resource: AppResource): boolean {
         return this._resourceTypes.some(rt => rt === resource.azExtResourceType);
+    }
+
+    public matchesApplicationResourceType(resource: ApplicationResource): boolean {
+        return this._resourceTypes.some(rt => rt === resource.resourceType);
     }
 
     public getCodeExtension(): Extension<AzureExtensionApiProvider> | undefined {

--- a/src/tree/v2/GenericItem.ts
+++ b/src/tree/v2/GenericItem.ts
@@ -11,6 +11,7 @@ export interface GenericItemOptions {
     readonly children?: ResourceGroupsItem[];
     readonly commandArgs?: unknown[];
     readonly commandId?: string;
+    readonly contextValue?: string;
     readonly iconPath?: TreeItemIconPath;
 }
 
@@ -35,6 +36,7 @@ export class GenericItem implements ResourceGroupsItem {
             };
         }
 
+        treeItem.contextValue = this.options?.contextValue;
         treeItem.iconPath = this.options?.iconPath;
 
         return treeItem;

--- a/src/tree/v2/application/DefaultApplicationResourceBranchDataProvider.ts
+++ b/src/tree/v2/application/DefaultApplicationResourceBranchDataProvider.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { ApplicationResource, BranchDataProvider } from '../../../api/v2/v2AzureResourcesApi';
+import { ApplicationResource, ApplicationResourceModel, BranchDataProvider } from '../../../api/v2/v2AzureResourcesApi';
 import { DefaultApplicationResourceItem } from './DefaultApplicationResourceItem';
 
-export class DefaultApplicationResourceBranchDataProvider implements BranchDataProvider<ApplicationResource, DefaultApplicationResourceItem> {
-    getChildren(element: DefaultApplicationResourceItem): vscode.ProviderResult<DefaultApplicationResourceItem[]> {
+export class DefaultApplicationResourceBranchDataProvider implements BranchDataProvider<ApplicationResource, ApplicationResourceModel> {
+    getChildren(element: DefaultApplicationResourceItem): vscode.ProviderResult<ApplicationResourceModel[]> {
         return element.getChildren();
     }
 

--- a/src/tree/v2/application/DefaultApplicationResourceItem.ts
+++ b/src/tree/v2/application/DefaultApplicationResourceItem.ts
@@ -4,21 +4,44 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { ApplicationResource, ResourceModelBase } from '../../../api/v2/v2AzureResourcesApi';
+import { ApplicationResource } from '../../../api/v2/v2AzureResourcesApi';
 import { getIconPath } from '../../../utils/azureUtils';
+import { localize } from "../../../utils/localize";
+import { GenericItem } from '../GenericItem';
+import { ResourceGroupsItem } from '../ResourceGroupsItem';
 
-export class DefaultApplicationResourceItem implements ResourceModelBase {
+export class DefaultApplicationResourceItem implements ResourceGroupsItem {
     constructor(private readonly resource: ApplicationResource) {
     }
 
     public readonly id: string = this.resource.id;
 
-    getChildren(): vscode.ProviderResult<DefaultApplicationResourceItem[]> {
-        return undefined;
+    /**
+     * Returns true if the resource type extension is installed,
+     * false if the resource type extension is not installed,
+     * otherwise undefined if no extension is associated with the resource type.
+     */
+    private readonly isResourceTypeExtensionInstalled: boolean | undefined = false;
+
+    getChildren(): Promise<ResourceGroupsItem[] | undefined> {
+        if (this.isResourceTypeExtensionInstalled === false) {
+            return Promise.resolve([
+                new GenericItem(
+                    localize('installExtensionToEnableFeatures', 'Install extension to enable additional features...'),
+                    {
+                        commandArgs: [ 'TODO: Extension ID' ],
+                        commandId: 'azureResourceGroups.installExtension',
+                        contextValue: 'installExtension',
+                        iconPath: new vscode.ThemeIcon('extensions')
+                    })
+            ]);
+        } else {
+            return Promise.resolve(undefined);
+        }
     }
 
     getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem> {
-        const treeItem = new vscode.TreeItem(this.resource.name ?? 'Unnamed Resource');
+        const treeItem = new vscode.TreeItem(this.resource.name ?? 'Unnamed Resource', this.isResourceTypeExtensionInstalled === false ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None);
 
         treeItem.iconPath = getIconPath(this.resource.resourceType);
 


### PR DESCRIPTION
Brings back the RG V1 behavior where the application resource view would prompt the user to install extensions known to manage an enumerated resource type, if that extension was not yet installed.

<img width="466" alt="Screenshot 2022-11-02 at 15 11 28" src="https://user-images.githubusercontent.com/6402946/199613415-f16f2da6-8153-48a7-a499-04e5df2493f7.png">
