### PR TITLE
Implement `revealResource` for v2

### DIFF
--- a/src/api/v2/compatibility/CompatibleBranchDataProviderBase.ts
+++ b/src/api/v2/compatibility/CompatibleBranchDataProviderBase.ts
@@ -28,8 +28,8 @@ export abstract class CompatibleBranchDataProviderBase<TResource extends Resourc
         // Do nothing
     }
 
-    public override getParent(_treeItem: TModel): Promise<TModel> {
-        throw new Error('Use the Resources extension API to do getParent');
+    public override getParent(treeItem: TModel): Promise<TModel | undefined> {
+        return Promise.resolve(treeItem.parent as TModel);
     }
 
     public override async getChildren(treeItem: TModel & AzExtParentTreeItem): Promise<TModel[]> {

--- a/src/commands/revealResource.ts
+++ b/src/commands/revealResource.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { parseAzureResourceId } from '@microsoft/vscode-azext-azureutils';
-import { IActionContext, parseError } from '@microsoft/vscode-azext-utils';
+import { AzExtTreeItem, IActionContext, parseError } from '@microsoft/vscode-azext-utils';
 import { AppResource } from '@microsoft/vscode-azext-utils/hostapi';
 import { ext } from '../extensionVariables';
-import { AppResourceTreeItem } from '../tree/AppResourceTreeItem';
-import { SubscriptionTreeItem } from '../tree/SubscriptionTreeItem';
+import { ResourceGroupsItem } from '../tree/v2/ResourceGroupsItem';
+import { ResourceTreeDataProviderBase } from '../tree/v2/ResourceTreeDataProviderBase';
 
 export async function revealResource(context: IActionContext, resourceId: string): Promise<void>;
 export async function revealResource(context: IActionContext, resource: AppResource): Promise<void>;
@@ -18,12 +18,9 @@ export async function revealResource(context: IActionContext, arg: AppResource |
     context.telemetry.properties.resourceType = parseAzureResourceId(resourceId).provider.replace(/\//g, '|');
 
     try {
-        const subscriptionNode: SubscriptionTreeItem | undefined = await ext.appResourceTree.findTreeItem(`/subscriptions/${parseAzureResourceId(resourceId).subscriptionId}`, { ...context, loadAll: true });
-        const appResourceNode: AppResourceTreeItem | undefined = await subscriptionNode?.findAppResourceByResourceId(context, resourceId);
-        if (appResourceNode) {
-            // ensure the parent node loaded this AppResourceTreeItem
-            await appResourceNode.parent?.getCachedChildren(context);
-            await ext.appResourceTreeView.reveal(appResourceNode, { select: true, focus: true, expand: false });
+        const item: ResourceGroupsItem | undefined = await (ext.v2.api.resources.azureResourceTreeDataProvider as ResourceTreeDataProviderBase).findItemById(resourceId);
+        if (item) {
+            await ext.appResourceTreeView.reveal(item as unknown as AzExtTreeItem, { expand: false, focus: true, select: true });
         }
     } catch (error) {
         context.telemetry.properties.revealError = parseError(error).message;


### PR DESCRIPTION
Note that this currently doesn't support revealing subscriptions or resource groups, only resources. I hope to be able to modify this function to support them in a future PR.

Working towards https://github.com/microsoft/vscode-azureresourcegroups/issues/479