### PR TITLE
Add `CompatibleAzExtTreeDataProvider`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@azure/arm-resources": "5.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
                 "@microsoft/vscode-azext-azureutils": "^0.3.4",
-                "@microsoft/vscode-azext-utils": "^0.3.14",
+                "@microsoft/vscode-azext-utils": "^0.3.16",
                 "jsonc-parser": "^2.2.1",
                 "open": "^8.0.4",
                 "semver": "^7.3.7",
@@ -805,9 +805,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.14.tgz",
-            "integrity": "sha512-ic9pzUA3hpP8NLnlMYn3ebrz33w27AuFxJmTY5t7Z7PY026/A/+T4SPTBaWsyMRnE2KLbr5iti6ByMhhCm0MMw==",
+            "version": "0.3.16",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.16.tgz",
+            "integrity": "sha512-5udz8qYx+RRhrBcgEMJNGLzMml/WQpHRfrQWETfMmJgYNRJAAANVg4hrWsXb1eqoKWfg/GqATCWhTgGEQZ77KA==",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.6.2",
                 "dayjs": "^1.11.2",
@@ -12815,9 +12815,9 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.14.tgz",
-            "integrity": "sha512-ic9pzUA3hpP8NLnlMYn3ebrz33w27AuFxJmTY5t7Z7PY026/A/+T4SPTBaWsyMRnE2KLbr5iti6ByMhhCm0MMw==",
+            "version": "0.3.16",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.16.tgz",
+            "integrity": "sha512-5udz8qYx+RRhrBcgEMJNGLzMml/WQpHRfrQWETfMmJgYNRJAAANVg4hrWsXb1eqoKWfg/GqATCWhTgGEQZ77KA==",
             "requires": {
                 "@vscode/extension-telemetry": "^0.6.2",
                 "dayjs": "^1.11.2",

--- a/package.json
+++ b/package.json
@@ -584,7 +584,7 @@
         "@azure/arm-resources": "5.0.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
         "@microsoft/vscode-azext-azureutils": "^0.3.4",
-        "@microsoft/vscode-azext-utils": "^0.3.14",
+        "@microsoft/vscode-azext-utils": "^0.3.16",
         "jsonc-parser": "^2.2.1",
         "open": "^8.0.4",
         "semver": "^7.3.7",

--- a/src/api/v2/compatibility/CompatibleAzExtTreeDataProvider.ts
+++ b/src/api/v2/compatibility/CompatibleAzExtTreeDataProvider.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzExtParentTreeItem, AzExtTreeDataProvider, AzExtTreeItem, IActionContext, isWrapper, ITreeItemPickerContext } from "@microsoft/vscode-azext-utils";
+import { Disposable, Event, TreeItem, TreeView } from "vscode";
+import { ResourceGroupsItem } from "../../../tree/v2/ResourceGroupsItem";
+import { ResourceTreeDataProviderBase } from "../../../tree/v2/ResourceTreeDataProviderBase";
+
+/**
+ * An intermediate class that exists just to redeclare several events as abstract, so they
+ * can be re-redeclared as a accessors in {@link CompatibleAzExtTreeDataProvider} below
+ */
+abstract class IntermediateCompatibleAzExtTreeDataProvider extends AzExtTreeDataProvider {
+    public abstract onDidChangeTreeData: Event<AzExtTreeItem | undefined>;
+    public abstract onTreeItemCreate: Event<AzExtTreeItem>;
+    public abstract onDidExpandOrRefreshExpandedTreeItem: Event<AzExtTreeItem>;
+}
+
+/**
+ * Used for v1 API `api.appResourceTree` and `api.workspaceResourceTree` in place of `AzExtTreeDataProvider`.
+ */
+export class CompatibleAzExtTreeDataProvider extends IntermediateCompatibleAzExtTreeDataProvider {
+    public constructor(private readonly tdp: ResourceTreeDataProviderBase) {
+        super({ valuesToMask: [] } as unknown as AzExtParentTreeItem, undefined as unknown as string);
+    }
+
+    public override getParent(treeItem: AzExtTreeItem): Promise<AzExtTreeItem | undefined> {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        return this.tdp.getParent(treeItem);
+    }
+
+    public override getTreeItem(treeItem: AzExtTreeItem): TreeItem {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        return this.tdp.getTreeItem(treeItem);
+    }
+
+    public override getChildren(treeItem?: AzExtParentTreeItem): Promise<AzExtTreeItem[]> {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        return this.tdp.getChildren(treeItem);
+    }
+
+    public override async findTreeItem<T>(fullId: string): Promise<T | undefined> {
+        const result = await this.tdp.findItemById(fullId);
+        return isWrapper(result) ? result.unwrap<T>() : result as unknown as T;
+    }
+
+    public override showTreeItemPicker<T>(expectedContextValues: string | RegExp | (string | RegExp)[], context: ITreeItemPickerContext & { canPickMany: true }, startingTreeItem?: AzExtTreeItem): Promise<T[]>;
+    public override async showTreeItemPicker<T>(_expectedContextValues: string | RegExp | (string | RegExp)[], _context: ITreeItemPickerContext, _startingTreeItem?: AzExtTreeItem): Promise<T> {
+        throw new Error('TODO: Implement using new picker approach');
+    }
+
+    public override refresh(_context: IActionContext, treeItem?: AzExtTreeItem | undefined): Promise<void> {
+
+        // Flush the cache at and below the given treeItem
+        // Trigger a refresh at the given treeItem
+        this.tdp.notifyTreeDataChanged(treeItem as unknown as ResourceGroupsItem);
+
+        return Promise.resolve();
+    }
+
+    public override refreshUIOnly(treeItem: AzExtTreeItem | undefined): void {
+
+        this.tdp.notifyTreeDataChanged(treeItem as unknown as ResourceGroupsItem);
+
+    }
+
+    public override loadMore(_treeItem: AzExtTreeItem, _context: IActionContext): Promise<void> {
+        // TODO: unknown how this will be implemented?
+        throw new Error('TODO: Implement this using the new load more approach');
+    }
+
+    //#region Things that should not be called
+    public override trackTreeItemCollapsibleState(_treeView: TreeView<AzExtTreeItem>): Disposable {
+        throw new ShouldNeverBeCalledError('trackTreeItemCollapsibleState method');
+    }
+
+    public get onDidChangeTreeData(): Event<AzExtTreeItem | undefined> {
+        throw new ShouldNeverBeCalledError('onDidChangeTreeData accessor');
+    }
+
+    public get onTreeItemCreate(): Event<AzExtTreeItem> {
+        throw new ShouldNeverBeCalledError('onTreeItemCreate accessor');
+    }
+
+    public get onDidExpandOrRefreshExpandedTreeItem(): Event<AzExtTreeItem> {
+        throw new ShouldNeverBeCalledError('onDidExpandOrRefreshExpandedTreeItem accessor');
+    }
+    //#endregion Things that should not be called
+}
+
+class ShouldNeverBeCalledError extends Error {
+    constructor(methodName: string) {
+        super(`${methodName} should never be called.`);
+    }
+}

