### PR TITLE
Add `Buffer` Node standard library to `webpack` bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -585,6 +585,7 @@
         "mocha": "^10.1.0",
         "mocha-junit-reporter": "^1.23.1",
         "mocha-multi-reporters": "^1.1.7",
+        "node-stdlib-browser": "^1.2.0",
         "ts-node": "^10.9.1",
         "tsconfig-paths-webpack-plugin": "^4.0.0",
         "typescript": "^4.3.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,9 @@ const process = require('process');
 const dev = require("@microsoft/vscode-azext-dev");
 const webpack = require('webpack');
 
+const stdLibBrowser = require('node-stdlib-browser');
+const { NodeProtocolUrlPlugin } = require('node-stdlib-browser/helpers/webpack/plugin');
+
 let DEBUG_WEBPACK = !/^(false|0)?$/i.test(process.env.DEBUG_WEBPACK || '');
 
 const config = dev.getDefaultWebpackConfig({
@@ -45,7 +48,15 @@ const webConfig = dev.getDefaultWebpackConfig({
         '../build/default/bufferutil': 'commonjs ../build/default/bufferutil',
     },
     target: 'webworker',
-
+    resolve: {
+        alias: stdLibBrowser
+    },
+    plugins: [
+        new NodeProtocolUrlPlugin(),
+        new webpack.ProvidePlugin({
+            Buffer: [stdLibBrowser.buffer, 'Buffer']
+        })
+    ]
 });
 
 if (DEBUG_WEBPACK) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,9 +48,6 @@ const webConfig = dev.getDefaultWebpackConfig({
         '../build/default/bufferutil': 'commonjs ../build/default/bufferutil',
     },
     target: 'webworker',
-    resolve: {
-        alias: stdLibBrowser
-    },
     plugins: [
         new NodeProtocolUrlPlugin(),
         new webpack.ProvidePlugin({


### PR DESCRIPTION
Should solve the issue we're seeing with `edit tags` in #543

I'm using the `node-stdlib-browser` package as a dev dependency to help us bring in Node's `Buffer` library, let me know if there is another package or method we would prefer using instead to solve this issue.