### PR TITLE
Separate contexts with semicolons

### DIFF
--- a/src/tree/v2/BranchDataProviderItem.ts
+++ b/src/tree/v2/BranchDataProviderItem.ts
@@ -27,12 +27,12 @@ export interface WrappedResourceModel {
 }
 
 function appendContextValues(originalValues: string | undefined, optionsValues: string[] | undefined, extraValues: string[] | undefined): string {
-    const set = new Set<string>(originalValues?.split(' ') ?? []);
+    const set = new Set<string>(originalValues?.split(';') ?? []);
 
     optionsValues?.forEach(value => set.add(value));
     extraValues?.forEach(value => set.add(value));
 
-    return Array.from(set).join(' ');
+    return Array.from(set).join(';');
 }
 
 export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResourceModel {


### PR DESCRIPTION
We've been using semicolons so far, so it's probably best to keep using them.