### PR TITLE
Add `ApplicationResourceItem`

### DIFF
--- a/src/tree/v2/application/ApplicationResourceItem.ts
+++ b/src/tree/v2/application/ApplicationResourceItem.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { BranchDataProvider, ResourceBase, ResourceModelBase } from '../../../api/v2/v2AzureResourcesApi';
+import { BranchDataItemOptions, BranchDataProviderItem } from '../BranchDataProviderItem';
+import { ResourceGroupsItemCache } from '../ResourceGroupsItemCache';
+
+export class ApplicationResourceItem<T extends ResourceBase> extends BranchDataProviderItem {
+    constructor(
+        public readonly resource: T,
+        branchItem: ResourceModelBase,
+        branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>,
+        itemCache: ResourceGroupsItemCache,
+        options?: BranchDataItemOptions) {
+        super(branchItem, branchDataProvider, itemCache, options);
+    }
+}
+
+export type ResourceItemFactory<T extends ResourceBase> = (resource: T, branchItem: ResourceModelBase, branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>, options?: BranchDataItemOptions) => ApplicationResourceItem<T>;
+
+export function createResourceItemFactory<T extends ResourceBase>(itemCache: ResourceGroupsItemCache): ResourceItemFactory<T> {
+    return (resource, branchItem, branchDataProvider, options) => new ApplicationResourceItem(resource, branchItem, branchDataProvider, itemCache, options);
+}

--- a/src/tree/v2/application/GroupingItem.ts
+++ b/src/tree/v2/application/GroupingItem.ts
@@ -8,10 +8,11 @@ import { TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ApplicationResource, ApplicationResourceBranchDataProvider, ApplicationResourceModel, ApplicationSubscription } from '../../../api/v2/v2AzureResourcesApi';
 import { getIconPath } from '../../../utils/azureUtils';
-import { BranchDataItemFactory, BranchDataItemOptions } from '../BranchDataProviderItem';
+import { BranchDataItemOptions } from '../BranchDataProviderItem';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { ResourceGroupsTreeContext } from '../ResourceGroupsTreeContext';
 import { BranchDataProviderFactory } from './ApplicationResourceBranchDataProviderManager';
+import { ResourceItemFactory } from './ApplicationResourceItem';
 
 // TODO: This should be moved to the common library, for use by other extensions.
 function createPortalUrl(subscription: ApplicationSubscription, id: string, options?: OpenInPortalOptions): vscode.Uri {
@@ -26,7 +27,7 @@ export class GroupingItem implements ResourceGroupsItem {
 
     constructor(
         public readonly context: ResourceGroupsTreeContext,
-        private readonly branchDataItemFactory: BranchDataItemFactory,
+        private readonly resourceItemFactory: ResourceItemFactory<ApplicationResource>,
         private readonly branchDataProviderFactory: (ApplicationResource) => ApplicationResourceBranchDataProvider<ApplicationResourceModel>,
         private readonly contextValues: string[] | undefined,
         private readonly iconPath: TreeItemIconPath | undefined,
@@ -56,7 +57,7 @@ export class GroupingItem implements ResourceGroupsItem {
                     }
                 };
 
-                return this.branchDataItemFactory(resourceItem, branchDataProvider, options);
+                return this.resourceItemFactory(resource, resourceItem, branchDataProvider, options);
             }));
 
         return resourceItems;
@@ -87,6 +88,6 @@ export class GroupingItem implements ResourceGroupsItem {
 
 export type GroupingItemFactory = (context: ResourceGroupsTreeContext, contextValues: string[] | undefined, iconPath: TreeItemIconPath | undefined, label: string, resources: ApplicationResource[]) => GroupingItem;
 
-export function createGroupingItemFactory(branchDataItemFactory: BranchDataItemFactory, branchDataProviderFactory: BranchDataProviderFactory): GroupingItemFactory {
+export function createGroupingItemFactory(branchDataItemFactory: ResourceItemFactory<ApplicationResource>, branchDataProviderFactory: BranchDataProviderFactory): GroupingItemFactory {
     return (context, contextValues, iconPath, label, resources) => new GroupingItem(context, branchDataItemFactory, branchDataProviderFactory, contextValues, iconPath, label, resources);
 }

--- a/src/tree/v2/application/registerResourceGroupsTreeV2.ts
+++ b/src/tree/v2/application/registerResourceGroupsTreeV2.ts
@@ -5,11 +5,12 @@
 
 import * as vscode from 'vscode';
 import { ApplicationResourceProviderManager } from '../../../api/v2/ResourceProviderManagers';
-import { createBranchDataItemFactory } from '../BranchDataProviderItem';
+import { ApplicationResource } from '../../../api/v2/v2AzureResourcesApi';
 import { ResourceGroupsItemCache } from '../ResourceGroupsItemCache';
 import { localize } from './../../../utils/localize';
 import { ApplicationResourceBranchDataProviderManager } from './ApplicationResourceBranchDataProviderManager';
 import { ApplicationResourceGroupingManager } from './ApplicationResourceGroupingManager';
+import { createResourceItemFactory } from './ApplicationResourceItem';
 import { ApplicationResourceTreeDataProvider } from './ApplicationResourceTreeDataProvider';
 import { createGroupingItemFactory } from './GroupingItem';
 
@@ -19,7 +20,7 @@ export function registerResourceGroupsTreeV2(
     refreshEvent: vscode.Event<void>,
     resourceProviderManager: ApplicationResourceProviderManager): void {
     const itemCache = new ResourceGroupsItemCache();
-    const branchDataItemFactory = createBranchDataItemFactory(itemCache);
+    const branchDataItemFactory = createResourceItemFactory<ApplicationResource>(itemCache);
     const groupingItemFactory = createGroupingItemFactory(branchDataItemFactory, resource => branchDataProviderManager.getProvider(resource.resourceType));
     const resourceGroupingManager = new ApplicationResourceGroupingManager(groupingItemFactory);
 


### PR DESCRIPTION
Context https://github.com/microsoft/vscode-azureresourcegroups/pull/358#discussion_r1019549830

This makes it so that Application resource items all have the `resource` property defined and set to the `ApplicationResource`. Children will not have this property and will be instances of the base `BranchDataProviderItem`, while application resources will be `ApplicationResourceItem`s.

The `resource` property is needed by [QuickPickAppResourceStep](https://github.com/microsoft/vscode-azuretools/pull/1229/files#diff-d3a273a1f6a314889469732205ab9e72bb6664b6c344f89e60b2f0269cbf32edR19-R31)