### PR TITLE
Show workspace resources even if workspace isn't open

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,11 +244,6 @@
             },
             {
                 "view": "azureWorkspace",
-                "contents": "No workspace has been opened.",
-                "when": "azureWorkspace.state == 'noWorkspace'"
-            },
-            {
-                "view": "azureWorkspace",
                 "contents": "No local workspace resources exist.",
                 "when": "azureWorkspace.state == 'noWorkspaceResources'"
             },


### PR DESCRIPTION
Instead of not displaying resources if no workspace is opened, show resources and also add a tree item that prompts users to open a folder/workspace.

![image](https://user-images.githubusercontent.com/12476526/219814372-fcab2397-0420-45b7-8299-8573b753edc4.png)

This more closely mirrors the current behavior, and fixes https://github.com/microsoft/vscode-azurestorage/issues/1214
