### PR TITLE
Expose and implement "View Properties" for application resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -350,7 +350,12 @@
                 },
                 {
                     "command": "azureResourceGroups.viewProperties",
-                    "when": "view == azureResourceGroups && viewItem =~ /azureResource(?!Type)/",
+                    "when": "view == azureResourceGroups && viewItem =~ /hasProperties/",
+                    "group": "9@1"
+                },
+                {
+                    "command": "azureResourceGroups.viewProperties",
+                    "when": "view == azureResourceGroups && viewItem =~ /azureResourceGroup/",
                     "group": "9@1"
                 },
                 {

--- a/src/api/v2/DefaultApplicationResourceProvider.ts
+++ b/src/api/v2/DefaultApplicationResourceProvider.ts
@@ -42,7 +42,8 @@ export class DefaultApplicationResourceProvider implements ApplicationResourcePr
             name: nonNullProp(resourceGroup, 'name'),
             azureResourceType: {
                 type: nonNullProp(resourceGroup, 'type').toLowerCase()
-            }
+            },
+            raw: resourceGroup,
         };
     }
 
@@ -63,7 +64,8 @@ export class DefaultApplicationResourceProvider implements ApplicationResourcePr
             resourceType: getAzExtResourceType({
                 type: nonNullProp(resource, 'type'),
                 kind: resource.kind
-            })
+            }),
+            raw: resource,
         };
     }
 }

--- a/src/api/v2/v2AzureResourcesApi.ts
+++ b/src/api/v2/v2AzureResourcesApi.ts
@@ -188,6 +188,23 @@ export interface ApplicationResource extends ResourceBase {
     readonly tags?: {
         [propertyName: string]: string;
     };
+
+    /**
+     * A copy of the raw resource.
+     */
+    readonly raw: {};
+}
+
+export interface ViewPropertiesModel {
+    /**
+     * File name displayed in VS Code.
+     */
+    label: string;
+
+    /**
+     * Raw data associated with the resource to populate the properties file.
+     */
+    data: {};
 }
 
 /**
@@ -205,6 +222,11 @@ export interface ApplicationResourceModel extends ResourceModelBase {
      * The URL of the area of Azure portal related to this item.
      */
     readonly portalUrl?: vscode.Uri;
+
+    /**
+     * Define to enable the "View Properties" command.
+     */
+    readonly viewProperties?: ViewPropertiesModel;
 }
 
 /**
@@ -265,7 +287,7 @@ export interface V2AzureResourcesApi extends AzureResourcesApiBase {
      *
      * @param activity The activity information to show.
      */
