### PR TITLE
Define `id` on Azure resource nodes to fix children open in portal

### DIFF
--- a/src/api/compatibility/application/CompatibleApplicationResourceBranchDataProvider.ts
+++ b/src/api/compatibility/application/CompatibleApplicationResourceBranchDataProvider.ts
@@ -33,6 +33,11 @@ export class CompatibleApplicationResourceBranchDataProvider<TResource extends A
                 return element.id;
             }
         });
+        Object.defineProperty(result, 'id', {
+            get: () => {
+                return element.id;
+            }
+        });
 
         return result;
     }

--- a/src/api/compatibility/application/CompatibleApplicationResourceTreeItem.ts
+++ b/src/api/compatibility/application/CompatibleApplicationResourceTreeItem.ts
@@ -34,10 +34,6 @@ export class CompatibleResolvedApplicationResourceTreeItem extends AzExtParentTr
     public mTime: number = Date.now();
     public tags?: { [propertyName: string]: string; } | undefined;
 
-    public get id(): string | undefined {
-        return undefined;
-    }
-
     public get label(): string {
         return nonNullProp(this.data, 'name');
     }


### PR DESCRIPTION
v1.5 client extension expect this node to have `id` defined. Specifically, they use it to create portal urls for child nodes.

Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/785