### PR TITLE
Fix `AzExtTreeItem.deleteTreeItem` compat

### DIFF
--- a/src/api/compatibility/application/CompatibleApplicationResourceTreeItem.ts
+++ b/src/api/compatibility/application/CompatibleApplicationResourceTreeItem.ts
@@ -69,7 +69,7 @@ export class CompatibleResolvedApplicationResourceTreeItem extends AzExtParentTr
                 subscription: __subscription,
                 parent: undefined,
                 removeChildFromCache: () => {
-                    //
+                    this.treeDataProvider.refreshUIOnly(undefined);
                 },
             }) as unknown as AzExtParentTreeItem
         );


### PR DESCRIPTION
We need to call refresh when a tree item calls removeChildFromCache on the parent. That way the removed items actually go away.

Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/783

I tested with VMs, but fix should apply to all extensions equally.