### PR TITLE
Refactor VS Code auth

### DIFF
--- a/.azure-pipelines/common/build.yml
+++ b/.azure-pipelines/common/build.yml
@@ -1,8 +1,8 @@
 steps:
 - task: NodeTool@0
-  displayName: 'Use Node 14.x'
+  displayName: 'Use Node 16.x'
   inputs:
-    versionSpec: 14.x
+    versionSpec: 16.x
 
 - task: Npm@1
   displayName: 'npm ci'

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
                 "@azure/arm-subscriptions": "^5.1.0",
                 "@microsoft/vscode-azext-azureutils": "0.4.0-alpha.1",
-                "@microsoft/vscode-azext-utils": "0.4.3-alpha",
+                "@microsoft/vscode-azext-utils": "^0.5.2-alpha.0",
                 "buffer": "^6.0.3",
                 "jsonc-parser": "^2.2.1",
                 "uuidv4": "^6.2.13",
@@ -668,6 +668,24 @@
                 "vscode-nls": "^5.0.1"
             }
         },
+        "node_modules/@microsoft/vscode-azext-azureutils/node_modules/@microsoft/vscode-azext-utils": {
+            "version": "0.4.3-alpha",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.4.3-alpha.tgz",
+            "integrity": "sha512-UdZ/WQAKLGPDk6ugjUxr13DnwBM7ptzuzWq1id2rVvmklzVKm75KTvONV3Lp2IbwwNy/w9I8OxcDxYauVOSZxQ==",
+            "dependencies": {
+                "@microsoft/vscode-azureresources-api": "^2.0.2",
+                "@vscode/extension-telemetry": "^0.6.2",
+                "crypto-randomuuid": "^1.0.0",
+                "dayjs": "^1.11.2",
+                "escape-string-regexp": "^2.0.0",
+                "semver": "^7.3.7",
+                "text-encoding": "^0.7.0",
+                "uuid": "^9.0.0",
+                "vscode-nls": "^5.0.1",
+                "vscode-tas-client": "^0.1.47",
+                "vscode-uri": "^3.0.6"
+            }
+        },
         "node_modules/@microsoft/vscode-azext-azureutils/node_modules/uuid": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -965,17 +983,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.5.1.tgz",
-            "integrity": "sha512-t/qValEWJzzTadvvexehfHYDOKJXQZJuiddq0TAjDmf74ZOsJZwtgqrCkFaL5nkVEvLH+SSFpKmxgN+q945Slg==",
-            "dependencies": {
-                "chalk": "^2.4.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@microsoft/vscode-azext-dev/node_modules/minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1246,9 +1253,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "0.4.3-alpha",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.4.3-alpha.tgz",
-            "integrity": "sha512-UdZ/WQAKLGPDk6ugjUxr13DnwBM7ptzuzWq1id2rVvmklzVKm75KTvONV3Lp2IbwwNy/w9I8OxcDxYauVOSZxQ==",
+            "version": "0.5.2-alpha.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.5.2-alpha.0.tgz",
+            "integrity": "sha512-OkBDa23N3C4TukjAs5Xf3JWP/Ubo953xSNklE91ByA04w5NTu2onrQOaY+lAjiM+5jQWmeDsWozVndCEvvSrhQ==",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.0.2",
                 "@vscode/extension-telemetry": "^0.6.2",
@@ -1861,152 +1868,6 @@
                 "semver": "bin/semver"
             }
         },
-        "node_modules/@webassemblyjs/ast": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-            "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
-            "dev": true,
-            "dependencies": {
-                "@webassemblyjs/helper-numbers": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
-            }
-        },
-        "node_modules/@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-            "dev": true
-        },
-        "node_modules/@webassemblyjs/helper-api-error": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-            "dev": true
-        },
-        "node_modules/@webassemblyjs/helper-buffer": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-            "dev": true
-        },
-        "node_modules/@webassemblyjs/helper-numbers": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-            "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
-            "dev": true,
-            "dependencies": {
-                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
-                "@webassemblyjs/helper-api-error": "1.11.1",
-                "@xtuc/long": "4.2.2"
-            }
-        },
-        "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-            "dev": true
-        },
-        "node_modules/@webassemblyjs/helper-wasm-section": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-            "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
-            "dev": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/helper-buffer": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-                "@webassemblyjs/wasm-gen": "1.11.1"
-            }
-        },
-        "node_modules/@webassemblyjs/ieee754": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-            "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
-            "dev": true,
-            "dependencies": {
-                "@xtuc/ieee754": "^1.2.0"
-            }
-        },
-        "node_modules/@webassemblyjs/leb128": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-            "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
-            "dev": true,
-            "dependencies": {
-                "@xtuc/long": "4.2.2"
-            }
-        },
-        "node_modules/@webassemblyjs/utf8": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-            "dev": true
-        },
-        "node_modules/@webassemblyjs/wasm-edit": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-            "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
-            "dev": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/helper-buffer": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-                "@webassemblyjs/helper-wasm-section": "1.11.1",
-                "@webassemblyjs/wasm-gen": "1.11.1",
-                "@webassemblyjs/wasm-opt": "1.11.1",
-                "@webassemblyjs/wasm-parser": "1.11.1",
-                "@webassemblyjs/wast-printer": "1.11.1"
-            }
-        },
-        "node_modules/@webassemblyjs/wasm-gen": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-            "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
-            "dev": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-                "@webassemblyjs/ieee754": "1.11.1",
-                "@webassemblyjs/leb128": "1.11.1",
-                "@webassemblyjs/utf8": "1.11.1"
-            }
-        },
-        "node_modules/@webassemblyjs/wasm-opt": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-            "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
-            "dev": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/helper-buffer": "1.11.1",
-                "@webassemblyjs/wasm-gen": "1.11.1",
-                "@webassemblyjs/wasm-parser": "1.11.1"
-            }
-        },
-        "node_modules/@webassemblyjs/wasm-parser": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-            "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
-            "dev": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/helper-api-error": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-                "@webassemblyjs/ieee754": "1.11.1",
-                "@webassemblyjs/leb128": "1.11.1",
-                "@webassemblyjs/utf8": "1.11.1"
-            }
-        },
-        "node_modules/@webassemblyjs/wast-printer": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-            "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
-            "dev": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@xtuc/long": "4.2.2"
-            }
-        },
         "node_modules/@webpack-cli/configtest": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