-     registerActivity(activity: Activity): Promise<void>;
+    registerActivity(activity: Activity): Promise<void>;
 
     /**
      * Registers a provider of application resources.

--- a/src/commands/viewProperties.ts
+++ b/src/commands/viewProperties.ts
@@ -4,13 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext, openReadOnlyJson } from '@microsoft/vscode-azext-utils';
-import { pickAppResource } from '../api/pickAppResource';
-import { AppResourceTreeItem } from '../tree/AppResourceTreeItem';
+import { randomUUID } from 'crypto';
+import { ApplicationResourceModel } from '../api/v2/v2AzureResourcesApi';
+import { localize } from '../utils/localize';
 
-export async function viewProperties(context: IActionContext, node?: AppResourceTreeItem): Promise<void> {
+export async function viewProperties(_context: IActionContext, node?: ApplicationResourceModel): Promise<void> {
     if (!node) {
-        node = await pickAppResource<AppResourceTreeItem>(context);
+        // TODO: Reenable this once we have a way to pick resources.
+        // node = await pickAppResource<AppResourceTreeItem>(context);
+
+        throw new Error(localize('commands.viewProperties.noSelectedResource', 'A resource must be selected.'));
     }
 
-    await openReadOnlyJson(node, node.data);
+    if (!node.viewProperties) {
+        throw new Error(localize('commands.viewProperties.noProperties', 'The selected resource has no properties to view.'));
+    }
+
+    await openReadOnlyJson({ fullId: node.id ?? randomUUID(), label: node.viewProperties.label }, node.viewProperties.data);
 }

--- a/src/tree/v2/BranchDataProviderItem.ts
+++ b/src/tree/v2/BranchDataProviderItem.ts
@@ -5,7 +5,7 @@
 
 import { randomUUID } from 'crypto';
 import * as vscode from 'vscode';
-import { ApplicationResourceModel, BranchDataProvider, ResourceBase, ResourceModelBase } from '../../api/v2/v2AzureResourcesApi';
+import { ApplicationResourceModel, BranchDataProvider, ResourceBase, ResourceModelBase, ViewPropertiesModel } from '../../api/v2/v2AzureResourcesApi';
 import { ResourceGroupsItem } from './ResourceGroupsItem';
 import { ResourceGroupsItemCache } from './ResourceGroupsItemCache';
 
@@ -14,6 +14,7 @@ export type BranchDataItemOptions = {
     defaultId?: string;
     defaults?: vscode.TreeItem;
     portalUrl?: vscode.Uri;
+    viewProperties?: ViewPropertiesModel;
 };
 
 /**
@@ -47,6 +48,7 @@ export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResour
     readonly id: string = this.branchItem.id ?? this?.options?.defaultId ?? randomUUID();
 
     readonly portalUrl: vscode.Uri | undefined = this.options?.portalUrl;
+    readonly viewProperties?: ViewPropertiesModel = this.options?.viewProperties;
 
     async getChildren(): Promise<ResourceGroupsItem[] | undefined> {
         const children = await this.branchDataProvider.getChildren(this.branchItem);
@@ -57,13 +59,18 @@ export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResour
         //       having to create specialized item types for application and workspace resources and their
         //       requisite factories.
 
-        return children?.map(child => factory(child, this.branchDataProvider, { portalUrl: (child as ApplicationResourceModel).portalUrl }));
+        return children?.map(child =>
+            factory(child, this.branchDataProvider, {
+                portalUrl: (child as ApplicationResourceModel).portalUrl,
+                viewProperties: (child as ApplicationResourceModel).viewProperties,
+            })
+        );
     }
 
     async getTreeItem(): Promise<vscode.TreeItem> {
         const treeItem = await this.branchDataProvider.getTreeItem(this.branchItem);
 
-        const contextValue = appendContextValues(treeItem.contextValue, this.options?.contextValues, this.portalUrl ? ['hasPortalUrl'] : undefined);
+        const contextValue = appendContextValues(treeItem.contextValue, this.options?.contextValues, this.getExtraContextValues());
 
         return {
             ...this.options?.defaults ?? {},
@@ -74,6 +81,17 @@ export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResour
 
     unwrap<T extends ResourceModelBase>(): T | undefined {
         return this.branchItem as T;
+    }
+
+    private getExtraContextValues(): string[] {
+        const extraValues: string[] = [];
+        if (this.portalUrl) {
+            extraValues.push('hasPortalUrl');
+        }
+        if (this.viewProperties) {
+            extraValues.push('hasProperties');
+        }
+        return extraValues;
     }
 }
 

--- a/src/tree/v2/application/GroupingItem.ts
+++ b/src/tree/v2/application/GroupingItem.ts
@@ -8,7 +8,7 @@ import { TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ApplicationResource, ApplicationResourceBranchDataProvider, ApplicationResourceModel, ApplicationSubscription } from '../../../api/v2/v2AzureResourcesApi';
 import { getIconPath } from '../../../utils/azureUtils';
-import { BranchDataItemFactory } from '../BranchDataProviderItem';
+import { BranchDataItemFactory, BranchDataItemOptions } from '../BranchDataProviderItem';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { ResourceGroupsTreeContext } from '../ResourceGroupsTreeContext';
 import { BranchDataProviderFactory } from './ApplicationResourceBranchDataProviderManager';
@@ -43,13 +43,17 @@ export class GroupingItem implements ResourceGroupsItem {
                 const branchDataProvider = this.branchDataProviderFactory(resource);
                 const resourceItem = await branchDataProvider.getResourceItem(resource);
 
-                const options = {
+                const options: BranchDataItemOptions = {
                     contextValues: ['azureResource'],
                     defaultId: resource.id,
                     defaults: {
                         iconPath: getIconPath(resource.resourceType)
                     },
-                    portalUrl: resourceItem.portalUrl ?? createPortalUrl(resource.subscription, resource.id)
+                    portalUrl: resourceItem.portalUrl ?? createPortalUrl(resource.subscription, resource.id),
+                    viewProperties: {
+                        label: resource.name,
+                        data: resource.raw
+                    }
                 };
 
                 return this.branchDataItemFactory(resourceItem, branchDataProvider, options);

--- a/src/tree/v2/application/GroupingItem.ts
+++ b/src/tree/v2/application/GroupingItem.ts
@@ -50,7 +50,7 @@ export class GroupingItem implements ResourceGroupsItem {
                         iconPath: getIconPath(resource.resourceType)
                     },
                     portalUrl: resourceItem.portalUrl ?? createPortalUrl(resource.subscription, resource.id),
-                    viewProperties: {
+                    viewProperties: resourceItem.viewProperties ?? {
                         label: resource.name,
                         data: resource.raw
                     }


### PR DESCRIPTION
Followed how Open in Portal was implemented in #419

The Resource Groups extension now exposes a "View Properties" command for all application resources. BranchDataProvider's have the option to override the properties. The command is also exposed if any child of an application resource sets the optional `ApplicationResourceModel.viewProperties` property.

Command for application resources without a registered BDP:
<img width="392" alt="image" src="https://user-images.githubusercontent.com/12476526/200984964-33c86900-1145-46f2-aabd-7abf02bcbfce.png">

Command for application resources with a registered BDP:
<img width="371" alt="image" src="https://user-images.githubusercontent.com/12476526/200985058-266820a9-2850-4b89-bdc6-44af424eac3b.png">

Command for arbitrary children that expose the viewProperties property:
<img width="352" alt="image" src="https://user-images.githubusercontent.com/12476526/200985344-7a10430e-6d56-4729-aa1e-beaf5d8aa0af.png">
