### PR TITLE
Only keep one object per id cached

### DIFF
--- a/src/api/compatibility/pickAppResource.ts
+++ b/src/api/compatibility/pickAppResource.ts
@@ -7,16 +7,15 @@ import { AzExtTreeItem, ContextValueFilter, getAzExtResourceType, ITreeItemPicke
 import { PickAppResourceOptions } from "@microsoft/vscode-azext-utils/hostapi";
 import { AzExtResourceType } from "../../../api/src/index";
 import { ext } from "../../extensionVariables";
-import { BranchDataItemCache } from "../../tree/BranchDataItemCache";
 
-export function createCompatibilityPickAppResource(itemCache: BranchDataItemCache) {
+export function createCompatibilityPickAppResource() {
     return async function pickAppResource<T extends AzExtTreeItem>(context: ITreeItemPickerContext, options?: PickAppResourceOptions): Promise<T> {
         const result = await PickTreeItemWithCompatibility.resource<T>(context, ext.v2.api.resources.azureResourceTreeDataProvider, {
             resourceTypes: convertAppResourceFilterToAzExtResourceType(options?.filter),
             childItemFilter: convertExpectedChildContextValueToContextValueFilter(options?.expectedChildContextValue)
         });
 
-        return itemCache.getItemForId(result.fullId) as T | undefined ?? result;
+        return result;
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -155,7 +155,7 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
                     registerApplicationResourceResolver,
                     registerWorkspaceResourceProvider,
                     registerActivity,
-                    pickAppResource: createCompatibilityPickAppResource(azureResourcesBranchDataItemCache),
+                    pickAppResource: createCompatibilityPickAppResource(),
                 }),
             },
             v2ApiFactory,

--- a/src/tree/BranchDataItemCache.ts
+++ b/src/tree/BranchDataItemCache.ts
@@ -8,13 +8,18 @@ import { ResourceGroupsItem } from './ResourceGroupsItem';
 
 export class BranchDataItemCache {
     private readonly branchItemToResourceGroupsItemCache: Map<ResourceModelBase, ResourceGroupsItem> = new Map();
+    private readonly idToBranchItemCache: Map<string, ResourceModelBase> = new Map();
 
     addBranchItem(branchItem: ResourceModelBase, item: ResourceGroupsItem): void {
         this.branchItemToResourceGroupsItemCache.set(branchItem, item);
+        if (branchItem.id) {
+            this.idToBranchItemCache.set(branchItem.id, branchItem);
+        }
     }
 
     clear(): void {
         this.branchItemToResourceGroupsItemCache.clear();
+        this.idToBranchItemCache.clear();
     }
 
     getItemForBranchItem(branchItem: ResourceModelBase): ResourceGroupsItem | undefined {
@@ -25,11 +30,7 @@ export class BranchDataItemCache {
         if (!id) {
             return undefined;
         }
-        for (const [key, value] of this.branchItemToResourceGroupsItemCache.entries()) {
-            if (key.id === id) {
-                return value;
-            }
-        }
-        return undefined;
+        const branchItem = this.idToBranchItemCache.get(id);
+        return branchItem ? this.branchItemToResourceGroupsItemCache.get(branchItem) : undefined;
     }
 }

--- a/src/tree/BranchDataItemCache.ts
+++ b/src/tree/BranchDataItemCache.ts
@@ -3,12 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ResourceModelBase } from 'api/src/resources/base';
 import { ResourceGroupsItem } from './ResourceGroupsItem';
 
 export class BranchDataItemCache {
-    private readonly branchItemToResourceGroupsItemCache: Map<unknown, ResourceGroupsItem> = new Map();
+    private readonly branchItemToResourceGroupsItemCache: Map<ResourceModelBase, ResourceGroupsItem> = new Map();
 
-    addBranchItem(branchItem: unknown, item: ResourceGroupsItem): void {
+    addBranchItem(branchItem: ResourceModelBase, item: ResourceGroupsItem): void {
         this.branchItemToResourceGroupsItemCache.set(branchItem, item);
     }
 
@@ -16,17 +17,19 @@ export class BranchDataItemCache {
         this.branchItemToResourceGroupsItemCache.clear();
     }
 
-    getItemForBranchItem(branchItem: unknown): ResourceGroupsItem | undefined {
+    getItemForBranchItem(branchItem: ResourceModelBase): ResourceGroupsItem | undefined {
         return this.branchItemToResourceGroupsItemCache.get(branchItem);
     }
 
-    getItemForId(id: string): unknown {
+    getItemForId(id?: string): ResourceGroupsItem | undefined {
+        if (!id) {
+            return undefined;
+        }
         for (const [key, value] of this.branchItemToResourceGroupsItemCache.entries()) {
-            if (value.id === id) {
-                return key;
+            if (key.id === id) {
+                return value;
             }
         }
-
         return undefined;
     }
 }

--- a/src/tree/BranchDataProviderItem.ts
+++ b/src/tree/BranchDataProviderItem.ts
@@ -33,7 +33,7 @@ export class BranchDataItemWrapper implements ResourceGroupsItem, Wrapper {
     static readonly hasPortalUrlContextValue = 'hasPortalUrl';
 
     constructor(
-        private readonly branchItem: ResourceModelBase,
+        public branchItem: ResourceModelBase,
         private readonly branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>,
         private readonly itemCache: BranchDataItemCache,
         private readonly options?: BranchDataItemOptions) {
@@ -116,9 +116,11 @@ export type BranchDataItemFactory = (branchItem: ResourceModelBase, branchDataPr
 
 export function createBranchDataItemFactory(itemCache: BranchDataItemCache): BranchDataItemFactory {
     return (branchItem, branchDataProvider, options) => {
-        const cachedItem = itemCache.getItemForId(branchItem.id);
+        const cachedItem = itemCache.getItemForId(branchItem.id) as BranchDataItemWrapper | undefined;
         if (cachedItem) {
-            return cachedItem as BranchDataItemWrapper;
+            cachedItem.branchItem = branchItem;
+            itemCache.addBranchItem(branchItem, cachedItem);
+            return cachedItem;
         }
         return new BranchDataItemWrapper(branchItem, branchDataProvider, itemCache, options);
     }

--- a/src/tree/ResourceTreeDataProviderBase.ts
+++ b/src/tree/ResourceTreeDataProviderBase.ts
@@ -51,7 +51,7 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
         if (!!data) {
             // e was defined, either a single item or array
             // Make an array for consistency
-            const branchItems: unknown[] = Array.isArray(data) ? data : [data];
+            const branchItems: ResourceModelBase[] = Array.isArray(data) ? data : [data];
 
             for (const branchItem of branchItems) {
                 const rgItem = this.itemCache.getItemForBranchItem(branchItem);

--- a/src/tree/azure/AzureResourceItem.ts
+++ b/src/tree/azure/AzureResourceItem.ts
@@ -54,5 +54,11 @@ export class AzureResourceItem<T extends AzureResource> extends BranchDataItemWr
 export type ResourceItemFactory<T extends AzureResource> = (resource: T, branchItem: ResourceModelBase, branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>, parent?: ResourceGroupsItem, options?: BranchDataItemOptions) => AzureResourceItem<T>;
 
 export function createResourceItemFactory<T extends AzureResource>(itemCache: BranchDataItemCache): ResourceItemFactory<T> {
-    return (resource, branchItem, branchDataProvider, parent, options) => new AzureResourceItem(resource, branchItem, branchDataProvider, itemCache, parent, options);
+    return (resource, branchItem, branchDataProvider, parent, options) => {
+        const cachedItem = itemCache.getItemForId(branchItem.id);
+        if (cachedItem) {
+            return cachedItem as AzureResourceItem<T>;
+        }
+        return new AzureResourceItem(resource, branchItem, branchDataProvider, itemCache, parent, options);
+    }
 }

--- a/src/tree/azure/AzureResourceItem.ts
+++ b/src/tree/azure/AzureResourceItem.ts
@@ -55,9 +55,11 @@ export type ResourceItemFactory<T extends AzureResource> = (resource: T, branchI
 
 export function createResourceItemFactory<T extends AzureResource>(itemCache: BranchDataItemCache): ResourceItemFactory<T> {
     return (resource, branchItem, branchDataProvider, parent, options) => {
-        const cachedItem = itemCache.getItemForId(branchItem.id);
+        const cachedItem = itemCache.getItemForId(branchItem.id) as AzureResourceItem<T> | undefined;
         if (cachedItem) {
-            return cachedItem as AzureResourceItem<T>;
+            cachedItem.branchItem = branchItem;
+            itemCache.addBranchItem(branchItem, cachedItem);
+            return cachedItem;
         }
         return new AzureResourceItem(resource, branchItem, branchDataProvider, itemCache, parent, options);
     }


### PR DESCRIPTION
Fixes #640, and a bunch of others including:
* "Cannot read properties of undefined (reading 'createClient')" errors.
* Issues related to things not being refreshed on the tree after running a command from the palette.

### Background

This following line was added in https://github.com/microsoft/vscode-azureresourcegroups/pull/510 as a band aid solution to try and fix issues where the item returned by the picker was not reference equal to the same item in the tree view. This made it so calling refresh with the item didn't refresh on the tree among other things.
https://github.com/microsoft/vscode-azureresourcegroups/blob/11e06179ad12c30fb01259bbe8bfc0a87304c8eb/src/api/compatibility/pickAppResource.ts#L19

The fix in #510 only worked sometimes, as seen by the numerous bugs reported by CTI surrounding things not refreshing on the tree when commands are invoked via command palette. It turns out this is because multiple items were being added to the cache with the same id. We were just returning the first one we found with a matching id when iterating through the cached items.

### Solution

The solution I implemented makes it so we only ever have one object in memory for each id. Before creating a new object, we check if we have an object in the cache with that id. 

In psuedocode:
```
if (cache.getItemForId(id)) {
    return cache.getItemForId(id)
} else {
    return createItem(id);
}
```

I've taken extra time on this PR to do a lot of manual testing with the client extensions to make sure this functionality works. I will have CTI do test passes on the clients as well.