### PR TITLE
Don't refresh entire tree on add/remove BDP

### DIFF
--- a/src/tree/v2/azure/GroupingItem.ts
+++ b/src/tree/v2/azure/GroupingItem.ts
@@ -30,7 +30,7 @@ export class GroupingItem implements ResourceGroupsItem {
         public readonly context: ResourceGroupsTreeContext,
         private readonly resourceItemFactory: ResourceItemFactory<AzureResource>,
         private readonly branchDataProviderFactory: (azureResource: AzureResource) => AzureResourceBranchDataProvider<AzureResourceModel>,
-        private readonly onChangeBranchDataProviders: vscode.Event<AzExtResourceType>,
+        private readonly onDidChangeBranchDataProviders: vscode.Event<AzExtResourceType>,
         private readonly contextValues: string[] | undefined,
         private readonly iconPath: TreeItemIconPath | undefined,
         public readonly label: string,
@@ -49,7 +49,7 @@ export class GroupingItem implements ResourceGroupsItem {
     async getChildren(): Promise<ResourceGroupsItem[] | undefined> {
         const sortedResources = this.resources.sort((a, b) => a.name.localeCompare(b.name));
 
-        this.onChangeBranchDataProviders((type: AzExtResourceType) => {
+        this.onDidChangeBranchDataProviders((type: AzExtResourceType) => {
             const azExtResourceTypes = sortedResources.map(r => r.resourceType);
             if (azExtResourceTypes.includes(type)) {
                 ext.actions.refreshAzureTree(this);

--- a/src/tree/v2/azure/GroupingItem.ts
+++ b/src/tree/v2/azure/GroupingItem.ts
@@ -50,7 +50,7 @@ export class GroupingItem implements ResourceGroupsItem {
         const sortedResources = this.resources.sort((a, b) => a.name.localeCompare(b.name));
 
         this.onChangeBranchDataProviders((type: AzExtResourceType) => {
-            const azExtResourceTypes: AzExtResourceType[] = sortedResources.map(r => r.resourceType) as AzExtResourceType[];
+            const azExtResourceTypes = sortedResources.map(r => r.resourceType);
             if (azExtResourceTypes.includes(type)) {
                 ext.actions.refreshAzureTree(this);
             }

--- a/src/tree/v2/azure/registerAzureTree.ts
+++ b/src/tree/v2/azure/registerAzureTree.ts
@@ -28,7 +28,7 @@ export function registerAzureTree(context: vscode.ExtensionContext, options: Reg
 
     const itemCache = new BranchDataItemCache();
     const branchDataItemFactory = createResourceItemFactory<AzureResource>(itemCache);
-    const groupingItemFactory = createGroupingItemFactory(branchDataItemFactory, resource => azureResourceBranchDataProviderManager.getProvider(resource.resourceType));
+    const groupingItemFactory = createGroupingItemFactory(branchDataItemFactory, resource => azureResourceBranchDataProviderManager.getProvider(resource.resourceType), azureResourceBranchDataProviderManager.onChangeBranchDataProviders.bind(azureResourceBranchDataProviderManager));
 
     const resourceGroupingManager = new AzureResourceGroupingManager(groupingItemFactory);
     context.subscriptions.push(resourceGroupingManager);

--- a/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
+++ b/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
@@ -22,6 +22,8 @@ export class WorkspaceResourceTreeDataProvider extends ResourceTreeDataProviderB
             branchDataProviderManager.onDidChangeTreeData,
             resourceProviderManager.onDidChangeResourceChange,
             onRefresh);
+
+        branchDataProviderManager.onChangeBranchDataProviders(() => this.notifyTreeDataChanged());
     }
 
     async onGetChildren(element?: ResourceGroupsItem | undefined): Promise<ResourceGroupsItem[] | null | undefined> {


### PR DESCRIPTION
Before this change:
When a BDP was registered we refreshed the entire tree. A case where this becomes super annoying is if you have expanded the Azure Functions group but then expand another group, say App Service. The App Service extension will activate and register a BDP. The whole tree is then refreshed, including the Function Apps.

After this change:
Group items listen for changes to the registered BDPs. They will refresh when the BDP registered for a type (`AzExtResourceType`) they care about changes. The types they care about are the set of types of the group children.

For the Workspace tree, the refresh behavior remains the same. On any changes to registered BDPs, the whole tree will refresh. This is still needed for now since the client-controlled tree items are root tree items.