### PR TITLE
Don't do case-sensitive Azure resource ID comparison

### DIFF
--- a/src/commands/revealResource.ts
+++ b/src/commands/revealResource.ts
@@ -45,14 +45,13 @@ function parsePartialAzureResourceId(id: string): Partial<ParsedAzureResourceId>
 }
 
 function getResourceKindFromId(parsedId: Partial<ParsedAzureResourceId>): 'subscription' | 'resourceGroup' | 'resource' {
-    if (parsedId.subscriptionId) {
-        return 'subscription';
-    }
-    if (parsedId.resourceGroup) {
-        return 'resourceGroup';
-    }
     if (parsedId.resourceName) {
         return 'resource';
+    } else if (parsedId.resourceGroup) {
+        return 'resourceGroup';
+    } else if (parsedId.subscriptionId) {
+        return 'subscription';
     }
+
     throw new Error('Invalid Azure Resource Id');
 }

--- a/src/tree/ResourceTreeDataProviderBase.ts
+++ b/src/tree/ResourceTreeDataProviderBase.ts
@@ -103,7 +103,7 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
             }
 
             for (const child of children) {
-                if (child.id === id) {
+                if (child.id.toLowerCase() === id.toLowerCase()) {
                     return child;
                 } else if (this.isAncestorOf(child, id)) {
                     element = child;
@@ -116,7 +116,7 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
     }
 
     protected isAncestorOf(element: ResourceGroupsItem, id: string): boolean {
-        return id.startsWith(element.id + '/');
+        return id.toLowerCase().startsWith(element.id.toLowerCase() + '/');
     }
 
     protected abstract onGetChildren(element?: ResourceGroupsItem | undefined): Promise<ResourceGroupsItem[] | null | undefined>;

--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -140,7 +140,7 @@ export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase 
 
     protected override isAncestorOf(element: ResourceGroupsItem, id: string): boolean {
         if (element instanceof GroupingItem) {
-            return element.resources.some(resource => id.startsWith(resource.id));
+            return element.resources.some(resource => id.toLowerCase().startsWith(resource.id.toLowerCase()));
         }
         return super.isAncestorOf(element, id)
     }


### PR DESCRIPTION
Fixes a bug where nothing was happening when I was calling for a resource to be revealed