### PR TITLE
Scoped global refresh for BDPs

### DIFF
--- a/src/tree/ResourceBranchDataProviderManagerBase.ts
+++ b/src/tree/ResourceBranchDataProviderManagerBase.ts
@@ -34,7 +34,14 @@ export abstract class ResourceBranchDataProviderManagerBase<TResourceType, TBran
             type,
             {
                 provider,
-                listener: provider.onDidChangeTreeData?.(e => this.onDidChangeTreeDataEmitter.fire(e))
+                listener: provider.onDidChangeTreeData?.((e) => {
+                    if (e) {
+                        this.onDidChangeTreeDataEmitter.fire(e);
+                    } else {
+                        // scope a change event to the specific branch data provider
+                        this.onDidChangeBranchDataProvidersEmitter.fire(type);
+                    }
+                }),
             }
         );
 


### PR DESCRIPTION
When a BDP does a root refresh, don't refresh the entire tree.

Instead, this refreshes any item which has a child that is provided by said BDP.