### PR TITLE
Make tree item ids mimic Azure ids

### DIFF
--- a/src/tree/v2/ResourceGroupsItem.ts
+++ b/src/tree/v2/ResourceGroupsItem.ts
@@ -8,13 +8,6 @@ import * as vscode from 'vscode';
 export interface ResourceGroupsItem {
     readonly id: string;
 
-    /**
-    * Override default isAncestorOf behavior based on paths.
-    *
-    * If defined, the item id will be excluded from paths of child items
-    */
-    isAncestorOf?(id: string): boolean;
-
     getChildren(): vscode.ProviderResult<ResourceGroupsItem[]>;
     getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem>;
 }

--- a/src/tree/v2/ResourceGroupsItem.ts
+++ b/src/tree/v2/ResourceGroupsItem.ts
@@ -8,6 +8,13 @@ import * as vscode from 'vscode';
 export interface ResourceGroupsItem {
     readonly id: string;
 
+    /**
+    * Override default isAncestorOf behavior based on paths.
+    *
+    * If defined, the item id will be excluded from paths of child items
+    */
+    isAncestorOf?(id: string): boolean;
+
     getChildren(): vscode.ProviderResult<ResourceGroupsItem[]>;
     getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem>;
 }

--- a/src/tree/v2/ResourceGroupsItemCache.ts
+++ b/src/tree/v2/ResourceGroupsItemCache.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../utils/localize';
+import { GroupingItem } from './application/GroupingItem';
 import { ResourceGroupsItem } from './ResourceGroupsItem';
 
 interface InternalResourceGroupsItem extends ResourceGroupsItem {
@@ -91,8 +92,7 @@ export class ResourceGroupsItemCache {
         while (currentItem) {
             const nextItem = this.getParentForItem(currentItem);
 
-            // if item has custom ancestor logic, exclude its id from the path of other items
-            if (!currentItem.isAncestorOf || item === currentItem) {
+            if (!currentItem.id.includes('groupings') || item === currentItem) {
                 path.push(currentItem.id);
             }
 
@@ -129,7 +129,10 @@ export class ResourceGroupsItemCache {
     }
 
     isAncestorOf(element: ResourceGroupsItem, id: string): boolean {
-        return element.isAncestorOf?.(id) ?? id.startsWith(this.getId(element) + '/');
+        if (element instanceof GroupingItem) {
+            return element.resources.some(resource => id.startsWith(resource.id));
+        }
+        return id.startsWith(this.getId(element) + '/');
     }
 
     private createInternalResourceGroupsItem(child: ResourceGroupsItem, parent: ResourceGroupsItem): InternalResourceGroupsItem {

--- a/src/tree/v2/ResourceGroupsItemCache.ts
+++ b/src/tree/v2/ResourceGroupsItemCache.ts
@@ -79,13 +79,6 @@ export class ResourceGroupsItemCache {
         return this.branchItemToItemCache.get(branchItem);
     }
 
-    getChildrenForItem(item?: ResourceGroupsItem): ResourceGroupsItem[] | undefined {
-        if (!item) {
-            return this.rootItemCache;
-        }
-        return this.itemToChildrenCache.get(item);
-    }
-
     getParentForItem(item: InternalResourceGroupsItem): ResourceGroupsItem | undefined {
         return item.parent;
     }

--- a/src/tree/v2/ResourceGroupsItemCache.ts
+++ b/src/tree/v2/ResourceGroupsItemCache.ts
@@ -129,7 +129,7 @@ export class ResourceGroupsItemCache {
     }
 
     isAncestorOf(element: ResourceGroupsItem, id: string): boolean {
-        return element?.isAncestorOf?.(id) || id.startsWith(this.getId(element) + '/');
+        return element.isAncestorOf?.(id) ?? id.startsWith(this.getId(element) + '/');
     }
 
     private createInternalResourceGroupsItem(child: ResourceGroupsItem, parent: ResourceGroupsItem): InternalResourceGroupsItem {

--- a/src/tree/v2/ResourceGroupsItemCache.ts
+++ b/src/tree/v2/ResourceGroupsItemCache.ts
@@ -120,8 +120,8 @@ export class ResourceGroupsItemCache {
 
     updateItemChildren(item: ResourceGroupsItem, children: ResourceGroupsItem[]): InternalResourceGroupsItem[] {
         this.itemToChildrenCache.set(item, children);
-        // cache the parent on the item
-        return children.map(child => Object.assign(child, { parent: item }));
+        // cache the parent on the child items
+        return children.map(child => this.createInternalResourceGroupsItem(child, item));
     }
 
     getId(element: ResourceGroupsItem): string {
@@ -130,5 +130,10 @@ export class ResourceGroupsItemCache {
 
     isAncestorOf(element: ResourceGroupsItem, id: string): boolean {
         return element?.isAncestorOf?.(id) || id.startsWith(this.getId(element) + '/');
+    }
+
+    private createInternalResourceGroupsItem(child: ResourceGroupsItem, parent: ResourceGroupsItem): InternalResourceGroupsItem {
+        (child as ResourceGroupsItem & { parent: ResourceGroupsItem }).parent = parent;
+        return child as InternalResourceGroupsItem;
     }
 }

--- a/src/tree/v2/ResourceGroupsItemCache.ts
+++ b/src/tree/v2/ResourceGroupsItemCache.ts
@@ -6,11 +6,17 @@
 import { localize } from '../../utils/localize';
 import { ResourceGroupsItem } from './ResourceGroupsItem';
 
+interface InternalResourceGroupsItem extends ResourceGroupsItem {
+    /**
+     * Reference to the parent of this item. Only used within ResourceGroupsItemCache.
+     */
+    readonly parent?: InternalResourceGroupsItem;
+}
+
 export class ResourceGroupsItemCache {
     private readonly branchItemToItemCache: Map<unknown, ResourceGroupsItem> = new Map();
     private readonly itemToBranchItemCache: Map<ResourceGroupsItem, unknown> = new Map();
     private readonly itemToChildrenCache: Map<ResourceGroupsItem, ResourceGroupsItem[]> = new Map();
-    private readonly itemToParentCache: Map<ResourceGroupsItem, ResourceGroupsItem> = new Map();
     private readonly rootItemCache: ResourceGroupsItem[] = [];
 
     addBranchItem(branchItem: unknown, item: ResourceGroupsItem): void {
@@ -21,14 +27,12 @@ export class ResourceGroupsItemCache {
     addRootItem(item: ResourceGroupsItem, children: ResourceGroupsItem[]): void {
         this.rootItemCache.push(item);
         this.itemToChildrenCache.set(item, children);
-        children.forEach(child => this.itemToParentCache.set(child, item));
     }
 
     evictAll(): void {
         this.branchItemToItemCache.clear();
         this.itemToBranchItemCache.clear();
         this.itemToChildrenCache.clear();
-        this.itemToParentCache.clear();
         this.rootItemCache.length = 0;
     }
 
@@ -67,7 +71,6 @@ export class ResourceGroupsItemCache {
 
                 this.itemToBranchItemCache.delete(child);
                 this.itemToChildrenCache.delete(child);
-                this.itemToParentCache.delete(child);
             }
         }
     }
@@ -76,8 +79,15 @@ export class ResourceGroupsItemCache {
         return this.branchItemToItemCache.get(branchItem);
     }
 
-    getParentForItem(item: ResourceGroupsItem): ResourceGroupsItem | undefined {
-        return this.itemToParentCache.get(item);
+    getChildrenForItem(item?: ResourceGroupsItem): ResourceGroupsItem[] | undefined {
+        if (!item) {
+            return this.rootItemCache;
+        }
+        return this.itemToChildrenCache.get(item);
+    }
+
+    getParentForItem(item: InternalResourceGroupsItem): ResourceGroupsItem | undefined {
+        return item.parent;
     }
 
     getPathForItem(item: ResourceGroupsItem): string[] {
@@ -86,8 +96,14 @@ export class ResourceGroupsItemCache {
         let currentItem: ResourceGroupsItem | undefined = item;
 
         while (currentItem) {
-            path.push(currentItem.id);
-            currentItem = this.getParentForItem(currentItem);
+            const nextItem = this.getParentForItem(currentItem);
+
+            // if item has custom ancestor logic, exclude its id from the path of other items
+            if (!currentItem.isAncestorOf || item === currentItem) {
+                path.push(currentItem.id);
+            }
+
+            currentItem = nextItem;
         }
 
         return path.reverse();
@@ -109,8 +125,17 @@ export class ResourceGroupsItemCache {
         return currentItem;
     }
 
-    updateItemChildren(item: ResourceGroupsItem, children: ResourceGroupsItem[]): void {
+    updateItemChildren(item: ResourceGroupsItem, children: ResourceGroupsItem[]): InternalResourceGroupsItem[] {
         this.itemToChildrenCache.set(item, children);
-        children.forEach(child => this.itemToParentCache.set(child, item));
+        // cache the parent on the item
+        return children.map(child => Object.assign(child, { parent: item }));
+    }
+
+    getId(element: ResourceGroupsItem): string {
+        return '/' + this.getPathForItem(element).join('/');
+    }
+
+    isAncestorOf(element: ResourceGroupsItem, id: string): boolean {
+        return element?.isAncestorOf?.(id) || id.startsWith(this.getId(element) + '/');
     }
 }

--- a/src/tree/v2/ResourceTreeDataProviderBase.ts
+++ b/src/tree/v2/ResourceTreeDataProviderBase.ts
@@ -63,8 +63,13 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
 
     onDidChangeTreeData: vscode.Event<void | ResourceGroupsItem | ResourceGroupsItem[] | null | undefined> = this.onDidChangeTreeDataEmitter.event;
 
-    getTreeItem(element: ResourceGroupsItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
-        return element.getTreeItem();
+    async getTreeItem(element: ResourceGroupsItem): Promise<vscode.TreeItem> {
+        const treeItem = await element.getTreeItem();
+        treeItem.id = this.itemCache.getId(element);
+
+        // TODO: remove this when we're done working with ids
+        treeItem.tooltip = treeItem.id;
+        return treeItem;
     }
 
     async getChildren(element?: ResourceGroupsItem | undefined): Promise<ResourceGroupsItem[] | null | undefined> {

--- a/src/tree/v2/application/DefaultApplicationResourceItem.ts
+++ b/src/tree/v2/application/DefaultApplicationResourceItem.ts
@@ -6,12 +6,13 @@
 import * as vscode from 'vscode';
 import { ApplicationResource, ResourceModelBase } from '../../../api/v2/v2AzureResourcesApi';
 import { getIconPath } from '../../../utils/azureUtils';
+import { getApplicationResourceId } from '../../../utils/v2/getApplicationResourceId';
 
 export class DefaultApplicationResourceItem implements ResourceModelBase {
     constructor(private readonly resource: ApplicationResource) {
     }
 
-    public readonly id: string = this.resource.id;
+    public readonly id: string = getApplicationResourceId(this.resource.id);
 
     getChildren(): vscode.ProviderResult<DefaultApplicationResourceItem[]> {
         return undefined;

--- a/src/tree/v2/application/GroupingItem.ts
+++ b/src/tree/v2/application/GroupingItem.ts
@@ -34,7 +34,11 @@ export class GroupingItem implements ResourceGroupsItem {
         public readonly resources: ApplicationResource[]) {
     }
 
-    readonly id: string = this.label;
+    readonly id: string = `groupings/${this.label}`;
+
+    isAncestorOf(id: string): boolean {
+        return this.resources.some(resource => id === resource.id || id.startsWith(resource.id));
+    }
 
     async getChildren(): Promise<ResourceGroupsItem[] | undefined> {
         const sortedResources = this.resources.sort((a, b) => a.name.localeCompare(b.name));

--- a/src/tree/v2/application/GroupingItem.ts
+++ b/src/tree/v2/application/GroupingItem.ts
@@ -37,7 +37,7 @@ export class GroupingItem implements ResourceGroupsItem {
     readonly id: string = `groupings/${this.label}`;
 
     isAncestorOf(id: string): boolean {
-        return this.resources.some(resource => id === resource.id || id.startsWith(resource.id));
+        return this.resources.some(resource => id.startsWith(resource.id));
     }
 
     async getChildren(): Promise<ResourceGroupsItem[] | undefined> {
@@ -48,7 +48,7 @@ export class GroupingItem implements ResourceGroupsItem {
                 const resourceItem = await branchDataProvider.getResourceItem(resource);
 
                 const options = {
-                    contextValues: [ 'azureResource' ],
+                    contextValues: ['azureResource'],
                     defaultId: resource.id,
                     defaults: {
                         iconPath: getIconPath(resource.resourceType)

--- a/src/tree/v2/application/GroupingItem.ts
+++ b/src/tree/v2/application/GroupingItem.ts
@@ -36,10 +36,6 @@ export class GroupingItem implements ResourceGroupsItem {
 
     readonly id: string = `groupings/${this.label}`;
 
-    isAncestorOf(id: string): boolean {
-        return this.resources.some(resource => id.startsWith(resource.id));
-    }
-
     async getChildren(): Promise<ResourceGroupsItem[] | undefined> {
         const sortedResources = this.resources.sort((a, b) => a.name.localeCompare(b.name));
         const resourceItems = await Promise.all(sortedResources.map(

--- a/src/tree/v2/application/SubscriptionItem.ts
+++ b/src/tree/v2/application/SubscriptionItem.ts
@@ -28,7 +28,7 @@ export class SubscriptionItem implements ResourceGroupsItem {
         private readonly subscription: ApplicationSubscription) {
     }
 
-    public readonly id: string = this.subscription.subscriptionId;
+    public readonly id: string = `subscriptions/${this.subscription.subscriptionId}`;
 
     async getChildren(): Promise<ResourceGroupsItem[]> {
         let resources = await this.resourceProviderManager.getResources(this.subscription);
@@ -47,7 +47,6 @@ export class SubscriptionItem implements ResourceGroupsItem {
 
         treeItem.contextValue = 'azureextensionui.azureSubscription';
         treeItem.iconPath = treeUtils.getIconPath('azureSubscription');
-        treeItem.id = this.subscription.subscriptionId;
 
         return treeItem;
     }

--- a/src/utils/v2/getApplicationResourceId.ts
+++ b/src/utils/v2/getApplicationResourceId.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+/**
+ * @param resourceId Azure resource Id
+ * @returns Azure resource id minus the subscription part
+ */
+export function getApplicationResourceId(resourceId: string): string {
+    const splitId = resourceId.split(/(resourceGroups)/);
+    return splitId[1] + splitId[2];
+}


### PR DESCRIPTION
Cherry-picked non-compatibility related changes from #418.

Changed how we cache child -> parent relations. Instead of a map, I'm storing a reference to the parent on the child item itself. This way, no cache modification can accidentally remove a reference.