### PR TITLE
Rename `BranchDataProviderItem` to `BranchDataItemWrapper`

### DIFF
--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtTreeItem, IActionContext, openUrl } from '@microsoft/vscode-azext-utils';
-import { BranchDataProviderItem } from '../tree/v2/BranchDataProviderItem';
+import { BranchDataItemWrapper } from '../tree/v2/BranchDataProviderItem';
 import { localize } from '../utils/localize';
 
 export async function openInPortal(_context: IActionContext, node?: AzExtTreeItem): Promise<void> {
@@ -15,7 +15,7 @@ export async function openInPortal(_context: IActionContext, node?: AzExtTreeIte
         throw new Error(localize('commands.openInPortal.noSelectedResource', 'A resource must be selected.'));
     }
 
-    if (node instanceof BranchDataProviderItem && node.portalUrl) {
+    if (node instanceof BranchDataItemWrapper && node.portalUrl) {
         // NOTE: VS Code's URI type agressively encodes fragments heavily used in Portal URLs, but which the Portal doesn't understand, so skip encoding here.
         return await openUrl(node.portalUrl.toString(/* skipEncoding: */ true));
     }

--- a/src/tree/v2/BranchDataProviderItem.ts
+++ b/src/tree/v2/BranchDataProviderItem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isAzExtTreeItem } from '@microsoft/vscode-azext-utils';
+import { isAzExtTreeItem, Wrapper } from '@microsoft/vscode-azext-utils';
 import { AzureResourceModel, BranchDataProvider, ResourceBase, ResourceModelBase, ViewPropertiesModel } from '@microsoft/vscode-azext-utils/hostapi.v2';
 import { randomUUID } from 'crypto';
 import * as vscode from 'vscode';
@@ -18,16 +18,6 @@ export type BranchDataItemOptions = {
     viewProperties?: ViewPropertiesModel;
 };
 
-/**
- * Represents a branch data provider resource model as returned by a context menu command.
- */
-export interface BranchDataItem {
-    /**
-     * Unwraps the resource, returning the underlying branch data provider resource model.
-     */
-    unwrap<T extends ResourceModelBase>(): T | undefined;
-}
-
 function appendContextValues(originalValues: string | undefined, optionsValues: string[] | undefined, extraValues: string[] | undefined): string {
     const set = new Set<string>(originalValues?.split(';') ?? []);
 
@@ -37,7 +27,7 @@ function appendContextValues(originalValues: string | undefined, optionsValues: 
     return Array.from(set).join(';');
 }
 
-export class BranchDataItemWrapper implements ResourceGroupsItem, BranchDataItem {
+export class BranchDataItemWrapper implements ResourceGroupsItem, Wrapper {
     constructor(
         private readonly branchItem: ResourceModelBase,
         private readonly branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>,
@@ -98,7 +88,7 @@ export class BranchDataItemWrapper implements ResourceGroupsItem, BranchDataItem
         return undefined;
     }
 
-    unwrap<T extends ResourceModelBase>(): T | undefined {
+    unwrap<T>(): T {
         return this.branchItem as T;
     }
 

--- a/src/tree/v2/BranchDataProviderItem.ts
+++ b/src/tree/v2/BranchDataProviderItem.ts
@@ -21,7 +21,7 @@ export type BranchDataItemOptions = {
 /**
  * Represents a branch data provider resource model as returned by a context menu command.
  */
-export interface WrappedResourceModel {
+export interface BranchDataItem {
     /**
      * Unwraps the resource, returning the underlying branch data provider resource model.
      */
@@ -37,7 +37,7 @@ function appendContextValues(originalValues: string | undefined, optionsValues: 
     return Array.from(set).join(';');
 }
 
-export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResourceModel {
+export class BranchDataItemWrapper implements ResourceGroupsItem, BranchDataItem {
     constructor(
         private readonly branchItem: ResourceModelBase,
         private readonly branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>,
@@ -114,8 +114,8 @@ export class BranchDataProviderItem implements ResourceGroupsItem, WrappedResour
     }
 }
 
-export type BranchDataItemFactory = (branchItem: ResourceModelBase, branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>, options?: BranchDataItemOptions) => BranchDataProviderItem;
+export type BranchDataItemFactory = (branchItem: ResourceModelBase, branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>, options?: BranchDataItemOptions) => BranchDataItemWrapper;
 
 export function createBranchDataItemFactory(itemCache: BranchDataItemCache): BranchDataItemFactory {
-    return (branchItem, branchDataProvider, options) => new BranchDataProviderItem(branchItem, branchDataProvider, itemCache, options);
+    return (branchItem, branchDataProvider, options) => new BranchDataItemWrapper(branchItem, branchDataProvider, itemCache, options);
 }

--- a/src/tree/v2/azure/AzureResourceItem.ts
+++ b/src/tree/v2/azure/AzureResourceItem.ts
@@ -8,10 +8,10 @@ import { FileChangeType, TreeItem } from 'vscode';
 import { ResourceTags } from '../../../commands/tags/TagFileSystem';
 import { ext } from '../../../extensionVariables';
 import { BranchDataItemCache } from '../BranchDataItemCache';
-import { BranchDataItemOptions, BranchDataProviderItem } from '../BranchDataProviderItem';
+import { BranchDataItemOptions, BranchDataItemWrapper } from '../BranchDataProviderItem';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 
-export class AzureResourceItem<T extends AzureResource> extends BranchDataProviderItem {
+export class AzureResourceItem<T extends AzureResource> extends BranchDataItemWrapper {
     constructor(
         public readonly resource: T,
         branchItem: ResourceModelBase,

--- a/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
+++ b/src/tree/v2/workspace/WorkspaceResourceTreeDataProvider.ts
@@ -7,7 +7,7 @@ import { WorkspaceResource } from '@microsoft/vscode-azext-utils/hostapi.v2';
 import * as vscode from 'vscode';
 import { WorkspaceResourceProviderManager } from '../../../api/v2/ResourceProviderManagers';
 import { BranchDataItemCache } from '../BranchDataItemCache';
-import { BranchDataProviderItem } from '../BranchDataProviderItem';
+import { BranchDataItemWrapper } from '../BranchDataProviderItem';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { ResourceTreeDataProviderBase } from '../ResourceTreeDataProviderBase';
 import { WorkspaceResourceBranchDataProviderManager } from './WorkspaceResourceBranchDataProviderManager';
@@ -59,6 +59,6 @@ export class WorkspaceResourceTreeDataProvider extends ResourceTreeDataProviderB
 
         const resourceItem = await branchDataProvider.getResourceItem(resource);
 
-        return new BranchDataProviderItem(resourceItem, branchDataProvider, this.itemCache);
+        return new BranchDataItemWrapper(resourceItem, branchDataProvider, this.itemCache);
     }
 }


### PR DESCRIPTION
The thinking is...

`BranchDataProvider`s provide `BranchDataItem`s, which are wrapped up in `BranchDataItemWrapper`s, which are owned by RG. 

\- Brandon

@nturinski just want you to take a look at the PR description.