@@ -2572,15 +2433,6 @@
                 "node": ">= 4.5.0"
             }
         },
-        "node_modules/axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-            "dev": true,
-            "dependencies": {
-                "follow-redirects": "^1.14.0"
-            }
-        },
         "node_modules/azure-devops-node-api": {
             "version": "11.2.0",
             "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz",
@@ -2664,8 +2516,7 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "optional": true
+            ]
         },
         "node_modules/big-integer": {
             "version": "1.6.51",
@@ -4595,18 +4446,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/es-array-method-boxes-properly": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-            "dev": true
-        },
-        "node_modules/es-module-lexer": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-            "dev": true
-        },
         "node_modules/es-set-tostringtag": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
@@ -4672,12 +4511,6 @@
                 "es5-ext": "^0.10.35",
                 "es6-symbol": "^3.1.1"
             }
-        },
-        "node_modules/es6-object-assign": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-            "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
-            "dev": true
         },
         "node_modules/es6-symbol": {
             "version": "3.1.3",
@@ -7554,22 +7387,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-nan": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-            "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-negated-glob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -7870,12 +7687,6 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
-        },
-        "node_modules/json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -9566,22 +9377,6 @@
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
             "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
             "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-is": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -13607,19 +13402,6 @@
             "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "dev": true,
             "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/webpack/node_modules/webpack-sources": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-            "dev": true,
-            "engines": {
                 "node": ">=10.13.0"
             }
         },
@@ -13880,6 +13662,7 @@
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -14642,6 +14425,24 @@
                 "vscode-nls": "^5.0.1"
             },
             "dependencies": {
+                "@microsoft/vscode-azext-utils": {
+                    "version": "0.4.3-alpha",
+                    "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.4.3-alpha.tgz",
+                    "integrity": "sha512-UdZ/WQAKLGPDk6ugjUxr13DnwBM7ptzuzWq1id2rVvmklzVKm75KTvONV3Lp2IbwwNy/w9I8OxcDxYauVOSZxQ==",
+                    "requires": {
+                        "@microsoft/vscode-azureresources-api": "^2.0.2",
+                        "@vscode/extension-telemetry": "^0.6.2",
+                        "crypto-randomuuid": "^1.0.0",
+                        "dayjs": "^1.11.2",
+                        "escape-string-regexp": "^2.0.0",
+                        "semver": "^7.3.7",
+                        "text-encoding": "^0.7.0",
+                        "uuid": "^9.0.0",
+                        "vscode-nls": "^5.0.1",
+                        "vscode-tas-client": "^0.1.47",
+                        "vscode-uri": "^3.0.6"
+                    }
+                },
                 "uuid": {
                     "version": "9.0.0",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -14864,15 +14665,6 @@
                         "path-exists": "^3.0.0"
                     }
                 },
-                "log-symbols": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-                    "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.2"
-                    }
-                },
                 "minimatch": {
                     "version": "3.0.4",
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -15092,9 +14884,9 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.5.1.tgz",
-            "integrity": "sha512-t/qValEWJzzTadvvexehfHYDOKJXQZJuiddq0TAjDmf74ZOsJZwtgqrCkFaL5nkVEvLH+SSFpKmxgN+q945Slg==",
+            "version": "0.5.2-alpha.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-0.5.2-alpha.0.tgz",
+            "integrity": "sha512-OkBDa23N3C4TukjAs5Xf3JWP/Ubo953xSNklE91ByA04w5NTu2onrQOaY+lAjiM+5jQWmeDsWozVndCEvvSrhQ==",
             "requires": {
                 "@microsoft/vscode-azureresources-api": "^2.0.2",
                 "@vscode/extension-telemetry": "^0.6.2",
@@ -15585,152 +15377,6 @@
                 }
             }
         },
-        "@webassemblyjs/ast": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-            "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
-            "dev": true,
-            "requires": {
-                "@webassemblyjs/helper-numbers": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
-            }
-        },
-        "@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-            "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-            "dev": true
-        },
-        "@webassemblyjs/helper-api-error": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-            "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-            "dev": true
-        },
-        "@webassemblyjs/helper-buffer": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-            "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-            "dev": true
-        },
-        "@webassemblyjs/helper-numbers": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-            "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
-            "dev": true,
-            "requires": {
-                "@webassemblyjs/floating-point-hex-parser": "1.11.1",
-                "@webassemblyjs/helper-api-error": "1.11.1",
-                "@xtuc/long": "4.2.2"
-            }
-        },
-        "@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-            "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-            "dev": true
-        },
-        "@webassemblyjs/helper-wasm-section": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-            "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
-            "dev": true,
-            "requires": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/helper-buffer": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-                "@webassemblyjs/wasm-gen": "1.11.1"
-            }
-        },
-        "@webassemblyjs/ieee754": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-            "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
-            "dev": true,
-            "requires": {
-                "@xtuc/ieee754": "^1.2.0"
-            }
-        },
-        "@webassemblyjs/leb128": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-            "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
-            "dev": true,
-            "requires": {
-                "@xtuc/long": "4.2.2"
-            }
-        },
-        "@webassemblyjs/utf8": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-            "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-            "dev": true
-        },
-        "@webassemblyjs/wasm-edit": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-            "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
-            "dev": true,
-            "requires": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/helper-buffer": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-                "@webassemblyjs/helper-wasm-section": "1.11.1",
-                "@webassemblyjs/wasm-gen": "1.11.1",
-                "@webassemblyjs/wasm-opt": "1.11.1",
-                "@webassemblyjs/wasm-parser": "1.11.1",
-                "@webassemblyjs/wast-printer": "1.11.1"
-            }
-        },
-        "@webassemblyjs/wasm-gen": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-            "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
-            "dev": true,
-            "requires": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-                "@webassemblyjs/ieee754": "1.11.1",
-                "@webassemblyjs/leb128": "1.11.1",
-                "@webassemblyjs/utf8": "1.11.1"
-            }
-        },
-        "@webassemblyjs/wasm-opt": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-            "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
-            "dev": true,
-            "requires": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/helper-buffer": "1.11.1",
-                "@webassemblyjs/wasm-gen": "1.11.1",
-                "@webassemblyjs/wasm-parser": "1.11.1"
-            }
-        },
-        "@webassemblyjs/wasm-parser": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-            "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
-            "dev": true,
-            "requires": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@webassemblyjs/helper-api-error": "1.11.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-                "@webassemblyjs/ieee754": "1.11.1",
-                "@webassemblyjs/leb128": "1.11.1",
-                "@webassemblyjs/utf8": "1.11.1"
-            }
-        },
-        "@webassemblyjs/wast-printer": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-            "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
-            "dev": true,
-            "requires": {
-                "@webassemblyjs/ast": "1.11.1",
-                "@xtuc/long": "4.2.2"
-            }
-        },
         "@webpack-cli/configtest": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
