### PR TITLE
Actually throw errors in wrapFunctionsInTelemetry

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -16,6 +16,7 @@
 // At runtime the tests live in dist/tests and will therefore pick up the main webpack bundle at dist/extension.bundle.js.
 export * from '@microsoft/vscode-azext-utils';
 export * from './src/commands/tags/getTagDiagnostics';
+export * from './src/utils/wrapFunctionsInTelemetry';
 // Export activate/deactivate for main.js
 export { activateInternal, deactivateInternal } from './src/extension';
 export * from './src/extensionVariables';

--- a/src/api/createWrappedAzureResourcesExtensionApi.ts
+++ b/src/api/createWrappedAzureResourcesExtensionApi.ts
@@ -3,33 +3,33 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { AzureResourcesApiInternal } from '../../hostapi.v2.internal';
-import { wrapFunctionsInTelemetry } from '../utils/wrapFunctionsInTelemetry';
+import { wrapFunctionsInTelemetry, wrapFunctionsInTelemetrySync } from '../utils/wrapFunctionsInTelemetry';
 
 export function createWrappedAzureResourcesExtensionApi(api: AzureResourcesApiInternal, extensionId: string): AzureResourcesApiInternal {
-
-    function wrap<TFunctions extends Record<string, (...args: unknown[]) => unknown>>(functions: TFunctions): TFunctions {
-        return wrapFunctionsInTelemetry(functions, {
-            callbackIdPrefix: 'v2.',
-            beforeHook: context => context.telemetry.properties.callingExtensionId = extensionId,
-        });
-    }
+    const wrapOptions = {
+        callbackIdPrefix: 'v2.',
+        beforeHook: (context: IActionContext) => context.telemetry.properties.callingExtensionId = extensionId,
+    };
 
     return Object.freeze({
         apiVersion: api.apiVersion,
-        activity: wrap({
+        activity: wrapFunctionsInTelemetry({
             registerActivity: api.activity.registerActivity.bind(api) as typeof api.activity.registerActivity,
-        }),
+        }, wrapOptions),
         resources: {
             azureResourceTreeDataProvider: api.resources.azureResourceTreeDataProvider,
             workspaceResourceTreeDataProvider: api.resources.workspaceResourceTreeDataProvider,
-            ...wrap({
+            ...wrapFunctionsInTelemetry({
+                revealAzureResource: api.resources.revealAzureResource.bind(api) as typeof api.resources.revealAzureResource,
+            }, wrapOptions),
+            ...wrapFunctionsInTelemetrySync({
                 registerAzureResourceBranchDataProvider: api.resources.registerAzureResourceBranchDataProvider.bind(api) as typeof api.resources.registerAzureResourceBranchDataProvider,
                 registerAzureResourceProvider: api.resources.registerAzureResourceProvider.bind(api) as typeof api.resources.registerAzureResourceProvider,
                 registerWorkspaceResourceProvider: api.resources.registerWorkspaceResourceProvider.bind(api) as typeof api.resources.registerWorkspaceResourceProvider,
                 registerWorkspaceResourceBranchDataProvider: api.resources.registerWorkspaceResourceBranchDataProvider.bind(api) as typeof api.resources.registerWorkspaceResourceBranchDataProvider,
-                revealAzureResource: api.resources.revealAzureResource.bind(api) as typeof api.resources.revealAzureResource,
-            }),
+            }, wrapOptions),
         }
     });
 }

--- a/src/tree/ResourceBranchDataProviderManagerBase.ts
+++ b/src/tree/ResourceBranchDataProviderManagerBase.ts
@@ -85,7 +85,6 @@ function wrapBranchDataProvider<TBranchDataProvider extends BranchDataProvider<R
                     }
                     return result;
                 },
