### PR TITLE
Add GitHub Actions workflows for api package

### DIFF
--- a/.github/workflows/api-extractor.yaml
+++ b/.github/workflows/api-extractor.yaml
@@ -1,0 +1,34 @@
+name: 'API: Generate and Rollup Typings'
+# Runs the api-extractor tool to verify generating and rolling up API typings doesn't fail
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  api-extractor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run api-extractor
+        run: npm run api-extractor

--- a/.github/workflows/api-publish.yaml
+++ b/.github/workflows/api-publish.yaml
@@ -1,0 +1,33 @@
+name: 'API: Publish to npm'
+# Publishes the api package to npm
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  api-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish package
+        uses: pascalgn/npm-publish-action@1.3.9
+        with:
+          create_tag: "false"
+          workspace: "./api"
+          publish_command: "npm publish"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}

--- a/api/.npmignore
+++ b/api/.npmignore
@@ -13,6 +13,7 @@ test-results.xml
 .eslintrc.js
 resources/*.png
 *.tsbuildinfo
+docs/
 
 out/**/*.d.ts
 out/**/*.d.ts.map

--- a/api/README.md
+++ b/api/README.md
@@ -17,7 +17,7 @@ The Azure Resources extension exposes an API which enables any number of client 
 
 ### Resource views
 
-<img align="right" src="docs/media/resource-views.png" width="50%" />
+<img align="right" src="https://github.com/microsoft/vscode-azureresourcegroups/blob/main/api/docs/media/resource-views.png?raw=true" width="50%" />
 
 Allows multiple extensions to contribute rich features to unified resource tree views in the Azure view.
 
@@ -40,7 +40,7 @@ Consumers of the API can:
 
 ### Create Resource menu
 
-<img align="right" src="docs/media/create-resource.png" width="60%" />
+<img align="right" src="https://github.com/microsoft/vscode-azureresourcegroups/blob/main/api/docs/media/create-resource.png?raw=true" width="60%" />
 
 <br/>
 <br/>
@@ -259,7 +259,8 @@ todo
 
 ## Extension dependencies
 
-<img align="right" src="docs/media/extension-dependency-graphic.png" alt="Extension dependency graphic" width="50%" />
+
+<img align="right" src="https://github.com/microsoft/vscode-azureresourcegroups/blob/main/api/docs/media/extension-dependency-graphic.png?raw=true" alt="Extension dependency graphic" width="50%" />
 
 Client extensions must declare the Azure Resources extension as an extension dependency in their extension manifest `package.json` file.
 


### PR DESCRIPTION
Also changed the image links on the readme to point to the GitHub raw files, instead of relative paths. That way the readme can have images without publishing the images in the package.