### PR TITLE
Update minimum required version of VS Code to 1.66

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
                 "webpack-cli": "^4.6.0"
             },
             "engines": {
-                "vscode": "^1.65.0"
+                "vscode": "^1.66.0"
             }
         },
         "node_modules/@azure/abort-controller": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/resourceGroup.png",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "engines": {
-        "vscode": "^1.65.0"
+        "vscode": "^1.66.0"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
We require Node 16.13.0, which was introduced in 1.66. See https://code.visualstudio.com/updates/v1_66#_engineering

Fixes #403 