### PR TITLE
Translate items created via picker into items created via tree

### DIFF
--- a/src/api/compatibility/pickAppResource.ts
+++ b/src/api/compatibility/pickAppResource.ts
@@ -6,12 +6,17 @@
 import { AzExtResourceType, AzExtTreeItem, ContextValueFilter, getAzExtResourceType, ITreeItemPickerContext, PickTreeItemWithCompatibility } from "@microsoft/vscode-azext-utils";
 import { PickAppResourceOptions } from "@microsoft/vscode-azext-utils/hostapi";
 import { ext } from "../../extensionVariables";
+import { BranchDataItemCache } from "../../tree/BranchDataItemCache";
 
-export async function pickAppResource<T extends AzExtTreeItem>(context: ITreeItemPickerContext, options?: PickAppResourceOptions): Promise<T> {
-    return await PickTreeItemWithCompatibility.resource<T>(context, ext.v2.api.resources.azureResourceTreeDataProvider, {
-        resourceTypes: convertAppResourceFilterToAzExtResourceType(options?.filter),
-        childItemFilter: convertExpectedChildContextValueToContextValueFilter(options?.expectedChildContextValue)
-    });
+export function createCompatibilityPickAppResource(itemCache: BranchDataItemCache) {
+    return async function pickAppResource<T extends AzExtTreeItem>(context: ITreeItemPickerContext, options?: PickAppResourceOptions): Promise<T> {
+        const result = await PickTreeItemWithCompatibility.resource<T>(context, ext.v2.api.resources.azureResourceTreeDataProvider, {
+            resourceTypes: convertAppResourceFilterToAzExtResourceType(options?.filter),
+            childItemFilter: convertExpectedChildContextValueToContextValueFilter(options?.expectedChildContextValue)
+        });
+
+        return itemCache.getItemForId(result.fullId) as T | undefined ?? result;
+    }
 }
 
 function convertExpectedChildContextValueToContextValueFilter(expectedChildContextValue?: PickAppResourceOptions['expectedChildContextValue']): ContextValueFilter | undefined {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ import { ActivityLogTreeItem } from './activityLog/ActivityLogsTreeItem';
 import { registerActivity } from './activityLog/registerActivity';
 import { InternalAzureResourceGroupsExtensionApi } from './api/compatibility/AzureResourceGroupsExtensionApi';
 import { CompatibleAzExtTreeDataProvider } from './api/compatibility/CompatibleAzExtTreeDataProvider';
-import { pickAppResource } from './api/compatibility/pickAppResource';
+import { createCompatibilityPickAppResource } from './api/compatibility/pickAppResource';
 import { registerApplicationResourceResolver } from './api/compatibility/registerApplicationResourceResolver';
 import { registerWorkspaceResourceProvider } from './api/compatibility/registerWorkspaceResourceProvider';
 import { createAzureResourcesHostApi } from './api/createAzureResourcesHostApi';
@@ -30,6 +30,7 @@ import { ext } from './extensionVariables';
 import { AzureResourceBranchDataProviderManager } from './tree/azure/AzureResourceBranchDataProviderManager';
 import { DefaultAzureResourceBranchDataProvider } from './tree/azure/DefaultAzureResourceBranchDataProvider';
 import { registerAzureTree } from './tree/azure/registerAzureTree';
+import { BranchDataItemCache } from './tree/BranchDataItemCache';
 import { HelpTreeItem } from './tree/HelpTreeItem';
 import { ResourceGroupsItem } from './tree/ResourceGroupsItem';
 import { registerWorkspaceTree } from './tree/workspace/registerWorkspaceTree';
@@ -91,10 +92,12 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         type => void extensionManager.activateWorkspaceResourceBranchDataProvider(type));
     const workspaceResourceProviderManager = new WorkspaceResourceProviderManager(() => extensionManager.activateWorkspaceResourceProviders());
 
+    const azureResourcesBranchDataItemCache = new BranchDataItemCache();
     const azureResourceTreeDataProvider = registerAzureTree(context, {
         azureResourceProviderManager,
         azureResourceBranchDataProviderManager,
         refreshEvent: refreshAzureTreeEmitter.event,
+        itemCache: azureResourcesBranchDataItemCache
     });
 
     const workspaceResourceTreeDataProvider = registerWorkspaceTree(context, {
@@ -141,7 +144,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
                     registerApplicationResourceResolver,
                     registerWorkspaceResourceProvider,
                     registerActivity,
-                    pickAppResource,
+                    pickAppResource: createCompatibilityPickAppResource(azureResourcesBranchDataItemCache),
                 }),
             },
             v2ApiFactory,

