### PR TITLE
Don't provide duplicate resources

### DIFF
--- a/src/api/v2/compatibility/workspace/CompatibilityWorkspaceResourceProvider.ts
+++ b/src/api/v2/compatibility/workspace/CompatibilityWorkspaceResourceProvider.ts
@@ -15,7 +15,10 @@ export class CompatibilityWorkspaceResourceProvider implements V2WorkspaceResour
     // No comparable mechanism in v1, leave as undefined
     onDidChangeResource?: Event<WorkspaceResource | undefined> = undefined;
 
-    public async getResources(source: WorkspaceFolder): Promise<WorkspaceResource[]> {
+    public async getResources(source: WorkspaceFolder | undefined): Promise<WorkspaceResource[]> {
+        if (source) {
+            return [];
+        }
 
         const resources = await this.provider.provideResources(
             // pass in stub parent

--- a/src/api/v2/compatibility/workspace/CompatibilityWorkspaceResourceProvider.ts
+++ b/src/api/v2/compatibility/workspace/CompatibilityWorkspaceResourceProvider.ts
@@ -16,6 +16,8 @@ export class CompatibilityWorkspaceResourceProvider implements V2WorkspaceResour
     onDidChangeResource?: Event<WorkspaceResource | undefined> = undefined;
 
     public async getResources(source: WorkspaceFolder | undefined): Promise<WorkspaceResource[]> {
+        // For compatibility, and to avoid duplicating resources, we'll only return resources when undefined is passed.
+        // See https://github.com/microsoft/vscode-azureresourcegroups/pull/451
         if (source) {
             return [];
         }


### PR DESCRIPTION
In #449 we made it so `getResources` is called for each open workspace folder, and once with undefined as an argument for system-level resources.

For compatibility, we'll only return resources when undefined is passed.