### PR TITLE
Refactor create resource command to prevent serialization errors

### DIFF
--- a/src/utils/extensionUtils.ts
+++ b/src/utils/extensionUtils.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { contributesKey } from '../constants';
+
+const builtInExtensionIdRegex = /^vscode\./i;
+
+export function getExternalExtensions(): vscode.Extension<unknown>[] {
+    return vscode.extensions
+        .all
+        // We don't need to look at any built-in extensions (often the majority of them)
+        .filter(extension => !builtInExtensionIdRegex.test(extension.id));
+}
+
+export function getInactiveExtensions(): vscode.Extension<unknown>[] {
+    return getExternalExtensions()
+        // We don't need to activate extensions that are already active
+        .filter(extension => !extension.isActive);
+}
+
+interface ResourceGroupsContribution {
+    readonly azure: {
+        readonly branches?: { type: string }[];
+        readonly resources?: boolean;
+    }
+    readonly workspace: {
+        readonly branches?: { type: string }[];
+        readonly resources?: boolean;
+    }
+    readonly commands?: (vscode.Command & { detail?: string })[];
+}
+
+interface ExtensionPackage {
+    readonly contributes?: {
+        readonly [contributesKey]?: ResourceGroupsContribution;
+    };
+}
+
+export function getV2ResourceContributions(extension: vscode.Extension<unknown>): ResourceGroupsContribution | undefined {
+    const packageJson = extension.packageJSON as ExtensionPackage;
+
+    return packageJson?.contributes?.[contributesKey];
+}

--- a/src/utils/getResourceContributions.ts
+++ b/src/utils/getResourceContributions.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { contributesKey } from '../constants';
+
+interface ResourceGroupsContribution {
+    readonly azure: {
+        readonly branches?: { type: string }[];
+        readonly resources?: boolean;
+    }
+    readonly workspace: {
+        readonly branches?: { type: string }[];
+        readonly resources?: boolean;
+    }
+    readonly commands?: (vscode.Command & { detail?: string })[];
+}
+
+interface ExtensionPackage {
+    readonly contributes?: {
+        readonly [contributesKey]?: ResourceGroupsContribution;
+    };
+}
+
+export function getResourceContributions(extension: vscode.Extension<unknown>): ResourceGroupsContribution | undefined {
+    const packageJson = extension.packageJSON as ExtensionPackage;
+
+    return packageJson?.contributes?.[contributesKey];
+}


### PR DESCRIPTION
Fixes #559

Technically #559 is already fixed thanks to the new `SubscriptionItem` class being serializable. However, to prevent the error from coming back, we can manually activate the extension before calling the command, which prevents the arguments passed to `vscode.commands.executeCommand` from being serialized by VS Code at all.

FYI throwing when an arg can't be serialized is actually the expected behavior in VS Code. See https://github.com/microsoft/vscode/commit/79280beee2359239bbcceceac2e2fe2f1af12d17.