### PR TITLE
Gracefully handle tree errors with `InvalidItem`

### DIFF
--- a/src/tree/InvalidItem.ts
+++ b/src/tree/InvalidItem.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { IParsedError } from "@microsoft/vscode-azext-utils";
+import { randomUUID } from "crypto";
+import { ProviderResult, ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
+import { ResourceGroupsItem } from "./ResourceGroupsItem";
+
+export class InvalidItem implements ResourceGroupsItem {
+    constructor(public readonly error: IParsedError) { }
+    id = randomUUID();
+
+    getTreeItem(): TreeItem {
+        return {
+            collapsibleState: TreeItemCollapsibleState.None,
+            contextValue: 'invalidItem',
+            iconPath: new ThemeIcon('warning'),
+            id: this.id,
+            label: this.error.message,
+        }
+    }
+
+    getChildren(): ProviderResult<ResourceGroupsItem[]> {
+        return [];
+    }
+}

--- a/src/tree/workspace/WorkspaceResourceTreeDataProvider.ts
+++ b/src/tree/workspace/WorkspaceResourceTreeDataProvider.ts
@@ -54,6 +54,16 @@ export class WorkspaceResourceTreeDataProvider extends ResourceTreeDataProviderB
 
         const resourceItem = await branchDataProvider.getResourceItem(resource);
 
+        if (!resourceItem) {
+            throw new UnexpectedNullishReturnValueError('getResourceItem', resourceItem);
+        }
+
         return new BranchDataItemWrapper(resourceItem, branchDataProvider, this.itemCache);
+    }
+}
+
+export class UnexpectedNullishReturnValueError extends Error {
+    constructor(functionName: string, value: never) {
+        super(`Internal error: ${functionName} returned ${String(value)}. Expected a non-nullish value.`);
     }
 }


### PR DESCRIPTION
I'm keeping `InvalidItem` very simple for now. However, I can see us adding features like "Copy error information" command to it in the future.