### PR TITLE
v2 edit tags command for resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@azure/arm-resources": "5.0.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
                 "@microsoft/vscode-azext-azureutils": "^0.3.4",
-                "@microsoft/vscode-azext-utils": "^0.3.20",
+                "@microsoft/vscode-azext-utils": "^0.3.21",
                 "jsonc-parser": "^2.2.1",
                 "open": "^8.0.4",
                 "semver": "^7.3.7",
@@ -806,9 +806,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.20.tgz",
-            "integrity": "sha512-8Gs6bIjMamZ2BoUsqLGGRgQfKvwmPA9PB7CUtPab9/72lPN9ugGxoSAyYdXWnmZefJ1NBwyyf0sfSq7ggz1M+Q==",
+            "version": "0.3.21",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.21.tgz",
+            "integrity": "sha512-E4kMgvbR/oUZ6c4SCb5QsCrsa5SVKB4WMHyPH5SrUZ3h9eMVTGBM7AzG1n663FSI0vb7/RanaaOVmXv/asZDzQ==",
             "dependencies": {
                 "@vscode/extension-telemetry": "^0.6.2",
                 "dayjs": "^1.11.2",
@@ -12699,9 +12699,9 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.20.tgz",
-            "integrity": "sha512-8Gs6bIjMamZ2BoUsqLGGRgQfKvwmPA9PB7CUtPab9/72lPN9ugGxoSAyYdXWnmZefJ1NBwyyf0sfSq7ggz1M+Q==",
+            "version": "0.3.21",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.3.21.tgz",
+            "integrity": "sha512-E4kMgvbR/oUZ6c4SCb5QsCrsa5SVKB4WMHyPH5SrUZ3h9eMVTGBM7AzG1n663FSI0vb7/RanaaOVmXv/asZDzQ==",
             "requires": {
                 "@vscode/extension-telemetry": "^0.6.2",
                 "dayjs": "^1.11.2",

--- a/package.json
+++ b/package.json
@@ -590,7 +590,7 @@
         "@azure/arm-resources": "5.0.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
         "@microsoft/vscode-azext-azureutils": "^0.3.4",
-        "@microsoft/vscode-azext-utils": "^0.3.20",
+        "@microsoft/vscode-azext-utils": "^0.3.21",
         "jsonc-parser": "^2.2.1",
         "open": "^8.0.4",
         "semver": "^7.3.7",

--- a/src/commands/tags/TagFileSystem.ts
+++ b/src/commands/tags/TagFileSystem.ts
@@ -76,7 +76,7 @@ export class TagFileSystem extends AzExtTreeFileSystem<ITagsModel> {
             context.telemetry.measurements.tagDiagnosticsLength = diagnostics.length;
 
             const showErrors: MessageItem = { title: localize('showErrors', 'Show Errors') };
-            const message: string = localize('errorsExist', 'Failed to upload tags for {0}.', this.getDisplayName(model));
+            const message: string = localize('errorsExist', 'Failed to upload tags for {0}.', this.getDetailedName(model));
             void window.showErrorMessage(message, showErrors).then(async (result) => {
                 if (result === showErrors) {
                     const openedUri: Uri | undefined = window.activeTextEditor?.document.uri;
@@ -94,7 +94,7 @@ export class TagFileSystem extends AzExtTreeFileSystem<ITagsModel> {
             // This won't be displayed, but might as well track the first diagnostic for telemetry
             throw new Error(diagnostics[0].message);
         } else {
-            const confirmMessage: string = localize('confirmTags', 'Are you sure you want to update tags for {0}?', this.getDisplayName(model));
+            const confirmMessage: string = localize('confirmTags', 'Are you sure you want to update tags for {0}?', this.getDetailedName(model));
             const update: MessageItem = { title: localize('update', 'Update') };
             await context.ui.showWarningMessage(confirmMessage, { modal: true }, update);
 
@@ -109,7 +109,7 @@ export class TagFileSystem extends AzExtTreeFileSystem<ITagsModel> {
             const client: ResourceManagementClient = await createResourceClient([context, subscriptionContext]);
             await client.tagsOperations.updateAtScope(model.id, { properties: { tags }, operation: 'Replace' });
 
-            const updatedMessage: string = localize('updatedTags', 'Successfully updated tags for {0}.', this.getDisplayName(model));
+            const updatedMessage: string = localize('updatedTags', 'Successfully updated tags for {0}.', this.getDetailedName(model));
             void window.showInformationMessage(updatedMessage);
             ext.outputChannel.appendLog(updatedMessage);
         }
@@ -136,7 +136,7 @@ export class TagFileSystem extends AzExtTreeFileSystem<ITagsModel> {
         return await node.getTags();
     }
 
-    private getDisplayName(node: ITagsModel): string {
+    private getDetailedName(node: ITagsModel): string {
         return `${node.displayType} "${node.displayName}"`;
     }
 }

--- a/src/commands/tags/TagFileSystem.ts
+++ b/src/commands/tags/TagFileSystem.ts
@@ -4,54 +4,83 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ResourceManagementClient, Tags } from "@azure/arm-resources";
-import { AzExtTreeFileSystem, IActionContext } from '@microsoft/vscode-azext-utils';
+import { AzExtTreeFileSystem, AzExtTreeFileSystemItem, callWithTelemetryAndErrorHandling, IActionContext } from '@microsoft/vscode-azext-utils';
+import { AzureResource, AzureSubscription } from "@microsoft/vscode-azext-utils/hostapi.v2";
 import * as jsonc from 'jsonc-parser';
 import * as os from "os";
 import { commands, Diagnostic, DiagnosticSeverity, FileStat, FileType, languages, MessageItem, Uri, window } from "vscode";
 import { ext } from "../../extensionVariables";
-import { AppResourceTreeItem } from "../../tree/AppResourceTreeItem";
-import { ResourceGroupTreeItem } from "../../tree/ResourceGroupTreeItem";
 import { createResourceClient } from "../../utils/azureClients";
 import { localize } from "../../utils/localize";
+import { createSubscriptionContext } from "../../utils/v2/credentialsUtils";
 
 const insertKeyHere: string = localize('insertTagName', '<Insert tag name>');
 const insertValueHere: string = localize('insertTagValue', '<Insert tag value>');
+
+export interface ITagsModel extends AzExtTreeFileSystemItem {
+    getTags(): Promise<Tags>;
+    subscription: AzureSubscription;
+    displayName: string;
+    displayType: 'resource group' | 'resource';
+
+    cTime: number;
+    mTime: number;
+}
+
+export class EditableTags implements ITagsModel {
+
+    constructor(private readonly resource: AzureResource) { }
+    cTime: number;
+    mTime: number;
+
+    readonly id: string = this.resource.id;
+    readonly subscription: AzureSubscription = this.resource.subscription;
+
+    readonly displayName: string = this.resource.name;
+    readonly displayType: "resource";
+
+    async getTags(): Promise<Tags> {
+        return await callWithTelemetryAndErrorHandling('getTags', async (context): Promise<Tags | undefined> => {
+            const subscriptionContext = createSubscriptionContext(this.resource.subscription);
+            const client = await createResourceClient([context, subscriptionContext]);
+            const resource = await client.resources.getById(this.resource.id, '2022-03-01');
+            return resource.tags;
+        }) ?? {};
+    }
+}
 
 /**
  * For now this file system only supports editing tags.
  * However, the scheme was left generic so that it could support editing other stuff in this extension without needing to create a whole new file system
  */
-export class TagFileSystem extends AzExtTreeFileSystem<ResourceGroupTreeItem | AppResourceTreeItem> {
+export class TagFileSystem extends AzExtTreeFileSystem<ITagsModel> {
     public static scheme: string = 'azureResourceGroups';
     public scheme: string = TagFileSystem.scheme;
 
-    public async statImpl(_context: IActionContext, node: ResourceGroupTreeItem | AppResourceTreeItem): Promise<FileStat> {
-        const fileContent: string = this.getFileContentFromTags(await this.getTagsFromNode(node));
-        return { type: FileType.File, ctime: node.cTime, mtime: node.mTime, size: Buffer.byteLength(fileContent) };
+    public async statImpl(_context: IActionContext, model: ITagsModel): Promise<FileStat> {
+        const fileContent: string = this.getFileContentFromTags(await this.getTagsFromNode(model));
+        return { type: FileType.File, ctime: model.cTime, mtime: model.mTime, size: Buffer.byteLength(fileContent) };
     }
 
-    public async readFileImpl(_context: IActionContext, node: ResourceGroupTreeItem | AppResourceTreeItem): Promise<Uint8Array> {
+    public async readFileImpl(_context: IActionContext, node: ITagsModel): Promise<Uint8Array> {
         const fileContent: string = this.getFileContentFromTags(await this.getTagsFromNode(node));
         return Buffer.from(fileContent);
     }
 
-    public async writeFileImpl(context: IActionContext, node: ResourceGroupTreeItem | AppResourceTreeItem, content: Uint8Array, originalUri: Uri): Promise<void> {
+    public async writeFileImpl(context: IActionContext, model: ITagsModel, content: Uint8Array, originalUri: Uri): Promise<void> {
         const text: string = content.toString();
-        const isResourceGroup: boolean = node instanceof ResourceGroupTreeItem;
 
         const diagnostics: Diagnostic[] = languages.getDiagnostics(originalUri).filter(d => d.severity === DiagnosticSeverity.Error);
         if (diagnostics.length > 0) {
             context.telemetry.measurements.tagDiagnosticsLength = diagnostics.length;
 
             const showErrors: MessageItem = { title: localize('showErrors', 'Show Errors') };
-            const message: string = isResourceGroup ?
-                localize('errorsExistGroup', 'Failed to upload tags for resource group "{0}".', node.name) :
-                localize('errorsExistResource', 'Failed to upload tags for resource "{0}".', node.name);
+            const message: string = localize('errorsExist', 'Failed to upload tags for {0}.', this.getDisplayName(model));
             void window.showErrorMessage(message, showErrors).then(async (result) => {
                 if (result === showErrors) {
                     const openedUri: Uri | undefined = window.activeTextEditor?.document.uri;
                     if (!openedUri || originalUri.query !== openedUri.query) {
-                        await this.showTextDocument(node);
+                        await this.showTextDocument(model);
                     }
 
                     await commands.executeCommand('workbench.action.showErrorsWarnings');
@@ -64,9 +93,7 @@ export class TagFileSystem extends AzExtTreeFileSystem<ResourceGroupTreeItem | A
             // This won't be displayed, but might as well track the first diagnostic for telemetry
             throw new Error(diagnostics[0].message);
         } else {
-            const confirmMessage: string = isResourceGroup ?
-                localize('confirmTagsGroup', 'Are you sure you want to update tags for resource group "{0}"?', node.name) :
-                localize('confirmTagsResource', 'Are you sure you want to update tags for resource "{0}"?', node.name);
+            const confirmMessage: string = localize('confirmTags', 'Are you sure you want to update tags for {0}?', this.getDisplayName(model));
             const update: MessageItem = { title: localize('update', 'Update') };
             await context.ui.showWarningMessage(confirmMessage, { modal: true }, update);
 
@@ -77,19 +104,18 @@ export class TagFileSystem extends AzExtTreeFileSystem<ResourceGroupTreeItem | A
                 delete tags[insertKeyHere];
             }
 
-            const client: ResourceManagementClient = await createResourceClient([context, node]);
-            await client.tagsOperations.updateAtScope(node.id, { properties: { tags }, operation: 'Replace' });
+            const subscriptionContext = createSubscriptionContext(model.subscription);
+            const client: ResourceManagementClient = await createResourceClient([context, subscriptionContext]);
+            await client.tagsOperations.updateAtScope(model.id, { properties: { tags }, operation: 'Replace' });
 
-            const updatedMessage: string = isResourceGroup ?
-                localize('updatedTagsGroup', 'Successfully updated tags for resource group "{0}".', node.name) :
-                localize('updatedTagsResource', 'Successfully updated tags for resource "{0}".', node.name);
+            const updatedMessage: string = localize('updatedTags', 'Successfully updated tags for {0}.', this.getDisplayName(model));
             void window.showInformationMessage(updatedMessage);
             ext.outputChannel.appendLog(updatedMessage);
         }
     }
 
-    public getFilePath(node: ResourceGroupTreeItem | AppResourceTreeItem): string {
-        return `${node.name}-tags.jsonc`;
+    public getFilePath(node: ITagsModel): string {
+        return `${node.displayName}-tags.jsonc`;
     }
 
     private getFileContentFromTags(tags: {} | undefined): string {
@@ -105,10 +131,11 @@ export class TagFileSystem extends AzExtTreeFileSystem<ResourceGroupTreeItem | A
         return `// ${comment}${os.EOL}${JSON.stringify(tags, undefined, 4)}`;
     }
 
-    private async getTagsFromNode(node: ResourceGroupTreeItem | AppResourceTreeItem): Promise<Tags | undefined> {
-        if (node instanceof ResourceGroupTreeItem) {
-            return (await node.getData())?.tags;
-        }
-        return node.data.tags;
+    private async getTagsFromNode(node: ITagsModel): Promise<Tags | undefined> {
+        return await node.getTags();
+    }
+
+    private getDisplayName(node: ITagsModel): string {
+        return `${node.displayType} "${node.displayName}"`;
     }
 }

--- a/src/commands/tags/TagFileSystem.ts
+++ b/src/commands/tags/TagFileSystem.ts
@@ -52,8 +52,7 @@ export class ResourceTags implements ITagsModel {
 }
 
 /**
- * For now this file system only supports editing tags.
- * However, the scheme was left generic so that it could support editing other stuff in this extension without needing to create a whole new file system
+ * File system for editing resource tags.
  */
 export class TagFileSystem extends AzExtTreeFileSystem<ITagsModel> {
     public static scheme: string = 'azureResourceGroups';

--- a/src/commands/tags/editTags.ts
+++ b/src/commands/tags/editTags.ts
@@ -8,16 +8,16 @@ import { AzureResource } from "@microsoft/vscode-azext-utils/hostapi.v2";
 import { ext } from "../../extensionVariables";
 import { AzureResourceItem } from "../../tree/v2/azure/AzureResourceItem";
 
-export async function editTags(context: IActionContext, item?: AzureResourceItem<AzureResource>): Promise<void> {
+export async function editTags(_context: IActionContext, item?: AzureResourceItem<AzureResource>): Promise<void> {
     if (!item) {
         // todo
         // node = await pickAppResource<AppResourceTreeItem>(context);
         throw new Error("A resource must be selected.");
     }
 
-    if (!item.tags) {
+    if (!item.tagsModel) {
         throw new Error("Editing tags is not supported for this resource.");
     }
 
-    await ext.tagFS.showTextDocument(item.tags);
+    await ext.tagFS.showTextDocument(item.tagsModel);
 }

--- a/src/commands/tags/editTags.ts
+++ b/src/commands/tags/editTags.ts
@@ -4,14 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import { pickAppResource } from "../../api/pickAppResource";
+import { AzureResource } from "@microsoft/vscode-azext-utils/hostapi.v2";
 import { ext } from "../../extensionVariables";
-import { AppResourceTreeItem } from "../../tree/AppResourceTreeItem";
+import { AzureResourceItem } from "../../tree/v2/azure/AzureResourceItem";
 
-export async function editTags(context: IActionContext, node?: AppResourceTreeItem): Promise<void> {
-    if (!node) {
-        node = await pickAppResource<AppResourceTreeItem>(context);
+export async function editTags(context: IActionContext, item?: AzureResourceItem<AzureResource>): Promise<void> {
+    if (!item) {
+        // todo
+        // node = await pickAppResource<AppResourceTreeItem>(context);
+        throw new Error("A resource must be selected.");
     }
 
-    await ext.tagFS.showTextDocument(node);
+    if (!item.tags) {
+        throw new Error("Editing tags is not supported for this resource.");
+    }
+
+    await ext.tagFS.showTextDocument(item.tags);
 }

--- a/src/tree/AppResourceTreeItem.ts
+++ b/src/tree/AppResourceTreeItem.ts
@@ -6,7 +6,6 @@
 import { ResourceGroup } from "@azure/arm-resources";
 import { AzExtParentTreeItem, AzExtResourceType, AzExtTreeItem, IActionContext, nonNullProp, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { AppResource, GroupableResource, GroupingConfig, GroupNodeConfiguration, ResolvedAppResourceBase } from "@microsoft/vscode-azext-utils/hostapi";
-import { FileChangeType } from "vscode";
 import { azureExtensions } from "../azureExtensions";
 import { GroupBySettings } from "../commands/explorer/groupBy";
 import { ungroupedId } from "../constants";
@@ -46,7 +45,7 @@ export class AppResourceTreeItem extends ResolvableTreeItemBase implements Group
         this.groupConfig = createGroupConfigFromResource(resource, root.id);
 
         this.contextValues.add(AppResourceTreeItem.contextValue);
-        ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
+        // ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
 
         this.type = resource.type;
         this.kind = resource.kind;
@@ -102,7 +101,7 @@ export class AppResourceTreeItem extends ResolvableTreeItemBase implements Group
 
     public async refreshImpl(context: IActionContext): Promise<void> {
         this.mTime = Date.now();
-        ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
+        // ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
         await super.refreshImpl(context);
     }
 

--- a/src/tree/ResourceGroupTreeItem.ts
+++ b/src/tree/ResourceGroupTreeItem.ts
@@ -6,10 +6,8 @@
 import { ResourceGroup, ResourceManagementClient } from "@azure/arm-resources";
 import { AzExtParentTreeItem, AzureWizard, IActionContext, nonNullProp, TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { GroupNodeConfiguration } from "@microsoft/vscode-azext-utils/hostapi";
-import { FileChangeType } from "vscode";
 import { DeleteResourceGroupContext } from "../commands/deleteResourceGroup/DeleteResourceGroupContext";
 import { DeleteResourceGroupStep } from "../commands/deleteResourceGroup/DeleteResourceGroupStep";
-import { ext } from "../extensionVariables";
 import { createActivityContext } from "../utils/activityUtils";
 import { createResourceClient } from "../utils/azureClients";
 import { localize } from "../utils/localize";
@@ -34,7 +32,7 @@ export class ResourceGroupTreeItem extends GroupTreeItemBase {
             this.data = rg;
         });
 
-        ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
+        // ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
     }
 
     public static createFromResourceGroup(parent: AzExtParentTreeItem, rg: ResourceGroup): ResourceGroupTreeItem {
@@ -67,7 +65,7 @@ export class ResourceGroupTreeItem extends GroupTreeItemBase {
         const client: ResourceManagementClient = await createResourceClient([context, this.subscription]);
         this.data = await client.resourceGroups.get(this.name);
         this.mTime = Date.now();
-        ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
+        // ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this });
         await super.refreshImpl(context);
     }
 

--- a/src/tree/v2/azure/AzureResourceItem.ts
+++ b/src/tree/v2/azure/AzureResourceItem.ts
@@ -5,7 +5,7 @@
 
 import { AzureResource, BranchDataProvider, ResourceBase, ResourceModelBase } from '@microsoft/vscode-azext-utils/hostapi.v2';
 import { FileChangeType, TreeItem } from 'vscode';
-import { EditableTags } from '../../../commands/tags/TagFileSystem';
+import { ResourceTags } from '../../../commands/tags/TagFileSystem';
 import { ext } from '../../../extensionVariables';
 import { BranchDataItemCache } from '../BranchDataItemCache';
 import { BranchDataItemOptions, BranchDataProviderItem } from '../BranchDataProviderItem';
@@ -21,16 +21,15 @@ export class AzureResourceItem<T extends AzureResource> extends BranchDataProvid
         options?: BranchDataItemOptions) {
         super(branchItem, branchDataProvider, itemCache, options);
 
-        ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this.tags });
+        ext.tagFS.fireSoon({ type: FileChangeType.Changed, item: this.tagsModel });
     }
 
     readonly id = this.resource.id;
+    readonly tagsModel = new ResourceTags(this.resource);
 
     override async getParent(): Promise<ResourceGroupsItem | undefined> {
         return this.parent;
     }
-
-    tags = new EditableTags(this.resource);
 
     override async getTreeItem(): Promise<TreeItem> {
         const treeItem = await super.getTreeItem();


### PR DESCRIPTION
Depends on https://github.com/microsoft/vscode-azuretools/pull/1257

I will add support for editing tags on resource groups in a follow up PR.

Also, I need to add a `dontUnwrap` flag to `appResourceExperience` in utils so to support getting an item from the picker here.