### PR TITLE
Rename Application things to Azure things

### DIFF
--- a/src/AzExtWrapper.ts
+++ b/src/AzExtWrapper.ts
@@ -7,7 +7,7 @@ import { AzExtResourceType, IAzureQuickPickItem } from "@microsoft/vscode-azext-
 import { AzureExtensionApiProvider } from "@microsoft/vscode-azext-utils/api";
 import { AppResource } from "@microsoft/vscode-azext-utils/hostapi";
 import { commands, Extension, extensions } from "vscode";
-import { ApplicationResource } from './api/v2/v2AzureResourcesApi';
+import { AzureResource } from './api/v2/v2AzureResourcesApi';
 import { azureExtensions, IAzExtMetadata, IAzExtTutorial } from "./azureExtensions";
 import { contributesKey } from "./constants";
 
@@ -59,7 +59,7 @@ export class AzExtWrapper {
         return this._resourceTypes.some(rt => rt === resource.azExtResourceType);
     }
 
-    public matchesApplicationResourceType(resource: ApplicationResource): boolean {
+    public matchesApplicationResourceType(resource: AzureResource): boolean {
         return this._resourceTypes.some(rt => rt === resource.resourceType);
     }
 

--- a/src/api/v2/DefaultApplicationResourceProvider.ts
+++ b/src/api/v2/DefaultApplicationResourceProvider.ts
@@ -9,12 +9,12 @@ import { callWithTelemetryAndErrorHandling, getAzExtResourceType, IActionContext
 import * as vscode from 'vscode';
 import { createResourceClient } from '../../utils/azureClients';
 import { createSubscriptionContext } from '../../utils/v2/credentialsUtils';
-import { ApplicationResource, ApplicationResourceProvider, ApplicationSubscription } from './v2AzureResourcesApi';
+import { AzureResource, AzureResourceProvider, AzureSubscription } from './v2AzureResourcesApi';
 
-export class DefaultApplicationResourceProvider implements ApplicationResourceProvider {
-    private readonly onDidChangeResourceEmitter = new vscode.EventEmitter<ApplicationResource | undefined>();
+export class DefaultApplicationResourceProvider implements AzureResourceProvider {
+    private readonly onDidChangeResourceEmitter = new vscode.EventEmitter<AzureResource | undefined>();
 
-    getResources(subscription: ApplicationSubscription): Promise<ApplicationResource[] | undefined> {
+    getResources(subscription: AzureSubscription): Promise<AzureResource[] | undefined> {
         return callWithTelemetryAndErrorHandling(
             'provideResources',
             async (context: IActionContext) => {
@@ -34,7 +34,7 @@ export class DefaultApplicationResourceProvider implements ApplicationResourcePr
 
     onDidChangeResource = this.onDidChangeResourceEmitter.event;
 
-    private fromResourceGroup(subscription: ApplicationSubscription, resourceGroup: ResourceGroup): ApplicationResource {
+    private fromResourceGroup(subscription: AzureSubscription, resourceGroup: ResourceGroup): AzureResource {
         return {
             ...resourceGroup,
             subscription,
@@ -47,7 +47,7 @@ export class DefaultApplicationResourceProvider implements ApplicationResourcePr
         };
     }
 
-    private createAppResource(subscription: ApplicationSubscription, resource: GenericResource): ApplicationResource {
+    private createAppResource(subscription: AzureSubscription, resource: GenericResource): AzureResource {
         const resourceId = nonNullProp(resource, 'id');
 
         return {

--- a/src/api/v2/ResourceProviderManagers.ts
+++ b/src/api/v2/ResourceProviderManagers.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { ApplicationResource, ApplicationResourceProvider, ApplicationSubscription, ResourceBase, ResourceProvider, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
+import { AzureResource, AzureResourceProvider, AzureSubscription, ResourceBase, ResourceProvider, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
 
 export function isArray<T>(maybeArray: T[] | null | undefined): maybeArray is T[] {
     return Array.isArray(maybeArray);
@@ -81,7 +81,7 @@ class ResourceProviderManager<TResourceSource, TResource extends ResourceBase, T
 // NOTE: TS doesn't seem to like exporting a type alias (i.e. you cannot instantiate it),
 //       so we still have to extend the class.
 
-export class ApplicationResourceProviderManager extends ResourceProviderManager<ApplicationSubscription, ApplicationResource, ApplicationResourceProvider> {
+export class ApplicationResourceProviderManager extends ResourceProviderManager<AzureSubscription, AzureResource, AzureResourceProvider> {
 }
 
 export class WorkspaceResourceProviderManager extends ResourceProviderManager<vscode.WorkspaceFolder, WorkspaceResource, WorkspaceResourceProvider> {

--- a/src/api/v2/v2AzureResourcesApi.ts
+++ b/src/api/v2/v2AzureResourcesApi.ts
@@ -83,7 +83,7 @@ export interface BranchDataProvider<TResource extends ResourceBase, TModel exten
 /**
  * Represents a means of obtaining authentication data for an application subscription.
  */
-export interface ApplicationAuthentication {
+export interface AzureAuthentication {
     /**
      * Gets a VS Code authentication session for an application subscription.
      *
@@ -97,11 +97,11 @@ export interface ApplicationAuthentication {
 /**
  * Represents an Azure subscription.
  */
-export interface ApplicationSubscription {
+export interface AzureSubscription {
     /**
      * Access to the authentication session associated with this subscription.
      */
-    readonly authentication: ApplicationAuthentication;
+    readonly authentication: AzureAuthentication;
 
     /**
      * The Azure environment to which this subscription belongs.
@@ -147,7 +147,7 @@ export interface AzureResourceType {
 /**
  * Represents an individual resource in Azure.
  */
-export interface ApplicationResource extends ResourceBase {
+export interface AzureResource extends ResourceBase {
     /**
      * The Azure-designated type of this resource.
      */
@@ -173,7 +173,7 @@ export interface ApplicationResource extends ResourceBase {
     /**
      * The Azure subscription to which this resource belongs.
      */
-    readonly subscription: ApplicationSubscription;
+    readonly subscription: AzureSubscription;
 
     /**
      * The tags associated with this resource.
@@ -203,7 +203,7 @@ export interface ViewPropertiesModel {
 /**
  * Represents a model of an individual application resource or its child items.
  */
-export interface ApplicationResourceModel extends ResourceModelBase {
+export interface AzureResourceModel extends ResourceModelBase {
     /**
      * The Azure ID of this resource.
      *
@@ -225,12 +225,12 @@ export interface ApplicationResourceModel extends ResourceModelBase {
 /**
  * A provider for supplying items for the application resource tree (e.g. Cosmos DB, Storage, etc.).
  */
-export type ApplicationResourceProvider = ResourceProvider<ApplicationSubscription, ApplicationResource>;
+export type AzureResourceProvider = ResourceProvider<AzureSubscription, AzureResource>;
 
 /**
  * A provider for visualizing items in the application resource tree (e.g. Cosmos DB, Storage, etc.).
  */
-export type ApplicationResourceBranchDataProvider<TModel extends ApplicationResourceModel> = BranchDataProvider<ApplicationResource, TModel>;
+export type AzureResourceBranchDataProvider<TModel extends AzureResourceModel> = BranchDataProvider<AzureResource, TModel>;
 
 /**
  * Respresents a specific type of workspace resource.
@@ -289,7 +289,7 @@ export interface V2AzureResourcesApi extends AzureResourcesApiBase {
      *
      * @returns A disposable that unregisters the provider when disposed.
      */
-    registerApplicationResourceProvider(provider: ApplicationResourceProvider): vscode.Disposable;
+    registerApplicationResourceProvider(provider: AzureResourceProvider): vscode.Disposable;
 
     /**
      * Registers an application resource branch data provider.
@@ -299,7 +299,7 @@ export interface V2AzureResourcesApi extends AzureResourcesApiBase {
      *
      * @returns A disposable that unregisters the provider.
      */
-    registerApplicationResourceBranchDataProvider<TModel extends ApplicationResourceModel>(type: AzExtResourceType, provider: ApplicationResourceBranchDataProvider<TModel>): vscode.Disposable;
+    registerApplicationResourceBranchDataProvider<TModel extends AzureResourceModel>(type: AzExtResourceType, provider: AzureResourceBranchDataProvider<TModel>): vscode.Disposable;
 
     /**
      * Registers a provider of workspace resources.

--- a/src/api/v2/v2AzureResourcesApiImplementation.ts
+++ b/src/api/v2/v2AzureResourcesApiImplementation.ts
@@ -7,17 +7,17 @@ import { AzExtResourceType } from '@microsoft/vscode-azext-utils';
 import { Activity } from '@microsoft/vscode-azext-utils/hostapi';
 import * as vscode from 'vscode';
 import { registerActivity } from '../../activityLog/registerActivity';
-import { ApplicationResourceBranchDataProviderManager } from '../../tree/v2/application/ApplicationResourceBranchDataProviderManager';
+import { AzureResourceBranchDataProviderManager } from '../../tree/v2/azure/AzureResourceBranchDataProviderManager';
 import { WorkspaceResourceBranchDataProviderManager } from '../../tree/v2/workspace/WorkspaceResourceBranchDataProviderManager';
 import { ApplicationResourceProviderManager, WorkspaceResourceProviderManager } from './ResourceProviderManagers';
-import { ApplicationResource, ApplicationResourceProvider, BranchDataProvider, ResourceModelBase, V2AzureResourcesApi, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
+import { AzureResource, AzureResourceProvider, BranchDataProvider, ResourceModelBase, V2AzureResourcesApi, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
 
 export class V2AzureResourcesApiImplementation implements V2AzureResourcesApi {
     public static apiVersion: string = '2.0.0';
 
     constructor(
         private readonly applicationResourceProviderManager: ApplicationResourceProviderManager,
-        private readonly applicationResourceBranchDataProviderManager: ApplicationResourceBranchDataProviderManager,
+        private readonly applicationResourceBranchDataProviderManager: AzureResourceBranchDataProviderManager,
         private readonly workspaceResourceProviderManager: WorkspaceResourceProviderManager,
         private readonly workspaceResourceBranchDataProviderManager: WorkspaceResourceBranchDataProviderManager) {
     }
@@ -30,13 +30,13 @@ export class V2AzureResourcesApiImplementation implements V2AzureResourcesApi {
         return registerActivity(activity);
     }
 
-    registerApplicationResourceProvider(provider: ApplicationResourceProvider): vscode.Disposable {
+    registerApplicationResourceProvider(provider: AzureResourceProvider): vscode.Disposable {
         this.applicationResourceProviderManager.addResourceProvider(provider);
 
         return new vscode.Disposable(() => this.applicationResourceProviderManager.removeResourceProvider(provider));
     }
 
-    registerApplicationResourceBranchDataProvider<T extends ResourceModelBase>(type: AzExtResourceType, provider: BranchDataProvider<ApplicationResource, T>): vscode.Disposable {
+    registerApplicationResourceBranchDataProvider<T extends ResourceModelBase>(type: AzExtResourceType, provider: BranchDataProvider<AzureResource, T>): vscode.Disposable {
         this.applicationResourceBranchDataProviderManager.addProvider(type, provider);
 
         return new vscode.Disposable(() => this.applicationResourceBranchDataProviderManager.removeProvider(type));

--- a/src/api/v2/v2AzureResourcesApiWrapper.ts
+++ b/src/api/v2/v2AzureResourcesApiWrapper.ts
@@ -6,7 +6,7 @@
 import { AzExtResourceType, callWithTelemetryAndErrorHandlingSync } from '@microsoft/vscode-azext-utils';
 import { Activity } from '@microsoft/vscode-azext-utils/hostapi';
 import * as vscode from 'vscode';
-import { ApplicationResource, ApplicationResourceProvider, BranchDataProvider, ResourceModelBase, V2AzureResourcesApi, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
+import { AzureResource, AzureResourceProvider, BranchDataProvider, ResourceModelBase, V2AzureResourcesApi, WorkspaceResource, WorkspaceResourceProvider } from './v2AzureResourcesApi';
 
 export class V2AzureResourcesApiWrapper implements V2AzureResourcesApi {
     constructor(
@@ -22,11 +22,11 @@ export class V2AzureResourcesApiWrapper implements V2AzureResourcesApi {
         return this.callWithTelemetryAndErrorHandlingSync('v2.registerActivity', () => this.api.registerActivity(activity));
     }
 
-    registerApplicationResourceProvider(provider: ApplicationResourceProvider): vscode.Disposable {
+    registerApplicationResourceProvider(provider: AzureResourceProvider): vscode.Disposable {
         return this.callWithTelemetryAndErrorHandlingSync('v2.registerApplicationResourceProvider', () => this.api.registerApplicationResourceProvider(provider));
     }
 
-    registerApplicationResourceBranchDataProvider<T extends ResourceModelBase>(type: AzExtResourceType, provider: BranchDataProvider<ApplicationResource, T>): vscode.Disposable {
+    registerApplicationResourceBranchDataProvider<T extends ResourceModelBase>(type: AzExtResourceType, provider: BranchDataProvider<AzureResource, T>): vscode.Disposable {
         return this.callWithTelemetryAndErrorHandlingSync('v2.registerApplicationResourceBranchDataProvider', () => this.api.registerApplicationResourceBranchDataProvider(type, provider));
     }
 

--- a/src/commands/deleteResourceGroup/v2/deleteResourceGroupV2.ts
+++ b/src/commands/deleteResourceGroup/v2/deleteResourceGroupV2.ts
@@ -5,7 +5,7 @@
 
 import { AzureWizard, IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { ResourceGroupTreeItem } from '../../../tree/ResourceGroupTreeItem';
-import { GroupingItem } from '../../../tree/v2/application/GroupingItem';
+import { GroupingItem } from '../../../tree/v2/azure/GroupingItem';
 import { createActivityContext } from '../../../utils/activityUtils';
 import { localize } from '../../../utils/localize';
 import { settingUtils } from '../../../utils/settingUtils';

--- a/src/commands/viewProperties.ts
+++ b/src/commands/viewProperties.ts
@@ -5,10 +5,10 @@
 
 import { IActionContext, openReadOnlyJson } from '@microsoft/vscode-azext-utils';
 import { randomUUID } from 'crypto';
-import { ApplicationResourceModel } from '../api/v2/v2AzureResourcesApi';
+import { AzureResourceModel } from '../api/v2/v2AzureResourcesApi';
 import { localize } from '../utils/localize';
 
-export async function viewProperties(_context: IActionContext, node?: ApplicationResourceModel): Promise<void> {
+export async function viewProperties(_context: IActionContext, node?: AzureResourceModel): Promise<void> {
     if (!node) {
         // TODO: Reenable this once we have a way to pick resources.
         // node = await pickAppResource<AppResourceTreeItem>(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,9 +34,9 @@ import { wrapperResolver } from './resolvers/WrapperResolver';
 import { AzureAccountTreeItem } from './tree/AzureAccountTreeItem';
 import { GroupTreeItemBase } from './tree/GroupTreeItemBase';
 import { HelpTreeItem } from './tree/HelpTreeItem';
-import { ApplicationResourceBranchDataProviderManager } from './tree/v2/application/ApplicationResourceBranchDataProviderManager';
-import { DefaultApplicationResourceBranchDataProvider } from './tree/v2/application/DefaultApplicationResourceBranchDataProvider';
-import { registerResourceGroupsTreeV2 } from './tree/v2/application/registerResourceGroupsTreeV2';
+import { AzureResourceBranchDataProviderManager } from './tree/v2/azure/AzureResourceBranchDataProviderManager';
+import { DefaultAzureResourceBranchDataProvider } from './tree/v2/azure/DefaultAzureResourceBranchDataProvider';
+import { registerResourceGroupsTreeV2 } from './tree/v2/azure/registerResourceGroupsTreeV2';
 import { registerWorkspaceTreeV2 } from './tree/v2/workspace/registerWorkspaceTreeV2';
 import { WorkspaceDefaultBranchDataProvider } from './tree/v2/workspace/WorkspaceDefaultBranchDataProvider';
 import { WorkspaceResourceBranchDataProviderManager } from './tree/v2/workspace/WorkspaceResourceBranchDataProviderManager';
@@ -116,8 +116,8 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
 
     const extensionManager = new ResourceGroupsExtensionManager()
 
-    const branchDataProviderManager = new ApplicationResourceBranchDataProviderManager(
-        new DefaultApplicationResourceBranchDataProvider(),
+    const branchDataProviderManager = new AzureResourceBranchDataProviderManager(
+        new DefaultAzureResourceBranchDataProvider(),
         type => void extensionManager.activateApplicationResourceBranchDataProvider(type));
 
     context.subscriptions.push(branchDataProviderManager);

--- a/src/tree/v2/BranchDataProviderItem.ts
+++ b/src/tree/v2/BranchDataProviderItem.ts
@@ -5,7 +5,7 @@
 
 import { randomUUID } from 'crypto';
 import * as vscode from 'vscode';
-import { ApplicationResourceModel, BranchDataProvider, ResourceBase, ResourceModelBase, ViewPropertiesModel } from '../../api/v2/v2AzureResourcesApi';
+import { AzureResourceModel, BranchDataProvider, ResourceBase, ResourceModelBase, ViewPropertiesModel } from '../../api/v2/v2AzureResourcesApi';
 import { BranchDataItemCache } from './BranchDataItemCache';
 import { ResourceGroupsItem } from './ResourceGroupsItem';
 
@@ -61,8 +61,8 @@ export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResour
 
         return children?.map(child =>
             factory(child, this.branchDataProvider, {
-                portalUrl: (child as ApplicationResourceModel).portalUrl,
-                viewProperties: (child as ApplicationResourceModel).viewProperties,
+                portalUrl: (child as AzureResourceModel).portalUrl,
+                viewProperties: (child as AzureResourceModel).viewProperties,
             })
         );
     }

--- a/src/tree/v2/azure/AzureResourceBranchDataProviderManager.ts
+++ b/src/tree/v2/azure/AzureResourceBranchDataProviderManager.ts
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtResourceType } from "@microsoft/vscode-azext-utils";
-import { ApplicationResource, BranchDataProvider, ResourceModelBase } from "../../../api/v2/v2AzureResourcesApi";
+import { AzureResource, BranchDataProvider, ResourceModelBase } from "../../../api/v2/v2AzureResourcesApi";
 import { ResourceBranchDataProviderManagerBase } from '../ResourceBranchDataProviderManagerBase';
 
-export class ApplicationResourceBranchDataProviderManager extends ResourceBranchDataProviderManagerBase<AzExtResourceType, BranchDataProvider<ApplicationResource, ResourceModelBase>>{
+export class AzureResourceBranchDataProviderManager extends ResourceBranchDataProviderManagerBase<AzExtResourceType, BranchDataProvider<AzureResource, ResourceModelBase>>{
     constructor(
-        defaultProvider: BranchDataProvider<ApplicationResource, ResourceModelBase>,
+        defaultProvider: BranchDataProvider<AzureResource, ResourceModelBase>,
         extensionActivator: (type: AzExtResourceType) => void
     ) {
         super(
@@ -19,5 +19,5 @@ export class ApplicationResourceBranchDataProviderManager extends ResourceBranch
     }
 }
 
-export type BranchDataProviderFactory = (resource: ApplicationResource) => BranchDataProvider<ApplicationResource, ResourceModelBase>;
+export type BranchDataProviderFactory = (resource: AzureResource) => BranchDataProvider<AzureResource, ResourceModelBase>;
 

--- a/src/tree/v2/azure/AzureResourceGroupingManager.ts
+++ b/src/tree/v2/azure/AzureResourceGroupingManager.ts
@@ -5,7 +5,7 @@
 
 import { AzExtResourceType, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
-import { ApplicationResource } from '../../../api/v2/v2AzureResourcesApi';
+import { AzureResource } from '../../../api/v2/v2AzureResourcesApi';
 import { azureExtensions } from '../../../azureExtensions';
 import { GroupBySettings } from '../../../commands/explorer/groupBy';
 import { ext } from '../../../extensionVariables';
@@ -19,7 +19,7 @@ import { GroupingItem, GroupingItemFactory } from './GroupingItem';
 
 const unknownLabel = localize('unknown', 'Unknown');
 
-export class ApplicationResourceGroupingManager extends vscode.Disposable {
+export class AzureResourceGroupingManager extends vscode.Disposable {
     private readonly onDidChangeGroupingEmitter = new vscode.EventEmitter<void>();
     private readonly configSubscription: vscode.Disposable;
 
@@ -42,7 +42,7 @@ export class ApplicationResourceGroupingManager extends vscode.Disposable {
         return this.onDidChangeGroupingEmitter.event;
     }
 
-    groupResources(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: ApplicationResource[]): GroupingItem[] {
+    groupResources(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: AzureResource[]): GroupingItem[] {
         const groupBy = settingUtils.getWorkspaceSetting<string>('groupBy');
 
         if (groupBy?.startsWith('armTag')) {
@@ -67,7 +67,7 @@ export class ApplicationResourceGroupingManager extends vscode.Disposable {
         }
     }
 
-    private groupBy(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: ApplicationResource[], keySelector: (resource: ApplicationResource) => string, labelSelector: (key: string) => string, iconSelector: (key: string) => TreeItemIconPath | undefined, initialGrouping?: { [key: string]: ApplicationResource[] }, contextValues?: string[]): GroupingItem[] {
+    private groupBy(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: AzureResource[], keySelector: (resource: AzureResource) => string, labelSelector: (key: string) => string, iconSelector: (key: string) => TreeItemIconPath | undefined, initialGrouping?: { [key: string]: AzureResource[] }, contextValues?: string[]): GroupingItem[] {
         initialGrouping = initialGrouping ?? {};
 
         const map = resources.reduce(
@@ -96,7 +96,7 @@ export class ApplicationResourceGroupingManager extends vscode.Disposable {
         });
     }
 
-    private groupByArmTag(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: ApplicationResource[], tag: string): GroupingItem[] {
+    private groupByArmTag(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: AzureResource[], tag: string): GroupingItem[] {
         const ungroupedKey = 'ungrouped';
         return this.groupBy(
             parent,
@@ -107,7 +107,7 @@ export class ApplicationResourceGroupingManager extends vscode.Disposable {
             key => new vscode.ThemeIcon(key !== ungroupedKey ? 'tag' : 'json'));
     }
 
-    private groupByLocation(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: ApplicationResource[]): GroupingItem[] {
+    private groupByLocation(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: AzureResource[]): GroupingItem[] {
         return this.groupBy(
             parent,
             context,
@@ -117,13 +117,13 @@ export class ApplicationResourceGroupingManager extends vscode.Disposable {
             () => new vscode.ThemeIcon('globe'));
     }
 
-    private groupByResourceGroup(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: ApplicationResource[]): GroupingItem[] {
-        const resourceGroups: ApplicationResource[] = [];
-        const nonResourceGroups: ApplicationResource[] = [];
+    private groupByResourceGroup(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: AzureResource[]): GroupingItem[] {
+        const resourceGroups: AzureResource[] = [];
+        const nonResourceGroups: AzureResource[] = [];
 
         resources.forEach(resource => resource.azureResourceType.type === 'microsoft.resources/resourcegroups' ? resourceGroups.push(resource) : nonResourceGroups.push(resource));
 
-        const keySelector: (resource: ApplicationResource) => string = resource => resource.resourceGroup?.toLowerCase() ?? unknownLabel; // TODO: Is resource group ever undefined? Should resource group be normalized on creation?
+        const keySelector: (resource: AzureResource) => string = resource => resource.resourceGroup?.toLowerCase() ?? unknownLabel; // TODO: Is resource group ever undefined? Should resource group be normalized on creation?
 
         const initialGrouping = resourceGroups.reduce(
             (previous, next) => {
@@ -146,7 +146,7 @@ export class ApplicationResourceGroupingManager extends vscode.Disposable {
         return groupedResources;
     }
 
-    private groupByResourceType(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: ApplicationResource[]): GroupingItem[] {
+    private groupByResourceType(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: AzureResource[]): GroupingItem[] {
         const initialGrouping = {};
 
         // Pre-populate the initial grouping with the supported resource types...

--- a/src/tree/v2/azure/AzureResourceItem.ts
+++ b/src/tree/v2/azure/AzureResourceItem.ts
@@ -9,7 +9,7 @@ import { BranchDataItemCache } from '../BranchDataItemCache';
 import { BranchDataItemOptions, BranchDataProviderItem } from '../BranchDataProviderItem';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 
-export class ApplicationResourceItem<T extends ResourceBase> extends BranchDataProviderItem {
+export class AzureResourceItem<T extends ResourceBase> extends BranchDataProviderItem {
     constructor(
         public readonly resource: T,
         branchItem: ResourceModelBase,
@@ -33,8 +33,8 @@ export class ApplicationResourceItem<T extends ResourceBase> extends BranchDataP
     }
 }
 
-export type ResourceItemFactory<T extends ResourceBase> = (resource: T, branchItem: ResourceModelBase, branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>, parent?: ResourceGroupsItem, options?: BranchDataItemOptions) => ApplicationResourceItem<T>;
+export type ResourceItemFactory<T extends ResourceBase> = (resource: T, branchItem: ResourceModelBase, branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>, parent?: ResourceGroupsItem, options?: BranchDataItemOptions) => AzureResourceItem<T>;
 
 export function createResourceItemFactory<T extends ResourceBase>(itemCache: BranchDataItemCache): ResourceItemFactory<T> {
-    return (resource, branchItem, branchDataProvider, parent, options) => new ApplicationResourceItem(resource, branchItem, branchDataProvider, itemCache, parent, options);
+    return (resource, branchItem, branchDataProvider, parent, options) => new AzureResourceItem(resource, branchItem, branchDataProvider, itemCache, parent, options);
 }

--- a/src/tree/v2/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/v2/azure/AzureResourceTreeDataProvider.ts
@@ -16,11 +16,11 @@ import { BranchDataItemCache } from '../BranchDataItemCache';
 import { GenericItem } from '../GenericItem';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { ResourceTreeDataProviderBase } from '../ResourceTreeDataProviderBase';
-import { ApplicationResourceGroupingManager } from './ApplicationResourceGroupingManager';
+import { AzureResourceGroupingManager } from './AzureResourceGroupingManager';
 import { GroupingItem } from './GroupingItem';
 import { SubscriptionItem } from './SubscriptionItem';
 
-export class ApplicationResourceTreeDataProvider extends ResourceTreeDataProviderBase {
+export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase {
     private readonly groupingChangeSubscription: vscode.Disposable;
 
     private api: AzureAccountExtensionApi | undefined;
@@ -31,7 +31,7 @@ export class ApplicationResourceTreeDataProvider extends ResourceTreeDataProvide
         onDidChangeBranchTreeData: vscode.Event<void | ResourceModelBase | ResourceModelBase[] | null | undefined>,
         itemCache: BranchDataItemCache,
         onRefresh: vscode.Event<void>,
-        private readonly resourceGroupingManager: ApplicationResourceGroupingManager,
+        private readonly resourceGroupingManager: AzureResourceGroupingManager,
         private readonly resourceProviderManager: ApplicationResourceProviderManager) {
         super(
             itemCache,

--- a/src/tree/v2/azure/DefaultApplicationResourceItem.ts
+++ b/src/tree/v2/azure/DefaultApplicationResourceItem.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { ApplicationResource } from '../../../api/v2/v2AzureResourcesApi';
+import { AzureResource } from '../../../api/v2/v2AzureResourcesApi';
 import { AzExtWrapper, getAzureExtensions } from '../../../AzExtWrapper';
 import { getIconPath } from '../../../utils/azureUtils';
 import { localize } from "../../../utils/localize";
@@ -14,7 +14,7 @@ import { ResourceGroupsItem } from '../ResourceGroupsItem';
 export class DefaultApplicationResourceItem implements ResourceGroupsItem {
     private readonly resourceTypeExtension: AzExtWrapper | undefined;
 
-    constructor(private readonly resource: ApplicationResource) {
+    constructor(private readonly resource: AzureResource) {
         this.resourceTypeExtension = getAzureExtensions().find(ext => ext.matchesApplicationResourceType(resource));
     }
 

--- a/src/tree/v2/azure/DefaultAzureResourceBranchDataProvider.ts
+++ b/src/tree/v2/azure/DefaultAzureResourceBranchDataProvider.ts
@@ -4,15 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { ApplicationResource, ApplicationResourceModel, BranchDataProvider } from '../../../api/v2/v2AzureResourcesApi';
+import { AzureResource, AzureResourceModel, BranchDataProvider } from '../../../api/v2/v2AzureResourcesApi';
 import { DefaultApplicationResourceItem } from './DefaultApplicationResourceItem';
 
-export class DefaultApplicationResourceBranchDataProvider implements BranchDataProvider<ApplicationResource, ApplicationResourceModel> {
-    getChildren(element: DefaultApplicationResourceItem): vscode.ProviderResult<ApplicationResourceModel[]> {
+export class DefaultAzureResourceBranchDataProvider implements BranchDataProvider<AzureResource, AzureResourceModel> {
+    getChildren(element: DefaultApplicationResourceItem): vscode.ProviderResult<AzureResourceModel[]> {
         return element.getChildren();
     }
 
-    getResourceItem(element: ApplicationResource): DefaultApplicationResourceItem | Thenable<DefaultApplicationResourceItem> {
+    getResourceItem(element: AzureResource): DefaultApplicationResourceItem | Thenable<DefaultApplicationResourceItem> {
         return new DefaultApplicationResourceItem(element);
     }
 

--- a/src/tree/v2/azure/GroupingItem.ts
+++ b/src/tree/v2/azure/GroupingItem.ts
@@ -6,16 +6,16 @@
 import { OpenInPortalOptions } from '@microsoft/vscode-azext-azureutils';
 import { TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
-import { ApplicationResource, ApplicationResourceBranchDataProvider, ApplicationResourceModel, ApplicationSubscription } from '../../../api/v2/v2AzureResourcesApi';
+import { AzureResource, AzureResourceBranchDataProvider, AzureResourceModel, AzureSubscription } from '../../../api/v2/v2AzureResourcesApi';
 import { getIconPath } from '../../../utils/azureUtils';
 import { BranchDataItemOptions } from '../BranchDataProviderItem';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { ResourceGroupsTreeContext } from '../ResourceGroupsTreeContext';
-import { BranchDataProviderFactory } from './ApplicationResourceBranchDataProviderManager';
-import { ResourceItemFactory } from './ApplicationResourceItem';
+import { BranchDataProviderFactory } from './AzureResourceBranchDataProviderManager';
+import { ResourceItemFactory } from './AzureResourceItem';
 
 // TODO: This should be moved to the common library, for use by other extensions.
-function createPortalUrl(subscription: ApplicationSubscription, id: string, options?: OpenInPortalOptions): vscode.Uri {
+function createPortalUrl(subscription: AzureSubscription, id: string, options?: OpenInPortalOptions): vscode.Uri {
     const queryPrefix: string = (options && options.queryPrefix) ? `?${options.queryPrefix}` : '';
     const url: string = `${subscription.environment.portalUrl}/${queryPrefix}#@${subscription.tenantId}/resource${id}`;
 
@@ -27,12 +27,12 @@ export class GroupingItem implements ResourceGroupsItem {
 
     constructor(
         public readonly context: ResourceGroupsTreeContext,
-        private readonly resourceItemFactory: ResourceItemFactory<ApplicationResource>,
-        private readonly branchDataProviderFactory: (ApplicationResource) => ApplicationResourceBranchDataProvider<ApplicationResourceModel>,
+        private readonly resourceItemFactory: ResourceItemFactory<AzureResource>,
+        private readonly branchDataProviderFactory: (ApplicationResource) => AzureResourceBranchDataProvider<AzureResourceModel>,
         private readonly contextValues: string[] | undefined,
         private readonly iconPath: TreeItemIconPath | undefined,
         public readonly label: string,
-        public readonly resources: ApplicationResource[],
+        public readonly resources: AzureResource[],
         public readonly parent?: ResourceGroupsItem) {
     }
 
@@ -92,8 +92,8 @@ export class GroupingItem implements ResourceGroupsItem {
     }
 }
 
-export type GroupingItemFactory = (context: ResourceGroupsTreeContext, contextValues: string[] | undefined, iconPath: TreeItemIconPath | undefined, label: string, resources: ApplicationResource[], parent: ResourceGroupsItem,) => GroupingItem;
+export type GroupingItemFactory = (context: ResourceGroupsTreeContext, contextValues: string[] | undefined, iconPath: TreeItemIconPath | undefined, label: string, resources: AzureResource[], parent: ResourceGroupsItem,) => GroupingItem;
 
-export function createGroupingItemFactory(branchDataItemFactory: ResourceItemFactory<ApplicationResource>, branchDataProviderFactory: BranchDataProviderFactory): GroupingItemFactory {
+export function createGroupingItemFactory(branchDataItemFactory: ResourceItemFactory<AzureResource>, branchDataProviderFactory: BranchDataProviderFactory): GroupingItemFactory {
     return (context, contextValues, iconPath, label, resources, parent) => new GroupingItem(context, branchDataItemFactory, branchDataProviderFactory, contextValues, iconPath, label, resources, parent);
 }

--- a/src/tree/v2/azure/SubscriptionItem.ts
+++ b/src/tree/v2/azure/SubscriptionItem.ts
@@ -6,14 +6,14 @@
 import { AzExtResourceType } from "@microsoft/vscode-azext-utils";
 import * as vscode from "vscode";
 import { ApplicationResourceProviderManager } from "../../../api/v2/ResourceProviderManagers";
-import { ApplicationSubscription } from "../../../api/v2/v2AzureResourcesApi";
+import { AzureSubscription } from "../../../api/v2/v2AzureResourcesApi";
 import { azureExtensions } from "../../../azureExtensions";
 import { showHiddenTypesSettingKey } from "../../../constants";
 import { settingUtils } from "../../../utils/settingUtils";
 import { treeUtils } from "../../../utils/treeUtils";
 import { ResourceGroupsItem } from "../ResourceGroupsItem";
 import { ResourceGroupsTreeContext } from "../ResourceGroupsTreeContext";
-import { ApplicationResourceGroupingManager } from "./ApplicationResourceGroupingManager";
+import { AzureResourceGroupingManager } from "./AzureResourceGroupingManager";
 
 const supportedResourceTypes: AzExtResourceType[] =
     azureExtensions
@@ -23,9 +23,9 @@ const supportedResourceTypes: AzExtResourceType[] =
 export class SubscriptionItem implements ResourceGroupsItem {
     constructor(
         private readonly context: ResourceGroupsTreeContext,
-        private readonly resourceGroupingManager: ApplicationResourceGroupingManager,
+        private readonly resourceGroupingManager: AzureResourceGroupingManager,
         private readonly resourceProviderManager: ApplicationResourceProviderManager,
-        private readonly subscription: ApplicationSubscription) {
+        private readonly subscription: AzureSubscription) {
     }
 
     public readonly id: string = `/subscriptions/${this.subscription.subscriptionId}`;

--- a/src/tree/v2/azure/registerResourceGroupsTreeV2.ts
+++ b/src/tree/v2/azure/registerResourceGroupsTreeV2.ts
@@ -5,28 +5,28 @@
 
 import * as vscode from 'vscode';
 import { ApplicationResourceProviderManager } from '../../../api/v2/ResourceProviderManagers';
-import { ApplicationResource } from '../../../api/v2/v2AzureResourcesApi';
+import { AzureResource } from '../../../api/v2/v2AzureResourcesApi';
+import { localize } from '../../../utils/localize';
 import { BranchDataItemCache } from '../BranchDataItemCache';
-import { localize } from './../../../utils/localize';
-import { ApplicationResourceBranchDataProviderManager } from './ApplicationResourceBranchDataProviderManager';
-import { ApplicationResourceGroupingManager } from './ApplicationResourceGroupingManager';
-import { createResourceItemFactory } from './ApplicationResourceItem';
-import { ApplicationResourceTreeDataProvider } from './ApplicationResourceTreeDataProvider';
+import { AzureResourceBranchDataProviderManager } from './AzureResourceBranchDataProviderManager';
+import { AzureResourceGroupingManager } from './AzureResourceGroupingManager';
+import { createResourceItemFactory } from './AzureResourceItem';
+import { AzureResourceTreeDataProvider } from './AzureResourceTreeDataProvider';
 import { createGroupingItemFactory } from './GroupingItem';
 
 export function registerResourceGroupsTreeV2(
     context: vscode.ExtensionContext,
-    branchDataProviderManager: ApplicationResourceBranchDataProviderManager,
+    branchDataProviderManager: AzureResourceBranchDataProviderManager,
     refreshEvent: vscode.Event<void>,
     resourceProviderManager: ApplicationResourceProviderManager): void {
     const itemCache = new BranchDataItemCache();
-    const branchDataItemFactory = createResourceItemFactory<ApplicationResource>(itemCache);
+    const branchDataItemFactory = createResourceItemFactory<AzureResource>(itemCache);
     const groupingItemFactory = createGroupingItemFactory(branchDataItemFactory, resource => branchDataProviderManager.getProvider(resource.resourceType));
-    const resourceGroupingManager = new ApplicationResourceGroupingManager(groupingItemFactory);
+    const resourceGroupingManager = new AzureResourceGroupingManager(groupingItemFactory);
 
     context.subscriptions.push(resourceGroupingManager);
 
-    const treeDataProvider = new ApplicationResourceTreeDataProvider(branchDataProviderManager.onDidChangeTreeData, itemCache, refreshEvent, resourceGroupingManager, resourceProviderManager);
+    const treeDataProvider = new AzureResourceTreeDataProvider(branchDataProviderManager.onDidChangeTreeData, itemCache, refreshEvent, resourceGroupingManager, resourceProviderManager);
 
     context.subscriptions.push(treeDataProvider);
 

--- a/src/utils/v2/credentialsUtils.ts
+++ b/src/utils/v2/credentialsUtils.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { AzExtServiceClientCredentials, ISubscriptionContext } from '@microsoft/vscode-azext-dev';
+import * as vscode from 'vscode';
+import { AzureSubscription } from '../../api/v2/v2AzureResourcesApi';
 import { localize } from '../../utils/localize';
-import { ApplicationSubscription } from '../../api/v2/v2AzureResourcesApi';
 
 /**
  * Converts a VS Code authentication session to an Azure Track 1 & 2 compatible compatible credential.
@@ -37,7 +37,7 @@ export function createCredential(getSession: (scopes?: string[]) => vscode.Provi
 /**
  * Creates a subscription context from an application subscription.
  */
-export function createSubscriptionContext(subscription: ApplicationSubscription): ISubscriptionContext {
+export function createSubscriptionContext(subscription: AzureSubscription): ISubscriptionContext {
     return {
         subscriptionDisplayName: '',
         subscriptionPath: '',


### PR DESCRIPTION
Renaming all `Application___` things to `Azure___`. Since we're pretty sure resources in the Azure view will continue to be Azure-only.

I considered using Remote instead of Azure in the names, but went with Azure in the end.

Suggested in https://github.com/microsoft/vscode-azuretools/pull/1229#discussion_r1013281223