@@ -16152,15 +15798,6 @@
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
-        "axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-            "dev": true,
-            "requires": {
-                "follow-redirects": "^1.14.0"
-            }
-        },
         "azure-devops-node-api": {
             "version": "11.2.0",
             "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.2.0.tgz",
@@ -16223,9 +15860,7 @@
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
-            "optional": true
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "big-integer": {
             "version": "1.6.51",
@@ -16590,9 +16225,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001228",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-            "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+            "version": "1.0.30001452",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001452.tgz",
+            "integrity": "sha512-Lkp0vFjMkBB3GTpLR8zk4NwW5EdRdnitwYJHDOOKIU85x4ckYCPQ+9WlVvSVClHxVReefkUMtWZH2l9KGlD51w==",
             "dev": true
         },
         "chainsaw": {
@@ -17797,18 +17432,6 @@
                 "which-typed-array": "^1.1.9"
             }
         },
-        "es-array-method-boxes-properly": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-            "dev": true
-        },
-        "es-module-lexer": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-            "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-            "dev": true
-        },
         "es-set-tostringtag": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
@@ -17861,12 +17484,6 @@
                 "es5-ext": "^0.10.35",
                 "es6-symbol": "^3.1.1"
             }
-        },
-        "es6-object-assign": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-            "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
-            "dev": true
         },
         "es6-symbol": {
             "version": "3.1.3",
@@ -19559,6 +19176,12 @@
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
         },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+            "dev": true
+        },
         "gulp": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
@@ -20139,16 +19762,6 @@
                 "is-extglob": "^2.1.1"
             }
         },
-        "is-nan": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-            "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3"
-            }
-        },
         "is-negated-glob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -20315,7 +19928,7 @@
         "isobject": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
             "dev": true
         },
         "jest-worker": {
@@ -20362,12 +19975,6 @@
                 "esprima": "^4.0.0"
             }
         },
-        "json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
-        },
         "json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -20398,9 +20005,8 @@
             "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
         },
         "jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.6"
@@ -21643,7 +21249,7 @@
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
             "dev": true
         },
         "object-assign": {
@@ -21725,16 +21331,6 @@
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
             "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
             "dev": true
-        },
-        "object-is": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
-            }
         },
         "object-keys": {
             "version": "1.1.1",
@@ -25121,7 +24717,8 @@
         "xmlbuilder": {
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "dev": true
         },
         "xpath.js": {
             "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -983,6 +983,18 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@microsoft/vscode-azext-dev/node_modules/log-symbols": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+            "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^2.4.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/@microsoft/vscode-azext-dev/node_modules/minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2008,6 +2020,16 @@
                 "follow-redirects": "^1.14.0"
             }
         },
+        "node_modules/adal-node/node_modules/uuid": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "dev": true,
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
         "node_modules/agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -2350,6 +2372,73 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/array.prototype.flatmap": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+            "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4",
+                "es-shim-unscopables": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/array.prototype.reduce": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
+            "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4",
+                "es-array-method-boxes-properly": "^1.0.0",
+                "is-string": "^1.0.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/asn1.js": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+            "dev": true,
+            "dependencies": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "node_modules/asn1.js/node_modules/bn.js": {
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+            "dev": true
+        },
+        "node_modules/assert": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+            "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+            "dev": true,
+            "dependencies": {
+                "es6-object-assign": "^1.1.0",
+                "is-nan": "^1.2.1",
+                "object-is": "^1.0.1",
+                "util": "^0.12.0"
+            }
+        },
         "node_modules/assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -2431,6 +2520,18 @@
             },
             "engines": {
                 "node": ">= 4.5.0"
+            }
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/azure-devops-node-api": {
@@ -3643,6 +3744,24 @@
                 "webpack": "^4.37.0 || ^5.0.0"
             }
         },
+        "node_modules/copy-webpack-plugin/node_modules/schema-utils": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+            "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+            "dev": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.5",
+                "ajv": "^6.12.4",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 8.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
         "node_modules/core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -4446,6 +4565,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es-array-method-boxes-properly": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+            "dev": true
+        },
         "node_modules/es-set-tostringtag": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
@@ -4511,6 +4636,12 @@
                 "es5-ext": "^0.10.35",
                 "es6-symbol": "^3.1.1"
             }
+        },
+        "node_modules/es6-object-assign": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+            "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
+            "dev": true
         },
         "node_modules/es6-symbol": {
             "version": "3.1.3",
@@ -6927,6 +7058,12 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
+            "dev": true
+        },
         "node_modules/https-proxy-agent": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -7387,6 +7524,22 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-nan": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+            "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-negated-glob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -7553,6 +7706,25 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-typed-array": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+            "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+            "dev": true,
+            "dependencies": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-unc-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
@@ -7648,6 +7820,15 @@
                 "node": ">= 10.13.0"
             }
         },
+        "node_modules/jest-worker/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/jest-worker/node_modules/supports-color": {
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -7724,10 +7905,13 @@
             "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
         },
         "node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -9381,6 +9565,22 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/object-is": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -9924,6 +10124,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+            "dev": true
+        },
+        "node_modules/picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
             "dev": true
         },
         "node_modules/picomatch": {
@@ -10734,6 +10940,26 @@
             "dependencies": {
                 "ret": "~0.1.10"
             }
+        },
+        "node_modules/safe-regex-test": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+            "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.3",
+                "is-regex": "^1.1.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "node_modules/sax": {
             "version": "1.2.4",
