### PR TITLE
Remove redundant workspace getResourceItem error handling

### DIFF
--- a/src/tree/workspace/WorkspaceResourceTreeDataProvider.ts
+++ b/src/tree/workspace/WorkspaceResourceTreeDataProvider.ts
@@ -51,19 +51,7 @@ export class WorkspaceResourceTreeDataProvider extends ResourceTreeDataProviderB
 
     private async getWorkspaceItemModel(resource: WorkspaceResource): Promise<ResourceGroupsItem> {
         const branchDataProvider = this.branchDataProviderManager.getProvider(resource.resourceType);
-
         const resourceItem = await branchDataProvider.getResourceItem(resource);
-
-        if (!resourceItem) {
-            throw new UnexpectedNullishReturnValueError('getResourceItem', resourceItem);
-        }
-
         return new BranchDataItemWrapper(resourceItem, branchDataProvider, this.itemCache);
-    }
-}
-
-export class UnexpectedNullishReturnValueError extends Error {
-    constructor(functionName: string, value: never) {
-        super(`Internal error: ${functionName} returned ${String(value)}. Expected a non-nullish value.`);
     }
 }


### PR DESCRIPTION
This error handling is now covered centrally by https://github.com/microsoft/vscode-azureresourcegroups/blob/43ea37f416779b5b6c0e7945e36850c402cee7cc/src/tree/ResourceBranchDataProviderManagerBase.ts#L81-L87