### PR TITLE
Add `findItemById` to ResourceGroups TDP

### DIFF
--- a/src/tree/v2/ResourceGroupsItemCache.ts
+++ b/src/tree/v2/ResourceGroupsItemCache.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../utils/localize';
-import { GroupingItem } from './application/GroupingItem';
 import { ResourceGroupsItem } from './ResourceGroupsItem';
 
 interface InternalResourceGroupsItem extends ResourceGroupsItem {
@@ -126,13 +125,6 @@ export class ResourceGroupsItemCache {
 
     getId(element: ResourceGroupsItem): string {
         return '/' + this.getPathForItem(element).join('/');
-    }
-
-    isAncestorOf(element: ResourceGroupsItem, id: string): boolean {
-        if (element instanceof GroupingItem) {
-            return element.resources.some(resource => id.startsWith(resource.id));
-        }
-        return id.startsWith(this.getId(element) + '/');
     }
 
     private createInternalResourceGroupsItem(child: ResourceGroupsItem, parent: ResourceGroupsItem): InternalResourceGroupsItem {

--- a/src/tree/v2/ResourceTreeDataProviderBase.ts
+++ b/src/tree/v2/ResourceTreeDataProviderBase.ts
@@ -98,5 +98,32 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
         return this.itemCache.getParentForItem(element);
     }
 
+    async findItemById(id: string): Promise<ResourceGroupsItem | undefined> {
+        let element: ResourceGroupsItem | undefined = undefined;
+
+        outerLoop: while (true) {
+            const children: ResourceGroupsItem[] | null | undefined = await this.getChildren(element);
+
+            if (!children) {
+                return;
+            }
+
+            for (const child of children) {
+                if (this.itemCache.getId(child) === id) {
+                    return child;
+                } else if (this.isAncestorOf(child, id)) {
+                    element = child;
+                    continue outerLoop;
+                }
+            }
+
+            return undefined;
+        }
+    }
+
+    protected isAncestorOf(element: ResourceGroupsItem, id: string): boolean {
+        return id.startsWith(this.itemCache.getId(element) + '/');
+    }
+
     protected abstract onGetChildren(element?: ResourceGroupsItem | undefined): Promise<ResourceGroupsItem[] | null | undefined>;
 }

--- a/src/tree/v2/application/ApplicationResourceTreeDataProvider.ts
+++ b/src/tree/v2/application/ApplicationResourceTreeDataProvider.ts
@@ -17,6 +17,7 @@ import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { ResourceGroupsItemCache } from '../ResourceGroupsItemCache';
 import { ResourceTreeDataProviderBase } from '../ResourceTreeDataProviderBase';
 import { ApplicationResourceGroupingManager } from './ApplicationResourceGroupingManager';
+import { GroupingItem } from './GroupingItem';
 import { SubscriptionItem } from './SubscriptionItem';
 
 export class ApplicationResourceTreeDataProvider extends ResourceTreeDataProviderBase {
@@ -157,6 +158,13 @@ export class ApplicationResourceTreeDataProvider extends ResourceTreeDataProvide
         }
 
         return undefined;
+    }
+
+    protected override isAncestorOf(element: ResourceGroupsItem, id: string): boolean {
+        if (element instanceof GroupingItem) {
+            return element.resources.some(resource => id.startsWith(resource.id));
+        }
+        return super.isAncestorOf(element, id)
     }
 
     private async getAzureAccountExtensionApi(): Promise<AzureAccountExtensionApi | undefined> {


### PR DESCRIPTION
I think this better fits here, than `findByIdExperience` in utils. For now, we'll only use this method for V1.5 extension compatibility and will not expose this in the V2 API.