@@ -12931,6 +13157,15 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/vinyl": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
@@ -14665,6 +14900,15 @@
                         "path-exists": "^3.0.0"
                     }
                 },
+                "log-symbols": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+                    "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.2"
+                    }
+                },
                 "minimatch": {
                     "version": "3.0.4",
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -15480,6 +15724,12 @@
                     "requires": {
                         "follow-redirects": "^1.14.0"
                     }
+                },
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+                    "dev": true
                 }
             }
         },
@@ -15739,6 +15989,63 @@
                 "es-shim-unscopables": "^1.0.0"
             }
         },
+        "array.prototype.flatmap": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+            "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4",
+                "es-shim-unscopables": "^1.0.0"
+            }
+        },
+        "array.prototype.reduce": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
+            "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4",
+                "es-array-method-boxes-properly": "^1.0.0",
+                "is-string": "^1.0.7"
+            }
+        },
+        "asn1.js": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+                    "dev": true
+                }
+            }
+        },
+        "assert": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+            "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+            "dev": true,
+            "requires": {
+                "es6-object-assign": "^1.1.0",
+                "is-nan": "^1.2.1",
+                "object-is": "^1.0.1",
+                "util": "^0.12.0"
+            }
+        },
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -15796,6 +16103,12 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
+        },
+        "available-typed-arrays": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
             "dev": true
         },
         "azure-devops-node-api": {
@@ -16764,6 +17077,19 @@
                 "schema-utils": "^2.6.6",
                 "serialize-javascript": "^3.0.0",
                 "webpack-sources": "^1.4.3"
+            },
+            "dependencies": {
+                "schema-utils": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+                    "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.5",
+                        "ajv": "^6.12.4",
+                        "ajv-keywords": "^3.5.2"
+                    }
+                }
             }
         },
         "core-util-is": {
@@ -17432,6 +17758,12 @@
                 "which-typed-array": "^1.1.9"
             }
         },
+        "es-array-method-boxes-properly": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+            "dev": true
+        },
         "es-set-tostringtag": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
@@ -17484,6 +17816,12 @@
                 "es5-ext": "^0.10.35",
                 "es6-symbol": "^3.1.1"
             }
+        },
+        "es6-object-assign": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+            "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
+            "dev": true
         },
         "es6-symbol": {
             "version": "3.1.3",
@@ -19434,6 +19772,12 @@
                 "debug": "4"
             }
         },
+        "https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
+            "dev": true
+        },
         "https-proxy-agent": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -19762,6 +20106,16 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-nan": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+            "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3"
+            }
+        },
         "is-negated-glob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -19871,6 +20225,19 @@
                 "has-symbols": "^1.0.2"
             }
         },
+        "is-typed-array": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+            "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+            "dev": true,
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
         "is-unc-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
@@ -19942,6 +20309,12 @@
                 "supports-color": "^8.0.0"
             },
             "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
                 "supports-color": {
                     "version": "8.1.1",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -20005,11 +20378,13 @@
             "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
         },
         "jsonfile": {
-            "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.6"
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
             }
         },
         "just-debounce": {
@@ -21332,6 +21707,16 @@
             "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
             "dev": true
         },
+        "object-is": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -21755,6 +22140,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+            "dev": true
+        },
+        "picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
             "dev": true
         },
         "picomatch": {
@@ -22357,6 +22748,23 @@
             "requires": {
                 "ret": "~0.1.10"
             }
+        },
+        "safe-regex-test": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+            "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.3",
+                "is-regex": "^1.1.4"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "sax": {
             "version": "1.2.4",
@@ -24112,6 +24520,12 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
             "integrity": "sha512-jdBB2FrWvQC/pnPtIqcLsMaQgjhdb6B7tk1MMyTKapox+tQZbdRP4uLxu/JY0t7fbfDCUMnuelzEYv5GsxHhdg==",
+            "dev": true
+        },
+        "vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
             "dev": true
         },
         "vinyl": {

--- a/package.json
+++ b/package.json
@@ -602,7 +602,5 @@
         "vscode-nls": "^5.0.1",
         "vscode-uri": "^3.0.7"
     },
-    "extensionDependencies": [
-        "ms-vscode.azure-account"
-    ]
+    "extensionDependencies": []
 }

--- a/package.json
+++ b/package.json
@@ -595,7 +595,7 @@
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
         "@azure/arm-subscriptions": "^5.1.0",
         "@microsoft/vscode-azext-azureutils": "0.4.0-alpha.1",
-        "@microsoft/vscode-azext-utils": "0.4.3-alpha",
+        "@microsoft/vscode-azext-utils": "^0.5.2-alpha.0",
         "buffer": "^6.0.3",
         "jsonc-parser": "^2.2.1",
         "uuidv4": "^6.2.13",

--- a/src/commands/accounts/logIn.ts
+++ b/src/commands/accounts/logIn.ts
@@ -7,5 +7,6 @@ import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
 
 export async function logIn(_context: IActionContext): Promise<void> {
-    await ext.subscriptionProvider.logIn();
+    const provider = await ext.subscriptionProviderFactory();
+    await provider.logIn();
 }

--- a/src/commands/accounts/logOut.ts
+++ b/src/commands/accounts/logOut.ts
@@ -7,5 +7,6 @@ import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
 
 export async function logOut(_context: IActionContext): Promise<void> {
-    await ext.subscriptionProvider.logOut();
+    const provider = await ext.subscriptionProviderFactory();
+    await provider.logOut();
 }

--- a/src/commands/accounts/selectSubscriptions.ts
+++ b/src/commands/accounts/selectSubscriptions.ts
@@ -7,5 +7,6 @@ import { IActionContext } from "@microsoft/vscode-azext-utils";
 import { ext } from "../../extensionVariables";
 
 export async function selectSubscriptions(_context: IActionContext): Promise<void> {
-    await ext.subscriptionProvider.selectSubscriptions();
+    const provider = await ext.subscriptionProviderFactory();
+    await provider.selectSubscriptions();
 }