--- a/src/api/v2/compatibility/CompatibleAzExtTreeDataProvider.ts
+++ b/src/api/v2/compatibility/CompatibleAzExtTreeDataProvider.ts
@@ -66,7 +66,6 @@ export class CompatibleAzExtTreeDataProvider extends IntermediateCompatibleAzExt
     public override refreshUIOnly(treeItem: AzExtTreeItem | undefined): void {
 
         this.tdp.notifyTreeDataChanged(treeItem as unknown as ResourceGroupsItem);
-
     }
 
     public override loadMore(_treeItem: AzExtTreeItem, _context: IActionContext): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,33 +6,26 @@
 'use strict';
 
 import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
-import { AzExtTreeDataProvider, AzExtTreeItem, callWithTelemetryAndErrorHandling, createAzExtOutputChannel, IActionContext, registerEvent, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
+import { AzExtTreeDataProvider, callWithTelemetryAndErrorHandling, createAzExtOutputChannel, IActionContext, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
 import type { AppResourceResolver } from '@microsoft/vscode-azext-utils/hostapi';
 import * as vscode from 'vscode';
 import { ActivityLogTreeItem } from './activityLog/ActivityLogsTreeItem';
 import { registerActivity } from './activityLog/registerActivity';
 import { InternalAzureResourceGroupsExtensionApi } from './api/AzureResourceGroupsExtensionApi';
 import { pickAppResource } from './api/pickAppResource';
-import { registerApplicationResourceProvider } from './api/registerApplicationResourceProvider';
 import { registerApplicationResourceResolver } from './api/registerApplicationResourceResolver';
 import { registerWorkspaceResourceProvider } from './api/registerWorkspaceResourceProvider';
 import { revealTreeItem } from './api/revealTreeItem';
+import { CompatibleAzExtTreeDataProvider } from './api/v2/compatibility/CompatibleAzExtTreeDataProvider';
 import { DefaultApplicationResourceProvider } from './api/v2/DefaultApplicationResourceProvider';
 import { ResourceGroupsExtensionManager } from './api/v2/ResourceGroupsExtensionManager';
 import { AzureResourceProviderManager, WorkspaceResourceProviderManager } from './api/v2/ResourceProviderManagers';
 import { AzureResourcesApiManager } from './api/v2/v2AzureResourcesApi';
 import { V2AzureResourcesApiImplementation } from './api/v2/v2AzureResourcesApiImplementation';
-import { AzureResourceProvider } from './AzureResourceProvider';
 import { registerCommands } from './commands/registerCommands';
 import { registerTagDiagnostics } from './commands/tags/registerTagDiagnostics';
 import { TagFileSystem } from './commands/tags/TagFileSystem';
-import { azureResourceProviderId } from './constants';
 import { ext } from './extensionVariables';
-import { installableAppResourceResolver } from './resolvers/InstallableAppResourceResolver';
-import { shallowResourceResolver } from './resolvers/ShallowResourceResolver';
-import { wrapperResolver } from './resolvers/WrapperResolver';
-import { AzureAccountTreeItem } from './tree/AzureAccountTreeItem';
-import { GroupTreeItemBase } from './tree/GroupTreeItemBase';
 import { HelpTreeItem } from './tree/HelpTreeItem';
 import { AzureResourceBranchDataProviderManager } from './tree/v2/azure/AzureResourceBranchDataProviderManager';
 import { DefaultAzureResourceBranchDataProvider } from './tree/v2/azure/DefaultAzureResourceBranchDataProvider';
@@ -40,9 +33,6 @@ import { registerAzureTree } from './tree/v2/azure/registerAzureTree';
 import { registerWorkspaceTree } from './tree/v2/workspace/registerWorkspaceTree';
 import { WorkspaceDefaultBranchDataProvider } from './tree/v2/workspace/WorkspaceDefaultBranchDataProvider';
 import { WorkspaceResourceBranchDataProviderManager } from './tree/v2/workspace/WorkspaceResourceBranchDataProviderManager';
-import { WorkspaceTreeItem } from './tree/WorkspaceTreeItem';
-import { ExtensionActivationManager } from './utils/ExtensionActivationManager';
-import { localize } from './utils/localize';
 import { createApiProvider } from './utils/v2/apiUtils';
 
 let v2Api: V2AzureResourcesApiImplementation | undefined = undefined;
@@ -60,31 +50,15 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
 
     context.subscriptions.push(refreshEventEmitter);
 
-    const refreshWorkspaceEmitter = new vscode.EventEmitter<void>();
+    ext.emitters.refreshWorkspace = new vscode.EventEmitter<void>();
 
-    context.subscriptions.push(refreshWorkspaceEmitter);
+    context.subscriptions.push(ext.emitters.refreshWorkspace = new vscode.EventEmitter<void>());
 
     await callWithTelemetryAndErrorHandling('azureResourceGroups.activate', async (activateContext: IActionContext) => {
         activateContext.telemetry.properties.isActivationEvent = 'true';
         activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
 
         setupEvents(context);
-
-        ext.rootAccountTreeItem = new AzureAccountTreeItem();
-        context.subscriptions.push(ext.rootAccountTreeItem);
-        ext.appResourceTree = new AzExtTreeDataProvider(ext.rootAccountTreeItem, 'azureResourceGroups.loadMore');
-        context.subscriptions.push(ext.appResourceTreeView = vscode.window.createTreeView('azureResourceGroups', { treeDataProvider: ext.appResourceTree, showCollapseAll: true, canSelectMany: true }));
-        ext.appResourceTreeView.description = localize('remote', 'Remote');
-        context.subscriptions.push(ext.appResourceTree.trackTreeItemCollapsibleState(ext.appResourceTreeView));
-
-        // Hook up the resolve handler
-        registerEvent('treeItem.expanded', ext.appResourceTree.onDidExpandOrRefreshExpandedTreeItem, async (context: IActionContext, treeItem: AzExtTreeItem) => {
-            context.errorHandling.suppressDisplay = true;
-
-            if (treeItem instanceof GroupTreeItemBase) {
-                await treeItem.resolveAllChildrenOnExpanded(context);
-            }
-        });
 
         ext.tagFS = new TagFileSystem(ext.appResourceTree);
         context.subscriptions.push(vscode.workspace.registerFileSystemProvider(TagFileSystem.scheme, ext.tagFS));
@@ -94,24 +68,11 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         ext.helpTree = new AzExtTreeDataProvider(helpTreeItem, 'ms-azuretools.loadMore');
         context.subscriptions.push(vscode.window.createTreeView('ms-azuretools.helpAndFeedback', { treeDataProvider: ext.helpTree }));
 
-        const workspaceTreeItem = new WorkspaceTreeItem();
-        ext.workspaceTree = new AzExtTreeDataProvider(workspaceTreeItem, 'azureWorkspace.loadMore');
-        context.subscriptions.push(ext.workspaceTreeView = vscode.window.createTreeView('azureWorkspace', { treeDataProvider: ext.workspaceTree, canSelectMany: true }));
-        ext.workspaceTreeView.description = localize('local', 'Local');
-
         context.subscriptions.push(ext.activityLogTreeItem = new ActivityLogTreeItem());
         ext.activityLogTree = new AzExtTreeDataProvider(ext.activityLogTreeItem, 'azureActivityLog.loadMore');
         context.subscriptions.push(vscode.window.createTreeView('azureActivityLog', { treeDataProvider: ext.activityLogTree }));
 
-        context.subscriptions.push(ext.activationManager = new ExtensionActivationManager());
-
-        registerCommands(refreshEventEmitter, () => refreshWorkspaceEmitter.fire());
-        registerApplicationResourceProvider(azureResourceProviderId, new AzureResourceProvider());
-        registerApplicationResourceResolver('vscode-azureresourcegroups.wrapperResolver', wrapperResolver);
-        registerApplicationResourceResolver('vscode-azureresourcegroups.installableAppResourceResolver', installableAppResourceResolver);
-        registerApplicationResourceResolver('vscode-azureresourcegroups.shallowResourceResolver', shallowResourceResolver);
-
-        await vscode.commands.executeCommand('setContext', 'azure-account.signedIn', await ext.rootAccountTreeItem.getIsLoggedIn());
+        registerCommands(refreshEventEmitter, () => ext.emitters.refreshWorkspace.fire());
     });
 
     const extensionManager = new ResourceGroupsExtensionManager()
@@ -131,13 +92,13 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         type => void extensionManager.activateWorkspaceResourceBranchDataProvider(type));
     const workspaceResourceProviderManager = new WorkspaceResourceProviderManager(() => extensionManager.activateWorkspaceResourceProviders());
 
-    registerAzureTree(context, {
+    const { azureResourceTreeDataProvider } = registerAzureTree(context, {
         azureResourceProviderManager,
         azureResourceBranchDataProviderManager,
         refreshEvent: refreshEventEmitter.event,
     });
 
-    registerWorkspaceTree(context, {
+    const { workspaceResourceTreeDataProvider } = registerWorkspaceTree(context, {
         workspaceResourceProviderManager,
         workspaceResourceBranchDataProviderManager,
         refreshEvent: refreshEventEmitter.event,
@@ -149,11 +110,14 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                 azureResourceProviderManager,
                 azureResourceBranchDataProviderManager,
                 workspaceResourceProviderManager,
-                workspaceResourceBranchDataProviderManager);
+                workspaceResourceBranchDataProviderManager
+            );
         }
 
         return v2Api;
     }
+
+    ext.v2.api = v2ApiFactory();
 
     return createApiProvider(
         (<{ version: string }>context.extension.packageJSON).version,
@@ -163,9 +127,9 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                 apiFactory: () => new InternalAzureResourceGroupsExtensionApi(
                     {
                         apiVersion: InternalAzureResourceGroupsExtensionApi.apiVersion,
-                        appResourceTree: ext.appResourceTree,
+                        appResourceTree: new CompatibleAzExtTreeDataProvider(azureResourceTreeDataProvider),
                         appResourceTreeView: ext.appResourceTreeView,
-                        workspaceResourceTree: ext.workspaceTree,
+                        workspaceResourceTree: new CompatibleAzExtTreeDataProvider(workspaceResourceTreeDataProvider),
                         workspaceResourceTreeView: ext.workspaceTreeView,
                         revealTreeItem,
                         registerApplicationResourceResolver,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -117,7 +117,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         return v2Api;
     }
 
-    ext.v2.api = v2ApiFactory();
+    v2ApiFactory();
 
     return createApiProvider(
         (<{ version: string }>context.extension.packageJSON).version,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,13 +92,13 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         type => void extensionManager.activateWorkspaceResourceBranchDataProvider(type));
     const workspaceResourceProviderManager = new WorkspaceResourceProviderManager(() => extensionManager.activateWorkspaceResourceProviders());
 
-    const { azureResourceTreeDataProvider } = registerAzureTree(context, {
+    const azureResourceTreeDataProvider = registerAzureTree(context, {
         azureResourceProviderManager,
         azureResourceBranchDataProviderManager,
         refreshEvent: refreshEventEmitter.event,
     });
 
-    const { workspaceResourceTreeDataProvider } = registerWorkspaceTree(context, {
+    const workspaceResourceTreeDataProvider = registerWorkspaceTree(context, {
         workspaceResourceProviderManager,
         workspaceResourceBranchDataProviderManager,
         refreshEvent: refreshEventEmitter.event,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -117,8 +117,6 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         return v2Api;
     }
 
-    v2ApiFactory();
-
     return createApiProvider(
         (<{ version: string }>context.extension.packageJSON).version,
         [

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -7,7 +7,6 @@ import { AzExtTreeDataProvider, AzExtTreeItem, IAzExtOutputChannel } from "@micr
 import { AppResourceResolver } from "@microsoft/vscode-azext-utils/hostapi";
 import { DiagnosticCollection, Disposable, Event, EventEmitter, ExtensionContext, TreeView } from "vscode";
 import { ActivityLogTreeItem } from "./activityLog/ActivityLogsTreeItem";
-import { V2AzureResourcesApi } from "./api/v2/v2AzureResourcesApi";
 import { TagFileSystem } from "./commands/tags/TagFileSystem";
 import { AzureAccountTreeItem } from "./tree/AzureAccountTreeItem";
 import { ExtensionActivationManager } from "./utils/ExtensionActivationManager";
@@ -48,8 +47,4 @@ export namespace ext {
 
     export const emitters = extEmitters;
     export const events = extEvents;
-
-    export namespace v2 {
-        export let api: V2AzureResourcesApi;
-    }
 }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -7,6 +7,7 @@ import { AzExtTreeDataProvider, AzExtTreeItem, IAzExtOutputChannel } from "@micr
 import { AppResourceResolver } from "@microsoft/vscode-azext-utils/hostapi";
 import { DiagnosticCollection, Disposable, Event, EventEmitter, ExtensionContext, TreeView } from "vscode";
 import { ActivityLogTreeItem } from "./activityLog/ActivityLogsTreeItem";
+import { V2AzureResourcesApi } from "./api/v2/v2AzureResourcesApi";
 import { TagFileSystem } from "./commands/tags/TagFileSystem";
 import { AzureAccountTreeItem } from "./tree/AzureAccountTreeItem";
 import { ExtensionActivationManager } from "./utils/ExtensionActivationManager";
@@ -14,6 +15,7 @@ import { ExtensionActivationManager } from "./utils/ExtensionActivationManager";
 namespace extEmitters {
     export let onDidChangeFocusedGroup: EventEmitter<void>;
     export let onDidRegisterResolver: EventEmitter<AppResourceResolver>;
+    export let refreshWorkspace: EventEmitter<void>;
 }
 
 namespace extEvents {
@@ -46,4 +48,8 @@ export namespace ext {
 
     export const emitters = extEmitters;
     export const events = extEvents;
+
+    export namespace v2 {
+        export let api: V2AzureResourcesApi;
+    }
 }

--- a/src/tree/v2/azure/registerAzureTree.ts
+++ b/src/tree/v2/azure/registerAzureTree.ts
@@ -20,7 +20,11 @@ interface RegisterAzureTreeOptions {
     refreshEvent: vscode.Event<void>,
 }
 
-export function registerAzureTree(context: vscode.ExtensionContext, options: RegisterAzureTreeOptions): void {
+interface RegisterAzureTreeResult {
+    azureResourceTreeDataProvider: AzureResourceTreeDataProvider;
+}
+
+export function registerAzureTree(context: vscode.ExtensionContext, options: RegisterAzureTreeOptions): RegisterAzureTreeResult {
     const { azureResourceBranchDataProviderManager, azureResourceProviderManager: resourceProviderManager, refreshEvent } = options;
 
     const itemCache = new BranchDataItemCache();
@@ -42,4 +46,6 @@ export function registerAzureTree(context: vscode.ExtensionContext, options: Reg
     context.subscriptions.push(treeView);
 
     treeView.description = localize('remote', 'Remote');
+
+    return { azureResourceTreeDataProvider };
 }

--- a/src/tree/v2/azure/registerAzureTree.ts
+++ b/src/tree/v2/azure/registerAzureTree.ts
@@ -20,11 +20,7 @@ interface RegisterAzureTreeOptions {
     refreshEvent: vscode.Event<void>,
 }
 
-interface RegisterAzureTreeResult {
-    azureResourceTreeDataProvider: AzureResourceTreeDataProvider;
-}
-
-export function registerAzureTree(context: vscode.ExtensionContext, options: RegisterAzureTreeOptions): RegisterAzureTreeResult {
+export function registerAzureTree(context: vscode.ExtensionContext, options: RegisterAzureTreeOptions): AzureResourceTreeDataProvider {
     const { azureResourceBranchDataProviderManager, azureResourceProviderManager: resourceProviderManager, refreshEvent } = options;
 
     const itemCache = new BranchDataItemCache();
@@ -47,5 +43,5 @@ export function registerAzureTree(context: vscode.ExtensionContext, options: Reg
 
     treeView.description = localize('remote', 'Remote');
 
-    return { azureResourceTreeDataProvider };
+    return azureResourceTreeDataProvider;
 }

--- a/src/tree/v2/workspace/registerWorkspaceTree.ts
+++ b/src/tree/v2/workspace/registerWorkspaceTree.ts
@@ -15,11 +15,7 @@ interface RegisterWorkspaceTreeOptions {
     refreshEvent: vscode.Event<void>,
 }
 
-interface RegisterWorkspaceTreeResult {
-    workspaceResourceTreeDataProvider: WorkspaceResourceTreeDataProvider;
-}
-
-export function registerWorkspaceTree(context: vscode.ExtensionContext, options: RegisterWorkspaceTreeOptions): RegisterWorkspaceTreeResult {
+export function registerWorkspaceTree(context: vscode.ExtensionContext, options: RegisterWorkspaceTreeOptions): WorkspaceResourceTreeDataProvider {
     const { workspaceResourceBranchDataProviderManager, workspaceResourceProviderManager, refreshEvent } = options;
 
     const workspaceResourceTreeDataProvider =
@@ -35,5 +31,5 @@ export function registerWorkspaceTree(context: vscode.ExtensionContext, options:
 
     treeView.description = localize('local', 'Local');
 
-    return { workspaceResourceTreeDataProvider };
+    return workspaceResourceTreeDataProvider;
 }

--- a/src/tree/v2/workspace/registerWorkspaceTree.ts
+++ b/src/tree/v2/workspace/registerWorkspaceTree.ts
@@ -15,7 +15,11 @@ interface RegisterWorkspaceTreeOptions {
     refreshEvent: vscode.Event<void>,
 }
 
-export function registerWorkspaceTree(context: vscode.ExtensionContext, options: RegisterWorkspaceTreeOptions): void {
+interface RegisterWorkspaceTreeResult {
+    workspaceResourceTreeDataProvider: WorkspaceResourceTreeDataProvider;
+}
+
+export function registerWorkspaceTree(context: vscode.ExtensionContext, options: RegisterWorkspaceTreeOptions): RegisterWorkspaceTreeResult {
     const { workspaceResourceBranchDataProviderManager, workspaceResourceProviderManager, refreshEvent } = options;
 
     const workspaceResourceTreeDataProvider =
@@ -30,4 +34,6 @@ export function registerWorkspaceTree(context: vscode.ExtensionContext, options:
     context.subscriptions.push(treeView);
 
     treeView.description = localize('local', 'Local');
+
+    return { workspaceResourceTreeDataProvider };
 }


### PR DESCRIPTION
I found that I separate this class from the rest of the compatibility code easily. Figured it's worth it to reduce the size of #358. I will probably keep trying to apply the changes in #358 in separate smaller PRs like this.

Merging this PR should reduce #358 to a more reasonable size. 

Brandon and I worked on this code together, so it'd be good to get a final review from another source.