### PR TITLE
Only clear cache when VS Code calls `getChildren(undefined)`

### DIFF
--- a/src/tree/v2/ResourceTreeDataProviderBase.ts
+++ b/src/tree/v2/ResourceTreeDataProviderBase.ts
@@ -75,10 +75,6 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
     }
 
     async getChildren(element?: ResourceGroupsItem | undefined): Promise<ResourceGroupsItem[] | null | undefined> {
-        if (!element) {
-            this.itemCache.clear();
-        }
-
         return await this.onGetChildren(element);
     }
 

--- a/src/tree/v2/azure/registerAzureTree.ts
+++ b/src/tree/v2/azure/registerAzureTree.ts
@@ -11,6 +11,7 @@ import { ext } from '../../../extensionVariables';
 import { BranchDataItemCache } from '../BranchDataItemCache';
 import { createTreeView } from '../createTreeView';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
+import { wrapTreeForVSCode } from '../wrapTreeForVSCode';
 import { localize } from './../../../utils/localize';
 import { AzureResourceBranchDataProviderManager } from './AzureResourceBranchDataProviderManager';
 import { AzureResourceGroupingManager } from './AzureResourceGroupingManager';
@@ -41,9 +42,10 @@ export function registerAzureTree(context: vscode.ExtensionContext, options: Reg
     const treeView = createTreeView('azureResourceGroups', {
         canSelectMany: true,
         showCollapseAll: true,
-        treeDataProvider: azureResourceTreeDataProvider,
         itemCache,
-        description: localize('remote', 'Remote')
+        description: localize('remote', 'Remote'),
+        treeDataProvider: wrapTreeForVSCode(azureResourceTreeDataProvider, itemCache),
+        findItemById: azureResourceTreeDataProvider.findItemById.bind(azureResourceTreeDataProvider) as typeof azureResourceTreeDataProvider.findItemById
     });
     context.subscriptions.push(treeView);
 

--- a/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
+++ b/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
@@ -17,9 +17,9 @@ export class WorkspaceResourceTreeDataProvider extends ResourceTreeDataProviderB
         private readonly branchDataProviderManager: WorkspaceResourceBranchDataProviderManager,
         onRefresh: vscode.Event<void | ResourceGroupsItem | ResourceGroupsItem[] | null | undefined>,
         private readonly resourceProviderManager: WorkspaceResourceProviderManager,
-        itemCache: BranchDataItemCache) {
+        branchItemCache: BranchDataItemCache) {
         super(
-            itemCache,
+            branchItemCache,
             branchDataProviderManager.onDidChangeTreeData,
             resourceProviderManager.onDidChangeResourceChange,
             onRefresh);

--- a/src/tree/v2/workspace/registerWorkspaceTree.ts
+++ b/src/tree/v2/workspace/registerWorkspaceTree.ts
@@ -10,6 +10,7 @@ import { ext } from '../../../extensionVariables';
 import { BranchDataItemCache } from '../BranchDataItemCache';
 import { createTreeView } from '../createTreeView';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
+import { wrapTreeForVSCode } from '../wrapTreeForVSCode';
 import { localize } from './../../../utils/localize';
 import { WorkspaceResourceBranchDataProviderManager } from './WorkspaceResourceBranchDataProviderManager';
 import { WorkspaceResourceTreeDataProvider } from './WorkspaceResourceTreeDataProvider';
@@ -23,17 +24,18 @@ interface RegisterWorkspaceTreeOptions {
 export function registerWorkspaceTree(context: vscode.ExtensionContext, options: RegisterWorkspaceTreeOptions): WorkspaceResourceTreeDataProvider {
     const { workspaceResourceBranchDataProviderManager, workspaceResourceProviderManager, refreshEvent } = options;
 
-    const itemCache = new BranchDataItemCache();
+    const branchItemCache = new BranchDataItemCache();
     const workspaceResourceTreeDataProvider =
-        new WorkspaceResourceTreeDataProvider(workspaceResourceBranchDataProviderManager, refreshEvent, workspaceResourceProviderManager, itemCache);
+        new WorkspaceResourceTreeDataProvider(workspaceResourceBranchDataProviderManager, refreshEvent, workspaceResourceProviderManager, branchItemCache);
     context.subscriptions.push(workspaceResourceTreeDataProvider);
 
     const treeView = createTreeView('azureWorkspace', {
         canSelectMany: true,
         showCollapseAll: true,
-        treeDataProvider: workspaceResourceTreeDataProvider,
         description: localize('local', 'Local'),
-        itemCache,
+        itemCache: branchItemCache,
+        treeDataProvider: wrapTreeForVSCode(workspaceResourceTreeDataProvider, branchItemCache),
+        findItemById: workspaceResourceTreeDataProvider.findItemById.bind(workspaceResourceTreeDataProvider) as typeof workspaceResourceTreeDataProvider.findItemById,
     });
     context.subscriptions.push(treeView);
 

--- a/src/tree/v2/wrapTreeForVSCode.ts
+++ b/src/tree/v2/wrapTreeForVSCode.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import type { Event, ProviderResult, TreeDataProvider, TreeItem } from "vscode";
+import { BranchDataItemCache } from "./BranchDataItemCache";
+import { ResourceGroupsItem } from "./ResourceGroupsItem";
+import { ResourceTreeDataProviderBase } from "./ResourceTreeDataProviderBase";
+
+/**
+ * Returns a new tree data provider that clears the branch item cache when the root of the tree is refreshed.
+ */
+export function wrapTreeForVSCode(treeDataProvider: ResourceTreeDataProviderBase, branchItemCache: BranchDataItemCache): OnRefreshTreeDataProvider {
+    return new OnRefreshTreeDataProvider(treeDataProvider, () => branchItemCache.clear());
+}
+
+/**
+ * Wraps a tree data provider and calls a callback function when the root of the tree is refreshed.
+ */
+class OnRefreshTreeDataProvider implements TreeDataProvider<ResourceGroupsItem> {
+    constructor(
+        private readonly treeDataProvider: TreeDataProvider<ResourceGroupsItem>,
+        private readonly onRefresh: () => void,
+    ) { }
+
+    getTreeItem(element: ResourceGroupsItem): TreeItem | Thenable<TreeItem> {
+        return this.treeDataProvider.getTreeItem(element);
+    }
+
+    getParent(element: ResourceGroupsItem): ProviderResult<ResourceGroupsItem> {
+        return this.treeDataProvider.getParent?.(element);
+    }
+
+    getChildren(element?: ResourceGroupsItem): ProviderResult<ResourceGroupsItem[]> {
+        if (!element) {
+            this.onRefresh();
+        }
+        return this.treeDataProvider.getChildren(element);
+    }
+
+    onDidChangeTreeData?: Event<void | ResourceGroupsItem | ResourceGroupsItem[] | null | ResourceGroupsItem> = this.treeDataProvider.onDidChangeTreeData;
+}


### PR DESCRIPTION
Fixes #487 

Context:

Inside resource groups we wrap items provided by branch data providers to add some properties we use internally. The wrapper items are given to VS Code. We have to keep a map of the branch items to the wrapper items. This is so we can translate branch items to resource group items.

One place where we translate branch items to wrapper resource groups items is when a branch data provider fires the onDidChangeTreeData event. We have to translate the event data from branch items to wrapper items, and then pass the wrapper items to VS Code.

Bug cause:

When we use the tree data provider to pick a tree item, the branch item cache is cleared. It’s currently cleared when getChildren is called and undefined is passed. As a result, when onDidChangeTreeData is fired with a branch item we can’t translate the branch item to a wrapper item.

Any place we call getChildren(undefined) will cause this bug. I believe the only other place is during findItemById which is used for reveal.

Solution:

Wrap the tree data provider we give to VS Code so that the branch item cache is only cleared when VS Code itself refreshes the tree at the root. 