--- a/src/commands/accounts/selectSubscriptions.ts
+++ b/src/commands/accounts/selectSubscriptions.ts
@@ -4,37 +4,8 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from "@microsoft/vscode-azext-utils";
-import * as vscode from 'vscode';
-import { AzureSubscription } from '../../../api/src/index';
 import { ext } from "../../extensionVariables";
 
 export async function selectSubscriptions(_context: IActionContext): Promise<void> {
-    const results = await ext.subscriptionProvider.getSubscriptions();
-
-    if (results.status === 'LoggedIn') {
-
-        const subscriptionQuickPickItems: (vscode.QuickPickItem & { subscription: AzureSubscription })[] =
-            results
-                .allSubscriptions
-                .map(subscription => ({
-                    label: subscription.name,
-                    picked: results.filters.includes(subscription),
-                    subscription
-                }))
-                .sort((a, b) => a.label.localeCompare(b.label));
-
-        const picks = await vscode.window.showQuickPick(
-            subscriptionQuickPickItems,
-            {
-                canPickMany: true,
-                placeHolder: 'Select Subscriptions'
-            });
-
-        if (picks) {
-            await ext.subscriptionProvider.selectSubscriptions(
-                picks.length < results.allSubscriptions.length
-                    ? picks.map(pick => pick.subscription.subscriptionId)
-                    : undefined);
-        }
-    }
+    await ext.subscriptionProvider.selectSubscriptions();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,8 @@ import { registerCommands } from './commands/registerCommands';
 import { registerTagDiagnostics } from './commands/tags/registerTagDiagnostics';
 import { TagFileSystem } from './commands/tags/TagFileSystem';
 import { ext } from './extensionVariables';
-import { VSCodeAzureSubscriptionProvider } from './services/AzureSubscriptionProvider';
+import { createAzureAccountSubscriptionProviderFactory } from './services/DesktopSubscriptionProvider';
+import { createWebSubscriptionProviderFactory } from './services/WebAzureSubscriptionProvider';
 import { AzureResourceBranchDataProviderManager } from './tree/azure/AzureResourceBranchDataProviderManager';
 import { DefaultAzureResourceBranchDataProvider } from './tree/azure/DefaultAzureResourceBranchDataProvider';
 import { registerAzureTree } from './tree/azure/registerAzureTree';
@@ -64,7 +65,7 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
         activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
 
         setupEvents(context);
-        ext.subscriptionProvider = new VSCodeAzureSubscriptionProvider(context.globalState);
+        ext.subscriptionProviderFactory = ext.isWeb ? createWebSubscriptionProviderFactory(context) : createAzureAccountSubscriptionProviderFactory();
 
         ext.tagFS = new TagFileSystem(ext.appResourceTree);
         context.subscriptions.push(vscode.workspace.registerFileSystemProvider(TagFileSystem.scheme, ext.tagFS));

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -10,7 +10,6 @@ import { AzureResourcesApiInternal } from "../hostapi.v2.internal";
 import { ActivityLogTreeItem } from "./activityLog/ActivityLogsTreeItem";
 import { TagFileSystem } from "./commands/tags/TagFileSystem";
 import { AzureSubscriptionProvider } from "./services/SubscriptionProvider";
-import { VSCodeAzureSubscriptionProvider } from "./services/WebAzureSubscriptionProvider";
 import { ResourceGroupsItem } from "./tree/ResourceGroupsItem";
 import { TreeItemStateStore } from "./tree/TreeItemState";
 
@@ -55,7 +54,6 @@ export namespace ext {
     export const events = extEvents;
 
     export let azureTreeState: TreeItemStateStore;
-    export let subscriptionProvider: VSCodeAzureSubscriptionProvider;
 
     export let subscriptionProviderFactory: () => Promise<AzureSubscriptionProvider>;
 

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -9,7 +9,8 @@ import { DiagnosticCollection, Disposable, Event, EventEmitter, ExtensionContext
 import { AzureResourcesApiInternal } from "../hostapi.v2.internal";
 import { ActivityLogTreeItem } from "./activityLog/ActivityLogsTreeItem";
 import { TagFileSystem } from "./commands/tags/TagFileSystem";
-import { VSCodeAzureSubscriptionProvider } from "./services/AzureSubscriptionProvider";
+import { AzureSubscriptionProvider } from "./services/SubscriptionProvider";
+import { VSCodeAzureSubscriptionProvider } from "./services/WebAzureSubscriptionProvider";
 import { ResourceGroupsItem } from "./tree/ResourceGroupsItem";
 import { TreeItemStateStore } from "./tree/TreeItemState";
 
@@ -55,6 +56,8 @@ export namespace ext {
 
     export let azureTreeState: TreeItemStateStore;
     export let subscriptionProvider: VSCodeAzureSubscriptionProvider;
+
+    export let subscriptionProviderFactory: () => Promise<AzureSubscriptionProvider>;
 
     // When debugging thru VS Code as a web environment, the UIKind is Desktop. However, if you sideload it into the browser, you must
     // change this to UIKind.Web and then webpack it again

--- a/src/services/DesktopSubscriptionProvider.ts
+++ b/src/services/DesktopSubscriptionProvider.ts
@@ -35,7 +35,7 @@ export function createAzureAccountSubscriptionProviderFactory(): () => Promise<A
     }
 }
 
-export class AzureAccountSubscriptionProvider implements AzureSubscriptionProvider {
+class AzureAccountSubscriptionProvider implements AzureSubscriptionProvider {
     waitForFilters: () => Promise<boolean>;
     waitForLogin: () => Promise<boolean>;
     waitForSubscriptions: () => Promise<boolean>;

--- a/src/services/DesktopSubscriptionProvider.ts
+++ b/src/services/DesktopSubscriptionProvider.ts
@@ -50,7 +50,7 @@ class AzureAccountSubscriptionProvider implements AzureSubscriptionProvider {
         this.onFiltersChanged = azureAccountApi.onFiltersChanged;
         this.onSessionsChanged = azureAccountApi.onSessionsChanged;
         this.onSubscriptionsChanged = azureAccountApi.onSubscriptionsChanged;
-        this.waitForFilters = azureAccountApi.waitForFilters.bind(azureAccountApi);
+        this.waitForFilters = azureAccountApi.waitForFilters.bind(azureAccountApi) as typeof azureAccountApi.waitForFilters;
     }
 
     get status(): AzureLoginStatus {
@@ -66,13 +66,13 @@ class AzureAccountSubscriptionProvider implements AzureSubscriptionProvider {
     }
 
     async logIn(): Promise<void> {
-        vscode.commands.executeCommand('azure-account.login');
+        await vscode.commands.executeCommand('azure-account.login');
     }
     async logOut(): Promise<void> {
-        vscode.commands.executeCommand('azure-account.logout');
+        await vscode.commands.executeCommand('azure-account.logout');
     }
     async selectSubscriptions(): Promise<void> {
-        vscode.commands.executeCommand('azure-account.selectSubscriptions');
+        await vscode.commands.executeCommand('azure-account.selectSubscriptions');
     }
 
     private createAzureSubscription(subscription: AzureAccountSubscription): AzureSubscription {

--- a/src/services/DesktopSubscriptionProvider.ts
+++ b/src/services/DesktopSubscriptionProvider.ts
@@ -28,10 +28,15 @@ async function getAzureAccountExtensionApi(): Promise<AzureAccountExtensionApi> 
     }
 }
 
+let azureAccountSubscriptionProvider: AzureSubscriptionProvider | undefined;
+
 export function createAzureAccountSubscriptionProviderFactory(): () => Promise<AzureSubscriptionProvider> {
     return async () => {
-        const api = await getAzureAccountExtensionApi();
-        return new AzureAccountSubscriptionProvider(api);
+        if (!azureAccountSubscriptionProvider) {
+            const api = await getAzureAccountExtensionApi();
+            azureAccountSubscriptionProvider = new AzureAccountSubscriptionProvider(api);
+        }
+        return azureAccountSubscriptionProvider;
     }
 }
 

--- a/src/services/DesktopSubscriptionProvider.ts
+++ b/src/services/DesktopSubscriptionProvider.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { apiUtils } from '@microsoft/vscode-azext-utils';
+import { AzureSubscription } from 'api/src/resources/azure';
+import * as vscode from 'vscode';
+import { AzureAccountExtensionApi, AzureSubscription as AzureAccountSubscription, AzureLoginStatus } from '../tree/azure-account.api';
+import { AzureSubscriptionProvider } from "./SubscriptionProvider";
+
+async function getAzureAccountExtensionApi(): Promise<AzureAccountExtensionApi> {
+    const extension = vscode.extensions.getExtension<apiUtils.AzureExtensionApiProvider>('ms-vscode.azure-account');
+
+    if (extension) {
+        if (!extension.isActive) {
+            await extension.activate();
+        }
+
+        if ('getApi' in extension.exports) {
+            return extension.exports.getApi<AzureAccountExtensionApi>('1');
+        } else {
+            // support versions of the Azure Account extension <0.10.0
+            return extension.exports as unknown as AzureAccountExtensionApi;
+        }
+    } else {
+        throw new Error('Azure Account extension is not installed.');
+    }
+}
+
+export function createAzureAccountSubscriptionProviderFactory(): () => Promise<AzureSubscriptionProvider> {
+    return async () => {
+        const api = await getAzureAccountExtensionApi();
+        return new AzureAccountSubscriptionProvider(api);
+    }
+}
+
+export class AzureAccountSubscriptionProvider implements AzureSubscriptionProvider {
+    waitForFilters: () => Promise<boolean>;
+    waitForLogin: () => Promise<boolean>;
+    waitForSubscriptions: () => Promise<boolean>;
+
+    public onStatusChanged: vscode.Event<AzureLoginStatus>;
+    public onFiltersChanged: vscode.Event<void>;
+    public onSessionsChanged: vscode.Event<void>;
+    public onSubscriptionsChanged: vscode.Event<void>;
+
+    constructor(private readonly azureAccountApi: AzureAccountExtensionApi) {
+        this.onStatusChanged = azureAccountApi.onStatusChanged;
+        this.onFiltersChanged = azureAccountApi.onFiltersChanged;
+        this.onSessionsChanged = azureAccountApi.onSessionsChanged;
+        this.onSubscriptionsChanged = azureAccountApi.onSubscriptionsChanged;
+        this.waitForFilters = azureAccountApi.waitForFilters.bind(azureAccountApi);
+    }
+
+    get status(): AzureLoginStatus {
+        return this.azureAccountApi.status;
+    }
+
+    get filters(): AzureSubscription[] {
+        return this.azureAccountApi.filters.map(this.createAzureSubscription);
+    }
+
+    get allSubscriptions(): AzureSubscription[] {
+        return this.azureAccountApi.subscriptions.map(this.createAzureSubscription);
+    }
+
+    async logIn(): Promise<void> {
+        vscode.commands.executeCommand('azure-account.login');
+    }
+    async logOut(): Promise<void> {
+        vscode.commands.executeCommand('azure-account.logout');
+    }
+    async selectSubscriptions(): Promise<void> {
+        vscode.commands.executeCommand('azure-account.selectSubscriptions');
+    }
+
+    private createAzureSubscription(subscription: AzureAccountSubscription): AzureSubscription {
+        return ({
+            authentication: {
+                getSession: async scopes => {
+                    const token = await subscription.session.credentials2.getToken(scopes ?? []);
+
+                    if (!token) {
+                        return undefined;
+                    }
+
+                    return {
+                        accessToken: token.token,
+                        account: {
+                            id: subscription.session.userId,
+                            label: subscription.session.userId
+                        },
+                        id: 'microsoft',
+                        scopes: scopes ?? []
+                    };
+                }
+            },
+            name: subscription.subscription.displayName || 'TODO: ever undefined?',
+            environment: subscription.session.environment,
+            isCustomCloud: subscription.session.environment.name === 'AzureCustomCloud',
+            subscriptionId: subscription.subscription.subscriptionId || 'TODO: ever undefined?',
+            tenantId: subscription.session.tenantId
+        });
+    }
+}

--- a/src/services/SubscriptionProvider.ts
+++ b/src/services/SubscriptionProvider.ts
@@ -10,7 +10,7 @@ import { AzureLoginStatus } from '../tree/azure-account.api';
 export interface AzureSubscriptionProvider {
     logIn(): Promise<void>;
     logOut(): Promise<void>;
-    selectSubscriptions(subscriptionIds: string[] | undefined): Promise<void>;
+    selectSubscriptions(): Promise<void>;
 
     readonly onStatusChanged: vscode.Event<AzureLoginStatus>;
     readonly onFiltersChanged: vscode.Event<void>;

--- a/src/services/SubscriptionProvider.ts
+++ b/src/services/SubscriptionProvider.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { AzureSubscription } from 'api/src/resources/azure';
+import * as vscode from 'vscode';
+import { AzureLoginStatus } from '../tree/azure-account.api';
+
+export interface AzureSubscriptionProvider {
+    logIn(): Promise<void>;
+    logOut(): Promise<void>;
+    selectSubscriptions(subscriptionIds: string[] | undefined): Promise<void>;
+
+    readonly onStatusChanged: vscode.Event<AzureLoginStatus>;
+    readonly onFiltersChanged: vscode.Event<void>;
+    readonly onSessionsChanged: vscode.Event<void>;
+    readonly onSubscriptionsChanged: vscode.Event<void>;
+
+    readonly waitForFilters: () => Promise<boolean>;
+    readonly waitForLogin: () => Promise<boolean>;
+    readonly waitForSubscriptions: () => Promise<boolean>;
+
+    readonly status: AzureLoginStatus;
+    readonly allSubscriptions: AzureSubscription[];
+    readonly filters: AzureSubscription[];
+}

--- a/src/services/WebAzureSubscriptionProvider.ts
+++ b/src/services/WebAzureSubscriptionProvider.ts
@@ -44,6 +44,8 @@ class VSCodeAzureSubscriptionProvider extends vscode.Disposable implements Azure
     constructor(private readonly storage: vscode.Memento) {
         super(() => this.onSubscriptionsChangedEmitter.dispose());
 
+        this.subscriptionResultsTask = this.getSubscriptions;
+
         this.onStatusChanged = this.onStatusChangedEmitter.event;
         this.onFiltersChanged = this.onFiltersChangedEmitter.event;
         this.onSessionsChanged = this.onSessionsChangedEmitter.event;

--- a/src/services/WebAzureSubscriptionProvider.ts
+++ b/src/services/WebAzureSubscriptionProvider.ts
@@ -26,8 +26,8 @@ export function createWebSubscriptionProviderFactory(context: vscode.ExtensionCo
 }
 
 class VSCodeAzureSubscriptionProvider extends vscode.Disposable implements AzureSubscriptionProvider {
-    allSubscriptions: AzureSubscription[];
-    filters: AzureSubscription[];
+    allSubscriptions: AzureSubscription[] = [];
+    filters: AzureSubscription[] = [];
 
     public readonly onStatusChangedEmitter: vscode.EventEmitter<AzureLoginStatus> = new vscode.EventEmitter<AzureLoginStatus>();
     public readonly onFiltersChangedEmitter: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
@@ -91,6 +91,9 @@ class VSCodeAzureSubscriptionProvider extends vscode.Disposable implements Azure
 
         const selectedSubscriptionIds = settingUtils.getGlobalSetting<string[] | undefined>('selectedSubscriptions');
         const filters = allSubscriptions.filter(s => selectedSubscriptionIds === undefined || selectedSubscriptionIds.includes(s.subscriptionId));
+
+        this.filters = filters;
+        this.allSubscriptions = allSubscriptions;
 
         return {
             status: session ? 'LoggedIn' : 'LoggedOut',
@@ -158,9 +161,7 @@ class VSCodeAzureSubscriptionProvider extends vscode.Disposable implements Azure
                 return false;
             }
 
-            const result = await this.subscriptionResultsTask();
-            this.filters = result.filters;
-            this.allSubscriptions = result.allSubscriptions;
+            await this.subscriptionResultsTask();
             return true;
         }) || false;
     }

--- a/src/services/WebAzureSubscriptionProvider.ts
+++ b/src/services/WebAzureSubscriptionProvider.ts
@@ -25,7 +25,7 @@ export function createWebSubscriptionProviderFactory(context: vscode.ExtensionCo
     }
 }
 
-export class VSCodeAzureSubscriptionProvider extends vscode.Disposable implements AzureSubscriptionProvider {
+class VSCodeAzureSubscriptionProvider extends vscode.Disposable implements AzureSubscriptionProvider {
     allSubscriptions: AzureSubscription[];
     filters: AzureSubscription[];
 

--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -3,20 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtServiceClientCredentials, IActionContext, ISubscriptionContext, nonNullProp, registerEvent } from '@microsoft/vscode-azext-utils';
+import { IActionContext, registerEvent } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
-import { AzureSubscription, ResourceModelBase, apiUtils } from '../../../api/src/index';
+import { ResourceModelBase } from '../../../api/src/index';
 import { AzureResourceProviderManager } from '../../api/ResourceProviderManagers';
 import { showHiddenTypesSettingKey } from '../../constants';
 import { ext } from '../../extensionVariables';
-import { AzureSubscriptionsResult } from '../../services/AzureSubscriptionProvider';
+import { AzureSubscriptionProvider } from '../../services/SubscriptionProvider';
 import { localize } from '../../utils/localize';
 import { BranchDataItemCache } from '../BranchDataItemCache';
 import { GenericItem } from '../GenericItem';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { ResourceTreeDataProviderBase } from '../ResourceTreeDataProviderBase';
 import { TreeItemStateStore } from '../TreeItemState';
-import { AzureAccountExtensionApi, AzureSubscription as AzureAccountSubscription } from '../azure-account.api';
 import { AzureResourceGroupingManager } from './AzureResourceGroupingManager';
 import { GroupingItem } from './GroupingItem';
 import { SubscriptionItem } from './SubscriptionItem';
@@ -25,7 +24,7 @@ import { createSubscriptionContext } from './VSCodeAuthentication';
 export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase {
     private readonly groupingChangeSubscription: vscode.Disposable;
 
-    private api: AzureAccountExtensionApi | AzureSubscriptionsResult | undefined;
+    private subscriptionProvider: AzureSubscriptionProvider | undefined;
     private filtersSubscription: vscode.Disposable | undefined;
     private statusSubscription: vscode.Disposable | undefined;
 
@@ -82,13 +81,13 @@ export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase 
                         return api.filters.map(
                             subscription => new SubscriptionItem(
                                 {
-                                    subscription: this.createAzureSubscription(subscription),
-                                    subscriptionContext: this.createSubscriptionContext(subscription),
+                                    subscription: subscription,
+                                    subscriptionContext: createSubscriptionContext(subscription),
                                     refresh: item => this.notifyTreeDataChanged(item),
                                 },
                                 this.resourceGroupingManager,
                                 this.resourceProviderManager,
-                                this.createAzureSubscription(subscription)));
+                                subscription));
                     }
                 } else if (api.status === 'LoggedOut') {
                     return [
@@ -137,88 +136,16 @@ export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase 
         return super.isAncestorOf(element, id)
     }
 
-    private async getAzureAccountExtensionApi(): Promise<AzureAccountExtensionApi | AzureSubscriptionsResult | undefined> {
-        if (ext.isWeb) {
-            this.filtersSubscription = ext.subscriptionProvider.onFiltersChanged(() => this.notifyTreeDataChanged());
-            this.statusSubscription = ext.subscriptionProvider.onStatusChanged(() => this.notifyTreeDataChanged());
-            return await ext.subscriptionProvider.getSubscriptions();
+    private async getAzureAccountExtensionApi(): Promise<AzureSubscriptionProvider | undefined> {
+
+        if (!this.subscriptionProvider) {
+            this.subscriptionProvider = await ext.subscriptionProviderFactory();
+            await this.subscriptionProvider.waitForFilters();
         }
 
-        if (!this.api) {
-            const extension = vscode.extensions.getExtension<apiUtils.AzureExtensionApiProvider>('ms-vscode.azure-account');
+        this.filtersSubscription = this.subscriptionProvider.onFiltersChanged(() => this.notifyTreeDataChanged());
+        this.statusSubscription = this.subscriptionProvider.onStatusChanged(() => this.notifyTreeDataChanged());
 
-            if (extension) {
-                if (!extension.isActive) {
-                    await extension.activate();
-                }
-
-                if ('getApi' in extension.exports) {
-                    this.api = extension.exports.getApi<AzureAccountExtensionApi>('1');
-                } else {
-                    // support versions of the Azure Account extension <0.10.0
-                    this.api = extension.exports as unknown as AzureAccountExtensionApi;
-                }
-
-                if (this.api) {
-                    await this.api.waitForFilters();
-
-                    this.filtersSubscription = this.api.onFiltersChanged(() => this.notifyTreeDataChanged());
-                    this.statusSubscription = this.api.onStatusChanged(() => this.notifyTreeDataChanged());
-                }
-            }
-        }
-
-        return this.api;
-    }
-
-    private createAzureSubscription(subscription: AzureAccountSubscription): AzureSubscription {
-        if (ext.isWeb) {
-            return subscription as unknown as AzureSubscription;
-        }
-
-        return {
-            authentication: {
-                getSession: async scopes => {
-                    const token = await subscription.session.credentials2.getToken(scopes ?? []);
-
-                    if (!token) {
-                        return undefined;
-                    }
-
-                    return {
-                        accessToken: token.token,
-                        account: {
-                            id: subscription.session.userId,
-                            label: subscription.session.userId
-                        },
-                        id: 'microsoft',
-                        scopes: scopes ?? []
-                    };
-                }
-            },
-            name: subscription.subscription.displayName || 'TODO: ever undefined?',
-            environment: subscription.session.environment,
-            isCustomCloud: subscription.session.environment.name === 'AzureCustomCloud',
-            subscriptionId: subscription.subscription.subscriptionId || 'TODO: ever undefined?',
-            tenantId: subscription.session.tenantId
-        };
-    }
-
-    private createSubscriptionContext(subscription: AzureAccountSubscription): ISubscriptionContext {
-        if (ext.isWeb) {
-            // TODO: This is a hack to get the subscription context to work with the webview
-            return createSubscriptionContext(subscription as unknown as AzureSubscription);
-        }
-
-        return {
-            credentials: <AzExtServiceClientCredentials>subscription.session.credentials2,
-            subscriptionDisplayName: nonNullProp(subscription.subscription, 'displayName'),
-            subscriptionId: nonNullProp(subscription.subscription, 'subscriptionId'),
-            subscriptionPath: nonNullProp(subscription.subscription, 'id'),
-            tenantId: subscription.session.tenantId,
-            userId: subscription.session.userId,
-            environment: subscription.session.environment,
-            isCustomCloud: subscription.session.environment.name === 'AzureCustomCloud'
-        }
+        return this.subscriptionProvider;
     }
 }

--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -139,8 +139,8 @@ export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase 
 
     private async getAzureAccountExtensionApi(): Promise<AzureAccountExtensionApi | AzureSubscriptionsResult | undefined> {
         if (ext.isWeb) {
-            this.filtersSubscription = ext.subscriptionProvider.onFiltersChangedEvent(() => this.notifyTreeDataChanged());
-            this.statusSubscription = ext.subscriptionProvider.onStatusChangedEvent(() => this.notifyTreeDataChanged());
+            this.filtersSubscription = ext.subscriptionProvider.onFiltersChanged(() => this.notifyTreeDataChanged());
+            this.statusSubscription = ext.subscriptionProvider.onStatusChanged(() => this.notifyTreeDataChanged());
             return await ext.subscriptionProvider.getSubscriptions();
         }
 

--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -76,7 +76,7 @@ export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase 
             if (api) {
                 if (api.status === 'LoggedIn') {
                     if (api.filters.length === 0) {
-                        return [new GenericItem(localize('noSubscriptions', 'Select Subscriptions...'), { commandId: 'azure-account.selectSubscriptions' })]
+                        return [new GenericItem(localize('noSubscriptions', 'Select Subscriptions...'), { commandId: 'azureResourceGroups.vscodeAuth.selectSubscriptions' })]
                     } else {
                         return api.filters.map(
                             subscription => new SubscriptionItem(


### PR DESCRIPTION
Refactor VS Code auth portion of the vscode.dev work to hide the auth implementation details from the rest of the code. Now both the VS Code auth (used in vscode.dev) and the Azure Account API auth are shoehorned into a common interface.

This makes it easier to adapt for testing purposes and is similar to what I've done in https://github.com/microsoft/vscode-azureresourcegroups/pull/563