### PR TITLE
Refresh individual tree items, and fix refresh title button

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,12 @@
                 "icon": "$(refresh)"
             },
             {
+                "command": "azureResourceGroups.refreshAzureItem",
+                "title": "%azureResourceGroups.refresh%",
+                "category": "Azure",
+                "icon": "$(refresh)"
+            },
+            {
                 "command": "azureResourceGroups.revealResource",
                 "title": "%azureResourceGroups.revealResource%",
                 "category": "Azure"
@@ -319,7 +325,7 @@
                     "group": "9@1"
                 },
                 {
-                    "command": "azureResourceGroups.refresh",
+                    "command": "azureResourceGroups.refreshAzureItem",
                     "when": "view == azureResourceGroups && viewItem == azureextensionui.azureSubscription",
                     "group": "9@2"
                 },
@@ -339,7 +345,7 @@
                     "group": "9@2"
                 },
                 {
-                    "command": "azureResourceGroups.refresh",
+                    "command": "azureResourceGroups.refreshAzureItem",
                     "when": "view == azureResourceGroups && viewItem =~ /azureResource/",
                     "group": "9@3"
                 },
@@ -359,7 +365,7 @@
                     "group": "9@1"
                 },
                 {
-                    "command": "azureResourceGroups.refresh",
+                    "command": "azureResourceGroups.refreshAzureItem",
                     "when": "view == azureResourceGroups && viewItem =~ /group/",
                     "group": "inline@1"
                 }

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -6,6 +6,7 @@
 import { AzExtTreeItem, IActionContext, openUrl, registerCommand, registerErrorHandler, registerReportIssueCommand } from '@microsoft/vscode-azext-utils';
 import { commands } from 'vscode';
 import { ext } from '../extensionVariables';
+import { ResourceGroupsItem } from '../tree/v2/ResourceGroupsItem';
 import { clearActivities } from './activities/clearActivities';
 import { createResource } from './createResource';
 import { createResourceGroup } from './createResourceGroup';
@@ -31,7 +32,8 @@ export function registerCommands(): void {
     registerCommand('azureResourceGroups.deleteResourceGroupV2', deleteResourceGroupV2);
     registerCommand('azureResourceGroups.loadMore', async (context: IActionContext, node: AzExtTreeItem) => await ext.appResourceTree.loadMore(node, context));
     registerCommand('azureResourceGroups.openInPortal', openInPortal);
-    registerCommand('azureResourceGroups.refresh', ext.actions.refreshAzureTree);
+    registerCommand('azureResourceGroups.refresh', () => ext.actions.refreshAzureTree()); // don't pass in selected node to always refresh entire tree
+    registerCommand('azureResourceGroups.refreshAzureItem', (_context, node?: ResourceGroupsItem) => ext.actions.refreshAzureTree(node));
     registerCommand('azureResourceGroups.revealResource', revealResource);
     registerCommand('azureResourceGroups.selectSubscriptions', () => commands.executeCommand('azure-account.selectSubscriptions'));
     registerCommand('azureResourceGroups.viewProperties', viewProperties);
@@ -66,6 +68,6 @@ export function registerCommands(): void {
         await openUrl(url)
     });
 
-    registerCommand('azureWorkspace.refresh', ext.actions.refreshWorkspaceTree);
+    registerCommand('azureWorkspace.refresh', () => ext.actions.refreshWorkspaceTree()); // don't pass in selected node to always refresh entire tree
     registerCommand('azureWorkspace.loadMore', async (context: IActionContext, node: AzExtTreeItem) => await ext.workspaceTree.loadMore(node, context));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import { HelpTreeItem } from './tree/HelpTreeItem';
 import { AzureResourceBranchDataProviderManager } from './tree/v2/azure/AzureResourceBranchDataProviderManager';
 import { DefaultAzureResourceBranchDataProvider } from './tree/v2/azure/DefaultAzureResourceBranchDataProvider';
 import { registerAzureTree } from './tree/v2/azure/registerAzureTree';
+import { ResourceGroupsItem } from './tree/v2/ResourceGroupsItem';
 import { registerWorkspaceTree } from './tree/v2/workspace/registerWorkspaceTree';
 import { WorkspaceDefaultBranchDataProvider } from './tree/v2/workspace/WorkspaceDefaultBranchDataProvider';
 import { WorkspaceResourceBranchDataProviderManager } from './tree/v2/workspace/WorkspaceResourceBranchDataProviderManager';
@@ -44,13 +45,13 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
     registerUIExtensionVariables(ext);
     registerAzureUtilsExtensionVariables(ext);
 
-    const refreshAzureTreeEmitter = new vscode.EventEmitter<void>();
+    const refreshAzureTreeEmitter = new vscode.EventEmitter<void | ResourceGroupsItem | ResourceGroupsItem[] | null | undefined>();
     context.subscriptions.push(refreshAzureTreeEmitter);
