### PR TITLE
Publish web bundle and package.json to a blob container for testing on vscode.dev

### DIFF
--- a/.azure-pipelines/common/package.yml
+++ b/.azure-pipelines/common/package.yml
@@ -15,12 +15,74 @@ steps:
   displayName: 'Copy vsix to staging directory'
   inputs:
     Contents: '**/*.vsix'
-    TargetFolder: '$(build.artifactstagingdirectory)'
+    TargetFolder: '$(build.artifactstagingdirectory)/vsix'
+
+- task: CopyFiles@2
+  displayName: 'Copy web bundle to staging directory'
+  inputs:
+    Contents: 'dist/web/*.js*'
+    TargetFolder: '$(build.artifactstagingdirectory)/web/'
+
+- task: CopyFiles@2
+  displayName: 'Copy package.json to staging directory'
+  inputs:
+    Contents: 'package.json'
+    TargetFolder: '$(build.artifactstagingdirectory)/web'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish artifacts: vsix'
   inputs:
-    PathtoPublish: '$(build.artifactstagingdirectory)'
+    PathtoPublish: '$(build.artifactstagingdirectory)/vsix'
     ArtifactName: vsix
   # Only publish vsix from linux build since we use this to release and want to stay consistent
   condition: and(eq(variables['Agent.OS'], 'Linux'), ne(variables['System.PullRequest.IsFork'], 'True'))
+
+- task: AzureFileCopy@4
+  # If AzureFileCopy ever supports not using account keys we should consider making use of it.
+  # If we do, we should also consider moving to user delegatation SAS in the generate SAS step.
+  # See: https://github.com/microsoft/azure-pipelines-tasks/issues/15610
+  displayName: 'Upload web to blob storage'
+  inputs:
+    SourcePath: '$(build.artifactstagingdirectory)/web/*'
+    # This is a service connection for the ADO project. Can be managed under ADO project settings.
+    azureSubscription: ms-azuretools-vscode-dot-dev-connection
+    Destination: AzureBlob
+    storage: $(WEB_BUILDS_STG_ACCT)
+    ContainerName: $(WEB_BUILDS_CONTAINER)
+    BlobPrefix: '$(build.buildnumber)'
+  # Only do steps for publishing web bits on Windows as AzureFileCopy is only supported on Windows
+  # See: https://github.com/microsoft/azure-pipelines-tasks/issues/8920
+  condition: and(eq(variables['Agent.OS'], 'Windows_NT'), ne(variables['System.PullRequest.IsFork'], 'True'))
+
+- task: AzureCLI@2
+  displayName: 'Generate SAS to web'
+  inputs:
+    # This is a service connection for the ADO project. Can be managed under ADO project settings.
+    azureSubscription: ms-azuretools-vscode-dot-dev-connection
+    scriptType: 'ps'
+    scriptLocation: 'inlineScript'
+    inlineScript: |
+      $sasToken = az storage container generate-sas `
+        --account-name $(WEB_BUILDS_STG_ACCT) `
+        --name $(WEB_BUILDS_CONTAINER) `
+        --permissions r `
+        --expiry ((Get-Date).AddDays(30)).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssK") `
+        --auth-mode key `
+        --out tsv
+      # Replace all % with %25 so vscode.dev does not re-encode the URL thus breaking it.
+      $sasToken = $sasToken -replace ("%", "%25")
+      $extensionRootUrl = "https://$(WEB_BUILDS_STG_ACCT).blob.core.windows.net/$(WEB_BUILDS_CONTAINER)/" + "$(build.buildnumber)" + "/?" + $sasToken
+      $extensionRootUrl | Out-File -FilePath '$(build.artifactstagingdirectory)/web-sas.txt'
+      echo $extensionRootUrl
+  # Only do steps for publishing web bits on Windows as AzureFileCopy is only supported on Windows
+  # See: https://github.com/microsoft/azure-pipelines-tasks/issues/8920
+  condition: and(eq(variables['Agent.OS'], 'Windows_NT'), ne(variables['System.PullRequest.IsFork'], 'True'))
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts: web-sas'
+  inputs:
+    PathtoPublish: '$(build.artifactstagingdirectory)/web-sas.txt'
+    ArtifactName: web-sas
+  # Only do steps for publishing web bits on Windows as AzureFileCopy is only supported on Windows
+  # See: https://github.com/microsoft/azure-pipelines-tasks/issues/8920
+  condition: and(eq(variables['Agent.OS'], 'Windows_NT'), ne(variables['System.PullRequest.IsFork'], 'True'))

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -1,4 +1,6 @@
 variables:
+  WEB_BUILDS_STG_ACCT: vscodedotdev
+  WEB_BUILDS_CONTAINER: web-builds
   ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
     ENABLE_LONG_RUNNING_TESTS: true
     ENABLE_COMPLIANCE: true


### PR DESCRIPTION
Adds steps to the package.yml for:
1. Publishing bits for testing vscode.dev to a blob container
2. Generating a URL with a SAS token to the directory for the build
3. Publishing that SAS as a build artifact, which you can then give to vscode.dev

Some FYIs:
- Target storage account and container are defined by a pipeline variable.
- The SAS URL is currently both outputted to the build logs and uploaded as a build artifact. If ADO ever starts to redact the SAS in the logs, we can refer to the artifact until we work aroudn the redaction. To use the URL, copy and paste it, and then use it with the vscode.dev command to install from a location.
- The SAS is only good for 30 days. If you need to test a build for longer you can either:
   1. Generate a SAS on your own using Storage Explorer.
   2. Just use a SAS from a new-build on the URL for the build-you-want-to-test, since the SAS's are good for any blob/directory in the container.
- Blob service CORS rules have been configured for the storage account. You can go view those in Storage Explorer if you'd like. I'm allowing any host to make any GET request. Went with any host because I saw a variety of hosts making requests and it didn't seem worth it to try and figure out all of them. If we want to restrict the hosts we should probably just get a list from the VS Code team.
- A data lifecycle rule for deleting blobs which have not been modified in 90 days has been configured for the storage account.
- The container has been leased to help avoid being deleted.

Example build which is compatible with vscode.dev can be found here: https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=58210&view=results