### PR TITLE
Don't throw if resource group isn't found

### DIFF
--- a/src/tree/azure/AzureResourceGroupingManager.ts
+++ b/src/tree/azure/AzureResourceGroupingManager.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { nonNullValue, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
+import { TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { AzExtResourceType, AzureResource } from '../../../api/src/index';
 import { azureExtensions } from '../../azureExtensions';
@@ -64,7 +64,7 @@ export class AzureResourceGroupingManager extends vscode.Disposable {
         }
     }
 
-    private groupBy(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: AzureResource[], keySelector: (resource: AzureResource) => string, labelSelector: (key: string) => string, iconSelector: (key: string) => TreeItemIconPath | undefined, initialGrouping?: { [key: string]: AzureResource[] }, contextValues?: string[], resourceTypeSelector?: (key: string) => AzExtResourceType | undefined, resourceGroupSelector?: (key: string) => AzureResource): GroupingItem[] {
+    private groupBy(parent: ResourceGroupsItem, context: ResourceGroupsTreeContext, resources: AzureResource[], keySelector: (resource: AzureResource) => string, labelSelector: (key: string) => string, iconSelector: (key: string) => TreeItemIconPath | undefined, initialGrouping?: { [key: string]: AzureResource[] }, contextValues?: string[], resourceTypeSelector?: (key: string) => AzExtResourceType | undefined, resourceGroupSelector?: (key: string) => AzureResource | undefined): GroupingItem[] {
         initialGrouping = initialGrouping ?? {};
 
         const map = resources.reduce(
@@ -142,7 +142,7 @@ export class AzureResourceGroupingManager extends vscode.Disposable {
             initialGrouping,
             ['azureResourceGroup'],
             undefined,
-            key => nonNullValue(resourceGroups.find(resource => resource.name.toLowerCase() === key.toLowerCase())));
+            key => resourceGroups.find(resource => resource.name.toLowerCase() === key.toLowerCase()));
 
         return groupedResources;
     }


### PR DESCRIPTION
Fixes #608 

For some reason there are resources with a resource group name that we can't find in our list of resource groups. I still don't know how that happens. These changes allow loading the tree if a resource group isn't found.

In my testing, the impact of passing undefined down to a grouping item is the view properties command breaks. But that's a much better result than not being able to load the groups at all.

I tested this by manually removing a resource group from the resource groups array.