### PR TITLE
Expose registerActivity() from V2 API.

### DIFF
--- a/src/api/v2/v2AzureResourcesApi.ts
+++ b/src/api/v2/v2AzureResourcesApi.ts
@@ -5,6 +5,7 @@
 
 import type { Environment } from '@azure/ms-rest-azure-env';
 import { AzExtResourceType } from '@microsoft/vscode-azext-utils';
+import { Activity } from '@microsoft/vscode-azext-utils/hostapi';
 import * as vscode from 'vscode';
 
 /**
@@ -147,7 +148,7 @@ export interface AzureResourceType {
     /**
      * The (general) type of resource.
      */
-     readonly type: string;
+    readonly type: string;
 }
 
 /**
@@ -259,6 +260,13 @@ export type WorkspaceResourceBranchDataProvider<TModel extends WorkspaceResource
  * The current (v2) Azure Resources extension API.
  */
 export interface V2AzureResourcesApi extends AzureResourcesApiBase {
+    /**
+     * Registers an activity to appear in the activity window.
+     *
+     * @param activity The activity information to show.
+     */
+     registerActivity(activity: Activity): Promise<void>;
+
     /**
      * Registers a provider of application resources.
      *

--- a/src/api/v2/v2AzureResourcesApi.ts
+++ b/src/api/v2/v2AzureResourcesApi.ts
@@ -5,7 +5,7 @@
 
 import type { Environment } from '@azure/ms-rest-azure-env';
 import { AzExtResourceType } from '@microsoft/vscode-azext-utils';
-import { Activity } from '@microsoft/vscode-azext-utils/hostapi';
+import type { Activity } from '@microsoft/vscode-azext-utils/hostapi';
 import * as vscode from 'vscode';
 
 /**

--- a/src/api/v2/v2AzureResourcesApiImplementation.ts
+++ b/src/api/v2/v2AzureResourcesApiImplementation.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtResourceType } from '@microsoft/vscode-azext-utils';
+import { Activity } from '@microsoft/vscode-azext-utils/hostapi';
 import * as vscode from 'vscode';
+import { registerActivity } from '../../activityLog/registerActivity';
 import { ApplicationResourceBranchDataProviderManager } from '../../tree/v2/application/ApplicationResourceBranchDataProviderManager';
 import { WorkspaceResourceBranchDataProviderManager } from '../../tree/v2/workspace/WorkspaceResourceBranchDataProviderManager';
 import { ApplicationResourceProviderManager, WorkspaceResourceProviderManager } from './ResourceProviderManagers';
@@ -22,6 +24,10 @@ export class V2AzureResourcesApiImplementation implements V2AzureResourcesApi {
 
     get apiVersion(): string {
         return V2AzureResourcesApiImplementation.apiVersion;
+    }
+
+    registerActivity(activity: Activity): Promise<void> {
+        return registerActivity(activity);
     }
 
     registerApplicationResourceProvider(provider: ApplicationResourceProvider): vscode.Disposable {

--- a/src/api/v2/v2AzureResourcesApiWrapper.ts
+++ b/src/api/v2/v2AzureResourcesApiWrapper.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtResourceType, callWithTelemetryAndErrorHandlingSync } from '@microsoft/vscode-azext-utils';
+import { Activity } from '@microsoft/vscode-azext-utils/hostapi';
 import * as vscode from 'vscode';
 import { ApplicationResource, ApplicationResourceProvider, BranchDataProvider, ResourceModelBase, V2AzureResourcesApi, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
 
@@ -15,6 +16,10 @@ export class V2AzureResourcesApiWrapper implements V2AzureResourcesApi {
 
     get apiVersion(): string {
         return this.api.apiVersion;
+    }
+
+    registerActivity(activity: Activity): Promise<void> {
+        return this.callWithTelemetryAndErrorHandlingSync('v2.registerActivity', () => this.api.registerActivity(activity));
     }
 
     registerApplicationResourceProvider(provider: ApplicationResourceProvider): vscode.Disposable {


### PR DESCRIPTION
Expose the `registerActivity()` function from the V2 API. This eliminates the need for extensions to obtain references to both V1 and V2 APIs.