### PR TITLE
Consolidate login, logout, and selectSub commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "preview": true,
     "activationEvents": [
         "onFileSystem:azureResourceGroups",
-        "onCommand:azureResourceGroups.vscodeAuth.logIn",
-        "onCommand:azureResourceGroups.vscodeAuth.logOut",
-        "onCommand:azureResourceGroups.vscodeAuth.selectSubscriptions",
+        "onCommand:azureResourceGroups.logIn",
+        "onCommand:azureResourceGroups.logOut",
+        "onCommand:azureResourceGroups.selectSubscriptions",
         "onCommand:azureResourceGroups.createResourceGroup",
         "onCommand:azureResourceGroups.deleteResourceGroupV2",
         "onCommand:azureResourceGroups.editTags",
@@ -41,7 +41,6 @@
         "onCommand:azureResourceGroups.refresh",
         "onCommand:azureResourceGroups.reportIssue",
         "onCommand:azureResourceGroups.revealResource",
-        "onCommand:azureResourceGroups.selectSubscriptions",
         "onCommand:azureResourceGroups.viewProperties",
         "onCommand:azureResourceGroups.showGroupOptions",
         "onCommand:ms-azuretools.getStarted",
@@ -66,23 +65,20 @@
         },
         "commands": [
             {
-                "command": "azureResourceGroups.vscodeAuth.logIn",
-                "title": "%azureResourceGroups.vscodeAuth.logIn%",
-                "category": "Azure",
-                "enablement": "isWeb"
+                "command": "azureResourceGroups.logIn",
+                "title": "%azureResourceGroups.logIn%",
+                "category": "Azure"
             },
             {
-                "command": "azureResourceGroups.vscodeAuth.logOut",
-                "title": "%azureResourceGroups.vscodeAuth.logOut%",
-                "category": "Azure",
-                "enablement": "isWeb"
+                "command": "azureResourceGroups.logOut",
+                "title": "%azureResourceGroups.logOut%",
+                "category": "Azure"
             },
             {
-                "command": "azureResourceGroups.vscodeAuth.selectSubscriptions",
-                "title": "%azureResourceGroups.vscodeAuth.selectSubscriptions%",
+                "command": "azureResourceGroups.selectSubscriptions",
+                "title": "%azureResourceGroups.selectSubscriptions%",
                 "category": "Azure",
-                "icon": "$(filter)",
-                "enablement": "isWeb"
+                "icon": "$(filter)"
             },
             {
                 "command": "azureResourceGroups.createResourceGroup",
@@ -132,12 +128,6 @@
                 "title": "%azureResourceGroups.refresh%",
                 "category": "Azure",
                 "icon": "$(refresh)"
-            },
-            {
-                "command": "azureResourceGroups.selectSubscriptions",
-                "title": "%azureResourceGroups.selectSubscriptions%",
-                "category": "Azure",
-                "enablement": "!isWeb"
             },
             {
                 "command": "azureResourceGroups.revealResource",
@@ -312,7 +302,7 @@
             ],
             "view/item/context": [
                 {
-                    "command": "azureResourceGroups.vscodeAuth.selectSubscriptions",
+                    "command": "azureResourceGroups.selectSubscriptions",
                     "when": "view == azureResourceGroups && viewItem == azureextensionui.azureSubscription",
                     "group": "inline"
                 },
@@ -368,6 +358,14 @@
                 }
             ],
             "commandPalette": [
+                {
+                    "command": "azureResourceGroups.logIn",
+                    "when": "isWeb"
+                },
+                {
+                    "command": "azureResourceGroups.logOut",
+                    "when": "isWeb"
+                },
                 {
                     "command": "azureResourceGroups.selectSubscriptions",
                     "when": "never"

--- a/package.json
+++ b/package.json
@@ -368,7 +368,7 @@
                 },
                 {
                     "command": "azureResourceGroups.selectSubscriptions",
-                    "when": "never"
+                    "when": "isWeb"
                 },
                 {
                     "command": "azureResourceGroups.showGroupOptions",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,7 +1,7 @@
 {
-    "azureResourceGroups.vscodeAuth.logIn": "Sign In",
-    "azureResourceGroups.vscodeAuth.logOut": "Sign Out",
-    "azureResourceGroups.vscodeAuth.selectSubscriptions": "Select Subscriptions...",
+    "azureResourceGroups.logIn": "Sign In",
+    "azureResourceGroups.logOut": "Sign Out",
+    "azureResourceGroups.selectSubscriptions": "Select Subscriptions...",
     "azureResourceGroups.createResourceGroup": "Create Resource Group...",
     "azureResourceGroups.createResourceGroupDetail": "The logical grouping for your resources.",
     "azureResourceGroups.deleteResourceGroup": "Delete Resource Group...",

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -49,16 +49,15 @@ export function registerCommands(): void {
         ext.actions.refreshWorkspaceTree(node);
     });
 
-    registerCommand('azureResourceGroups.vscodeAuth.logIn', (context: IActionContext) => logIn(context));
-    registerCommand('azureResourceGroups.vscodeAuth.logOut', (context: IActionContext) => logOut(context));
-    registerCommand('azureResourceGroups.vscodeAuth.selectSubscriptions', (context: IActionContext) => selectSubscriptions(context));
+    registerCommand('azureResourceGroups.logIn', (context: IActionContext) => logIn(context));
+    registerCommand('azureResourceGroups.logOut', (context: IActionContext) => logOut(context));
+    registerCommand('azureResourceGroups.selectSubscriptions', (context: IActionContext) => selectSubscriptions(context));
 
     registerCommand('azureResourceGroups.createResourceGroup', createResourceGroup);
     registerCommand('azureResourceGroups.deleteResourceGroupV2', deleteResourceGroupV2);
     registerCommand('azureResourceGroups.loadMore', async (context: IActionContext, node: AzExtTreeItem) => await ext.appResourceTree.loadMore(node, context));
     registerCommand('azureResourceGroups.openInPortal', openInPortal);
     registerCommand('azureResourceGroups.revealResource', revealResource);
-    registerCommand('azureResourceGroups.selectSubscriptions', () => commands.executeCommand('azure-account.selectSubscriptions'));
     registerCommand('azureResourceGroups.viewProperties', viewProperties);
     registerCommand('azureResourceGroups.editTags', editTags);
 

--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -77,7 +77,7 @@ export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase 
                 if (api.status === 'LoggedIn') {
                     if (api.filters.length === 0) {
                         return [new GenericItem(localize('noSubscriptions', 'Select Subscriptions...'), {
-                            commandId: ext.isWeb ? 'azureResourceGroups.vscodeAuth.selectSubscriptions' : 'azure-account.selectSubscriptions',
+                            commandId: 'azureResourceGroups.selectSubscriptions'
                         })]
                     } else {
                         return api.filters.map(
@@ -96,7 +96,7 @@ export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase 
                         new GenericItem(
                             localize('signInLabel', 'Sign in to Azure...'),
                             {
-                                commandId: 'azureResourceGroups.vscodeAuth.logIn',
+                                commandId: 'azureResourceGroups.logIn',
                                 iconPath: new vscode.ThemeIcon('sign-in')
                             }),
                         new GenericItem(
@@ -120,7 +120,7 @@ export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase 
                                 ? localize('loadingTreeItem', 'Loading...')
                                 : localize('signingIn', 'Waiting for Azure sign-in...'),
                             {
-                                commandId: 'azureResourceGroups.vscodeAuth.logIn',
+                                commandId: 'azureResourceGroups.logIn',
                                 iconPath: new vscode.ThemeIcon('loading~spin')
                             })
                     ];


### PR DESCRIPTION
Fixes the bug Alex mentioned in triage where sub filter was grayed out on desktop.

Also removed duplicate commands because the treeDataProvider handles that for us now.

If I don't have the conditions for the logIn and logOut commands to show up in the command palette, we'll get double in VS Code desktop due to the Azure Account extension also contributing commands.