--- a/src/tree/BranchDataItemCache.ts
+++ b/src/tree/BranchDataItemCache.ts
@@ -19,4 +19,14 @@ export class BranchDataItemCache {
     getItemForBranchItem(branchItem: unknown): ResourceGroupsItem | undefined {
         return this.branchItemToResourceGroupsItemCache.get(branchItem);
     }
+
+    getItemForId(id: string): unknown {
+        for (const [key, value] of this.branchItemToResourceGroupsItemCache.entries()) {
+            if (value.id === id) {
+                return key;
+            }
+        }
+
+        return undefined;
+    }
 }

--- a/src/tree/azure/registerAzureTree.ts
+++ b/src/tree/azure/registerAzureTree.ts
@@ -41,7 +41,7 @@ export function registerAzureTree(context: vscode.ExtensionContext, options: Reg
         itemCache,
         description: localize('remote', 'Remote'),
         treeDataProvider: wrapTreeForVSCode(azureResourceTreeDataProvider, itemCache),
-        findItemById: azureResourceTreeDataProvider.findItemById.bind(azureResourceTreeDataProvider) as typeof azureResourceTreeDataProvider.findItemById,
+        findItemById: azureResourceTreeDataProvider.findItemById.bind(azureResourceTreeDataProvider) as typeof azureResourceTreeDataProvider.findItemById
     });
     context.subscriptions.push(treeView);
 

--- a/src/tree/createTreeView.ts
+++ b/src/tree/createTreeView.ts
@@ -14,12 +14,12 @@ export interface InternalTreeView extends TreeView<ResourceGroupsItem> {
 
 interface InternalTreeViewOptions extends TreeViewOptions<ResourceGroupsItem> {
     treeDataProvider: TreeDataProvider<ResourceGroupsItem>;
+    findItemById: (id: string) => Promise<ResourceGroupsItem | undefined>;
     itemCache: BranchDataItemCache;
     /**
      * See {@link TreeView.description}
      */
     description?: string;
-    findItemById: (id: string) => Promise<ResourceGroupsItem | undefined>;
 }
 
 /**

--- a/src/tree/createTreeView.ts
+++ b/src/tree/createTreeView.ts
@@ -14,12 +14,12 @@ export interface InternalTreeView extends TreeView<ResourceGroupsItem> {
 
 interface InternalTreeViewOptions extends TreeViewOptions<ResourceGroupsItem> {
     treeDataProvider: TreeDataProvider<ResourceGroupsItem>;
-    findItemById: (id: string) => Promise<ResourceGroupsItem | undefined>;
     itemCache: BranchDataItemCache;
     /**
      * See {@link TreeView.description}
      */
     description?: string;
+    findItemById: (id: string) => Promise<ResourceGroupsItem | undefined>;
 }
 
 /**


### PR DESCRIPTION
Fixes #487 

See [my comment](https://github.com/microsoft/vscode-azureresourcegroups/issues/487#issuecomment-1376616009) for why this issue happens, and why this fix is needed.

With v1, client extensions expected items returned by pickAppResource to be the same item as what might be on the tree. To fulfill this expectation in v2, after an item is picked we try to translate it into an item that was created by the tree.