### PR TITLE
Replace azure-account call with openUrl

### DIFF
--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -103,7 +103,7 @@ export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase 
                             localize('createAccountLabel', 'Create an Azure Account...'),
                             {
                                 commandId: 'azureResourceGroups.openUrl',
-                                commandArgs: ['https://azure.microsoft.com/en-us/free/?utm_source=campaign&utm_campaign=vscode-azure-account&mktingSource=vscode-azure-account'],
+                                commandArgs: ['https://aka.ms/VSCodeCreateAzureAccount'],
                                 iconPath: new vscode.ThemeIcon('add')
                             }),
                         new GenericItem(

--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -102,7 +102,8 @@ export class AzureResourceTreeDataProvider extends ResourceTreeDataProviderBase 
                         new GenericItem(
                             localize('createAccountLabel', 'Create an Azure Account...'),
                             {
-                                commandId: 'azure-account.createAccount',
+                                commandId: 'azureResourceGroups.openUrl',
+                                commandArgs: ['https://azure.microsoft.com/en-us/free/?utm_source=campaign&utm_campaign=vscode-azure-account&mktingSource=vscode-azure-account'],
                                 iconPath: new vscode.ThemeIcon('add')
                             }),
                         new GenericItem(


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azureresourcegroups/issues/643

The Account extension is just opening a url for the `createAccount` command. We can just by-pass that and open the url similar to how we do for creating a student account. 

https://github.com/microsoft/vscode-azure-account/blob/14d1d7e84b964742716fba224d032010ff3f1800/src/extension.ts#L167