-    const refreshWorkspaceTreeEmitter = new vscode.EventEmitter<void>();
+    const refreshWorkspaceTreeEmitter = new vscode.EventEmitter<void | ResourceGroupsItem | ResourceGroupsItem[] | null | undefined>();
     context.subscriptions.push(refreshWorkspaceTreeEmitter);
 
-    ext.actions.refreshWorkspaceTree = () => refreshWorkspaceTreeEmitter.fire();
-    ext.actions.refreshAzureTree = () => refreshAzureTreeEmitter.fire();
+    ext.actions.refreshWorkspaceTree = (data) => refreshWorkspaceTreeEmitter.fire(data);
+    ext.actions.refreshAzureTree = (data) => refreshAzureTreeEmitter.fire(data);
 
     await callWithTelemetryAndErrorHandling('azureResourceGroups.activate', async (activateContext: IActionContext) => {
         activateContext.telemetry.properties.isActivationEvent = 'true';
@@ -99,7 +100,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
     const workspaceResourceTreeDataProvider = registerWorkspaceTree(context, {
         workspaceResourceProviderManager,
         workspaceResourceBranchDataProviderManager,
-        refreshEvent: refreshAzureTreeEmitter.event,
+        refreshEvent: refreshWorkspaceTreeEmitter.event,
     });
 
     const v2ApiFactory: AzureExtensionApiFactory<AzureResourcesApiInternal> = {

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -10,6 +10,7 @@ import { AzureResourcesApiInternal } from "../hostapi.v2.internal";
 import { ActivityLogTreeItem } from "./activityLog/ActivityLogsTreeItem";
 import { TagFileSystem } from "./commands/tags/TagFileSystem";
 import { AzureAccountTreeItem } from "./tree/AzureAccountTreeItem";
+import { ResourceGroupsItem } from "./tree/v2/ResourceGroupsItem";
 import { ExtensionActivationManager } from "./utils/ExtensionActivationManager";
 
 namespace extEmitters {
@@ -23,8 +24,8 @@ namespace extEvents {
 }
 
 export namespace extActions {
-    export let refreshWorkspaceTree: () => void;
-    export let refreshAzureTree: () => void;
+    export let refreshWorkspaceTree: (data?: ResourceGroupsItem | ResourceGroupsItem[] | null | undefined | void) => void;
+    export let refreshAzureTree: (data?: ResourceGroupsItem | ResourceGroupsItem[] | null | undefined | void) => void;
 }
 
 /**

--- a/src/tree/v2/ResourceTreeDataProviderBase.ts
+++ b/src/tree/v2/ResourceTreeDataProviderBase.ts
@@ -82,7 +82,7 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
         return await this.onGetChildren(element);
     }
 
-    getParent(element: ResourceGroupsItem): vscode.ProviderResult<ResourceGroupsItem | null | undefined> {
+    getParent(element: ResourceGroupsItem): vscode.ProviderResult<ResourceGroupsItem> {
         return element.getParent?.();
     }
 

--- a/src/tree/v2/ResourceTreeDataProviderBase.ts
+++ b/src/tree/v2/ResourceTreeDataProviderBase.ts
@@ -18,7 +18,7 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
         protected readonly itemCache: BranchDataItemCache,
         onDidChangeBranchTreeData: vscode.Event<void | ResourceModelBase | ResourceModelBase[] | null | undefined>,
         onDidChangeResource: vscode.Event<ResourceBase | undefined>,
-        onRefresh: vscode.Event<void>,
+        onRefresh: vscode.Event<void | ResourceGroupsItem | ResourceGroupsItem[] | null | undefined>,
         callOnDispose?: () => void) {
         super(
             () => {
@@ -55,7 +55,7 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
                 }
             });
 
-        this.refreshSubscription = onRefresh(() => this.onDidChangeTreeDataEmitter.fire());
+        this.refreshSubscription = onRefresh((e) => this.onDidChangeTreeDataEmitter.fire(e));
 
         // TODO: If only individual resources change, just update the tree related to those resources.
         this.resourceProviderManagerListener = onDidChangeResource(() => this.onDidChangeTreeDataEmitter.fire());
@@ -82,7 +82,7 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
         return await this.onGetChildren(element);
     }
 
-    getParent(element: ResourceGroupsItem): vscode.ProviderResult<ResourceGroupsItem> {
+    getParent(element: ResourceGroupsItem): vscode.ProviderResult<ResourceGroupsItem | null | undefined> {
         return element.getParent?.();
     }
 

--- a/src/tree/v2/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/v2/azure/AzureResourceTreeDataProvider.ts
@@ -30,7 +30,7 @@ export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase 
     constructor(
         onDidChangeBranchTreeData: vscode.Event<void | ResourceModelBase | ResourceModelBase[] | null | undefined>,
         itemCache: BranchDataItemCache,
-        onRefresh: vscode.Event<void>,
+        onRefresh: vscode.Event<void | ResourceGroupsItem | ResourceGroupsItem[] | null | undefined>,
         private readonly resourceGroupingManager: AzureResourceGroupingManager,
         private readonly resourceProviderManager: AzureResourceProviderManager) {
         super(

--- a/src/tree/v2/azure/registerAzureTree.ts
+++ b/src/tree/v2/azure/registerAzureTree.ts
@@ -3,10 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzExtTreeItem } from '@microsoft/vscode-azext-utils';
 import { AzureResource } from '@microsoft/vscode-azext-utils/hostapi.v2';
 import * as vscode from 'vscode';
 import { AzureResourceProviderManager } from '../../../api/v2/ResourceProviderManagers';
+import { ext } from '../../../extensionVariables';
 import { BranchDataItemCache } from '../BranchDataItemCache';
+import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { localize } from './../../../utils/localize';
 import { AzureResourceBranchDataProviderManager } from './AzureResourceBranchDataProviderManager';
 import { AzureResourceGroupingManager } from './AzureResourceGroupingManager';
@@ -17,7 +20,7 @@ import { createGroupingItemFactory } from './GroupingItem';
 interface RegisterAzureTreeOptions {
     azureResourceBranchDataProviderManager: AzureResourceBranchDataProviderManager,
     azureResourceProviderManager: AzureResourceProviderManager,
-    refreshEvent: vscode.Event<void>,
+    refreshEvent: vscode.Event<void | ResourceGroupsItem | ResourceGroupsItem[] | null | undefined>,
 }
 
 export function registerAzureTree(context: vscode.ExtensionContext, options: RegisterAzureTreeOptions): AzureResourceTreeDataProvider {
@@ -42,6 +45,8 @@ export function registerAzureTree(context: vscode.ExtensionContext, options: Reg
     context.subscriptions.push(treeView);
 
     treeView.description = localize('remote', 'Remote');
+
+    ext.appResourceTreeView = treeView as unknown as vscode.TreeView<AzExtTreeItem>;
 
     return azureResourceTreeDataProvider;
 }

--- a/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
+++ b/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
@@ -15,7 +15,7 @@ import { WorkspaceResourceBranchDataProviderManager } from './WorkspaceResourceB
 export class WorkspaceResourceTreeDataProvider extends ResourceTreeDataProviderBase {
     constructor(
         private readonly branchDataProviderManager: WorkspaceResourceBranchDataProviderManager,
-        onRefresh: vscode.Event<void>,
+        onRefresh: vscode.Event<void | ResourceGroupsItem | ResourceGroupsItem[] | null | undefined>,
         private readonly resourceProviderManager: WorkspaceResourceProviderManager) {
         super(
             new BranchDataItemCache(),

--- a/src/tree/v2/workspace/registerWorkspaceTree.ts
+++ b/src/tree/v2/workspace/registerWorkspaceTree.ts
@@ -3,8 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzExtTreeItem } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { WorkspaceResourceProviderManager } from '../../../api/v2/ResourceProviderManagers';
+import { ext } from '../../../extensionVariables';
+import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { localize } from './../../../utils/localize';
 import { WorkspaceResourceBranchDataProviderManager } from './WorkspaceResourceBranchDataProviderManager';
 import { WorkspaceResourceTreeDataProvider } from './WorkspaceResourceTreeDataProvider';
@@ -12,7 +15,7 @@ import { WorkspaceResourceTreeDataProvider } from './WorkspaceResourceTreeDataPr
 interface RegisterWorkspaceTreeOptions {
     workspaceResourceBranchDataProviderManager: WorkspaceResourceBranchDataProviderManager,
     workspaceResourceProviderManager: WorkspaceResourceProviderManager,
-    refreshEvent: vscode.Event<void>,
+    refreshEvent: vscode.Event<void | ResourceGroupsItem | ResourceGroupsItem[] | null | undefined>,
 }
 
 export function registerWorkspaceTree(context: vscode.ExtensionContext, options: RegisterWorkspaceTreeOptions): WorkspaceResourceTreeDataProvider {
@@ -30,6 +33,8 @@ export function registerWorkspaceTree(context: vscode.ExtensionContext, options:
     context.subscriptions.push(treeView);
 
     treeView.description = localize('local', 'Local');
+
+    ext.workspaceTreeView = treeView as unknown as vscode.TreeView<AzExtTreeItem>;
 
     return workspaceResourceTreeDataProvider;
 }


### PR DESCRIPTION
Two changes:

1. Allow refreshing a single tree item instead of the entire tree everywhere. This means changing the `Event<void>` to `Event<void | ResourceGroupsItem | ResourceGroupsItem[] | null | undefined>` everywhere.
2. Split the Azure view refresh command in two. One that refreshes the entire tree, ignoring any selected nodes. This makes the refresh button on the Azure view title behave like it has in the past. The new command is `refreshAzureItem`, intended for the context menus of items in the Azure view.