### PR TITLE
Add Create Account command for web support

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,11 @@
         },
         "commands": [
             {
+                "command": "azureResourceGroups.vscodeAuth.createAccount",
+                "title": "%azureResourceGroups.vscodeAuth.createAccount%",
+                "category": "Azure"
+            },
+            {
                 "command": "azureResourceGroups.vscodeAuth.logIn",
                 "title": "%azureResourceGroups.vscodeAuth.logIn%",
                 "category": "Azure",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,4 +1,5 @@
 {
+    "azureResourceGroups.vscodeAuth.createAccount": "Create an Azure Account...",
     "azureResourceGroups.vscodeAuth.logIn": "Sign In",
     "azureResourceGroups.vscodeAuth.logOut": "Sign Out",
     "azureResourceGroups.vscodeAuth.selectSubscriptions": "Select Subscriptions...",

--- a/src/commands/accounts/createAccount.ts
+++ b/src/commands/accounts/createAccount.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from "@microsoft/vscode-azext-utils";
+import * as vscode from 'vscode';
+
+export async function createAccount(_context: IActionContext): Promise<void> {
+    await vscode.env.openExternal(vscode.Uri.parse('https://aka.ms/VSCodeCreateAzureAccount'));
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -6,9 +6,10 @@
 import { AzExtTreeItem, IActionContext, isAzExtTreeItem, openUrl, registerCommand, registerErrorHandler, registerReportIssueCommand } from '@microsoft/vscode-azext-utils';
 import { commands } from 'vscode';
 import { ext } from '../extensionVariables';
+import { GroupingItem } from '../tree/azure/GroupingItem';
 import { BranchDataItemWrapper } from '../tree/BranchDataProviderItem';
 import { ResourceGroupsItem } from '../tree/ResourceGroupsItem';
-import { GroupingItem } from '../tree/azure/GroupingItem';
+import { createAccount } from './accounts/createAccount';
 import { logIn } from './accounts/logIn';
 import { logOut } from './accounts/logOut';
 import { selectSubscriptions } from './accounts/selectSubscriptions';
@@ -52,6 +53,7 @@ export function registerCommands(): void {
     registerCommand('azureResourceGroups.vscodeAuth.logIn', (context: IActionContext) => logIn(context));
     registerCommand('azureResourceGroups.vscodeAuth.logOut', (context: IActionContext) => logOut(context));
     registerCommand('azureResourceGroups.vscodeAuth.selectSubscriptions', (context: IActionContext) => selectSubscriptions(context));
+    registerCommand('azureResourceGroups.vscodeAuth.createAccount', (context: IActionContext) => createAccount(context));
 
     registerCommand('azureResourceGroups.createResourceGroup', createResourceGroup);
     registerCommand('azureResourceGroups.deleteResourceGroupV2', deleteResourceGroupV2);


### PR DESCRIPTION
Fixes #643 

In web, we can no longer rely on the Create Account command contributed by the Azure Account extension. Instead I added another generic command that on desktop will use the Azure Account command and on web will just open the link.

Now that I write this I guess we could just always open the link ourselves and not use the Azure Account extension command at all.

Ok, updated the changes so that we're not relying on AA for this, and just opening the link in RGs.