-                // getResourceItem: branchDataProvider.getResourceItem.bind(branchDataProvider) as typeof branchDataProvider.getResourceItem,
                 getParent: branchDataProvider.getParent?.bind(branchDataProvider) as typeof branchDataProvider.getChildren,
             },
             {

--- a/src/utils/wrapFunctionsInTelemetry.ts
+++ b/src/utils/wrapFunctionsInTelemetry.ts
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { callWithTelemetryAndErrorHandling, IActionContext } from "@microsoft/vscode-azext-utils";
+import { callWithTelemetryAndErrorHandling, callWithTelemetryAndErrorHandlingSync, IActionContext } from "@microsoft/vscode-azext-utils";
 
 interface WrapFunctionsInTelemetryOptions {
     /**
@@ -16,8 +16,15 @@ interface WrapFunctionsInTelemetryOptions {
     callbackIdPrefix?: string;
 }
 
+type AsyncFunctions<T extends Record<string, (...args: unknown[]) => unknown | Promise<unknown>>> = {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    [P in keyof T]: AsyncFunction<T[P]>;
+};
+
+type AsyncFunction<T extends (...args: unknown[]) => Promise<unknown> | unknown> = (...args: Parameters<T>) => ReturnType<T> extends Promise<infer TPromise> ? Promise<TPromise> : Promise<ReturnType<T>>;
+
 /**
- * Wraps a set of functions in telemetry and error handling.
+ * Wraps a set of functions in telemetry and error handling. Returned functions are always async.
  *
  * Automatically sets the following on context:
  * ```
@@ -26,18 +33,45 @@ interface WrapFunctionsInTelemetryOptions {
  * context.errorHandling.suppressReportIssue = true;
  * ```
  */
-export function wrapFunctionsInTelemetry<TFunctions extends Record<string, (...args: unknown[]) => unknown | Promise<unknown>>>(functions: TFunctions, options?: WrapFunctionsInTelemetryOptions): TFunctions {
+export function wrapFunctionsInTelemetry<TFunctions extends Record<string, (...args: unknown[]) => unknown | Promise<unknown>>>(functions: TFunctions, options?: WrapFunctionsInTelemetryOptions): AsyncFunctions<TFunctions> {
     const wrappedFunctions = {};
 
     Object.entries(functions).forEach(([functionName, func]) => {
-        wrappedFunctions[functionName] = async (...args: Parameters<typeof func>): Promise<ReturnType<typeof func>> => {
-            return await callWithTelemetryAndErrorHandling((options?.callbackIdPrefix ?? '') + functionName, async (context) => {
+        wrappedFunctions[functionName] = (...args: Parameters<typeof func>): ReturnType<typeof func> => {
+            return callWithTelemetryAndErrorHandling((options?.callbackIdPrefix ?? '') + functionName, async (context) => {
                 context.errorHandling.rethrow = true;
                 context.errorHandling.suppressDisplay = true;
                 context.errorHandling.suppressReportIssue = true;
                 options?.beforeHook?.(context);
-                // await to ensure errors are handled in this scope
                 return await func(...args);
+            });
+        }
+    });
+
+    return wrappedFunctions as AsyncFunctions<TFunctions>;
+}
+
+/**
+ * Wraps a set of sync functions in telemetry and error handling.
+ *
+ * Automatically sets the following on context:
+ * ```
+ * context.errorHandling.rethrow = true;
+ * context.errorHandling.suppressDisplay = true;
+ * context.errorHandling.suppressReportIssue = true;
+ * ```
+ */
+export function wrapFunctionsInTelemetrySync<TFunctions extends Record<string, (...args: unknown[]) => unknown>>(functions: TFunctions, options?: WrapFunctionsInTelemetryOptions): TFunctions {
+    const wrappedFunctions = {};
+
+    Object.entries(functions).forEach(([functionName, func]) => {
+        wrappedFunctions[functionName] = (...args: Parameters<typeof func>): ReturnType<typeof func> => {
+            return callWithTelemetryAndErrorHandlingSync((options?.callbackIdPrefix ?? '') + functionName, (context) => {
+                context.errorHandling.rethrow = true;
+                context.errorHandling.suppressDisplay = true;
+                context.errorHandling.suppressReportIssue = true;
+                options?.beforeHook?.(context);
+                return func(...args);
             });
         }
     });

--- a/src/utils/wrapFunctionsInTelemetry.ts
+++ b/src/utils/wrapFunctionsInTelemetry.ts
@@ -36,6 +36,7 @@ export function wrapFunctionsInTelemetry<TFunctions extends Record<string, (...a
                 context.errorHandling.suppressDisplay = true;
                 context.errorHandling.suppressReportIssue = true;
                 options?.beforeHook?.(context);
+                // await to ensure errors are handled in this scope
                 return await func(...args);
             });
         }

--- a/src/utils/wrapFunctionsInTelemetry.ts
+++ b/src/utils/wrapFunctionsInTelemetry.ts
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { callWithTelemetryAndErrorHandlingSync, IActionContext } from "@microsoft/vscode-azext-utils";
+import { callWithTelemetryAndErrorHandling, IActionContext } from "@microsoft/vscode-azext-utils";
 
 interface WrapFunctionsInTelemetryOptions {
     /**
@@ -26,17 +26,17 @@ interface WrapFunctionsInTelemetryOptions {
  * context.errorHandling.suppressReportIssue = true;
  * ```
  */
-export function wrapFunctionsInTelemetry<TFunctions extends Record<string, (...args: unknown[]) => unknown>>(functions: TFunctions, options?: WrapFunctionsInTelemetryOptions): TFunctions {
+export function wrapFunctionsInTelemetry<TFunctions extends Record<string, (...args: unknown[]) => unknown | Promise<unknown>>>(functions: TFunctions, options?: WrapFunctionsInTelemetryOptions): TFunctions {
     const wrappedFunctions = {};
 
     Object.entries(functions).forEach(([functionName, func]) => {
-        wrappedFunctions[functionName] = (...args: Parameters<typeof func>): ReturnType<typeof func> => {
-            return callWithTelemetryAndErrorHandlingSync((options?.callbackIdPrefix ?? '') + functionName, context => {
+        wrappedFunctions[functionName] = async (...args: Parameters<typeof func>): Promise<ReturnType<typeof func>> => {
+            return await callWithTelemetryAndErrorHandling((options?.callbackIdPrefix ?? '') + functionName, async (context) => {
                 context.errorHandling.rethrow = true;
                 context.errorHandling.suppressDisplay = true;
                 context.errorHandling.suppressReportIssue = true;
                 options?.beforeHook?.(context);
-                return func(...args);
+                return await func(...args);
             });
         }
     });

--- a/test/wrapFunctionsInTelemetry.test.ts
+++ b/test/wrapFunctionsInTelemetry.test.ts
@@ -1,0 +1,96 @@
+import assert = require("assert");
+import { IActionContext, wrapFunctionsInTelemetry, wrapFunctionsInTelemetrySync } from "../extension.bundle";
+
+suite('wrapFunctionsInTelemetry', () => {
+    test('wrapped sync function returns a Promise', () => {
+        const functions = {
+            funcThatThrows: () => {
+                throw new Error();
+            }
+        };
+        const wrappedFunctions = wrapFunctionsInTelemetry(functions);
+        assert.ok(wrappedFunctions.funcThatThrows() instanceof Promise);
+    });
+
+    test('Wrapper function throws when the wrapped function throws', async () => {
+        const functions = {
+            asyncFuncThatThrows: async () => {
+                throw new Error();
+            }
+        };
+        const wrappedFunctions = wrapFunctionsInTelemetry(functions);
+        assertThrowsAsync(() => wrappedFunctions.asyncFuncThatThrows());
+    });
+
+    test('Telemetry result is "Failed" when function throws', async () => {
+        const functions = {
+            asyncFuncThatThrows: async () => {
+                throw new Error();
+            }
+        };
+
+        let wrapperContext: IActionContext | undefined;
+        const wrappedFunctions = wrapFunctionsInTelemetry(functions, {
+            beforeHook: (context) => {
+                wrapperContext = context;
+            },
+        });
+
+        try {
+            await wrappedFunctions.asyncFuncThatThrows();
+        } catch (e) {
+            // ignore error
+        }
+
+        console.log(JSON.stringify(wrapperContext?.telemetry));
+        assert.strictEqual(wrapperContext?.telemetry.properties.result, 'Failed', 'Expected result to be "Failed"');
+    });
+});
+
+suite('wrapFunctionsInTelemetrySync', () => {
+    test('Wrapper function throws when the wrapped function throws', () => {
+        const functions = {
+            funcThatThrows: () => {
+                throw new Error();
+            }
+        };
+        const wrappedFunctions = wrapFunctionsInTelemetrySync(functions);
+
+        assert.throws(() => wrappedFunctions.funcThatThrows());
+    });
+
+    test('Telemetry result is "Failed" when function throws', () => {
+        const functions = {
+            funcThatThrows: () => {
+                throw new Error();
+            }
+        };
+
+        let wrapperContext: IActionContext | undefined;
+        const wrappedFunctions = wrapFunctionsInTelemetrySync(functions, {
+            beforeHook: (context) => {
+                wrapperContext = context;
+            },
+        });
+
+        try {
+            wrappedFunctions.funcThatThrows();
+        } catch (e) {
+            // ignore error
+        }
+
+        console.log(JSON.stringify(wrapperContext?.telemetry));
+        assert.strictEqual(wrapperContext?.telemetry.properties.result, 'Failed', 'Expected result to be "Failed"');
+    });
+});
+
+export async function assertThrowsAsync<T>(block: () => Promise<T>): Promise<void> {
+    let blockSync = (): void => { /* ignore */ };
+    try {
+        await block();
+    } catch (e) {
+        blockSync = (): void => { throw e; };
+    } finally {
+        assert.throws(blockSync);
+    }
+}


### PR DESCRIPTION
Errors thrown inside the wrapped functions were not being handled in this scope, so they weren't being recorded in telemetry.

To make sure the errors are handled inside the `callWithTelemetryAndErrorHandling`, we gotta await stuff.