### PR TITLE
Change message of create resource group

### DIFF
--- a/src/commands/createResourceGroup.ts
+++ b/src/commands/createResourceGroup.ts
@@ -32,7 +32,7 @@ export async function createResourceGroup(context: IActionContext, node?: Subscr
     const wizard: AzureWizard<IResourceGroupWizardContext & ExecuteActivityContext> = new AzureWizard(wizardContext, { title, promptSteps, executeSteps });
     await wizard.prompt();
     const newResourceGroupName = nonNullProp(wizardContext, 'newResourceGroupName');
-    wizardContext.activityTitle = localize('createResourceGroup', 'Create Resource Group "{0}"', newResourceGroupName);
+    wizardContext.activityTitle = localize('createResourceGroup', 'Create resource group "{0}"', newResourceGroupName);
     await wizard.execute();
     if (!wizardContext.suppressNotification) {
         void window.showInformationMessage(localize('createdRg', 'Created resource group "{0}".', newResourceGroupName));


### PR DESCRIPTION
Fixes #627 

Though unless there's an Azure prefix, we're not supposed to capitalize the resources, so I went the other direction and fixed "Create resource group"