### PR TITLE
Make Azure resource provider mockable

### DIFF
--- a/src/services/AzureResourcesService.ts
+++ b/src/services/AzureResourcesService.ts
@@ -1,0 +1,31 @@
+import type { GenericResource, ResourceGroup, ResourceManagementClient } from "@azure/arm-resources";
+import { uiUtils } from "@microsoft/vscode-azext-azureutils";
+import { createSubscriptionContext, IActionContext } from "@microsoft/vscode-azext-utils";
+import { AzureSubscription } from "api/src/resources/azure";
+import { createResourceClient } from "../utils/azureClients";
+
+export interface AzureResourcesService {
+    listResources(context: IActionContext, subscription: AzureSubscription): Promise<GenericResource[]>;
+    listResourceGroups(context: IActionContext, subscription: AzureSubscription): Promise<ResourceGroup[]>;
+}
+
+export const defaultAzureResourcesServiceFactory = (): AzureResourcesService => {
+    async function createClient(context: IActionContext, subscription: AzureSubscription): Promise<ResourceManagementClient> {
+        const subContext = createSubscriptionContext(subscription);
+        return await createResourceClient([context, subContext]);
+    }
+    return {
+        async listResources(context: IActionContext, subscription: AzureSubscription): Promise<GenericResource[]> {
+            const client = await createClient(context, subscription);
+            return uiUtils.listAllIterator(client.resources.list());
+        },
+        async listResourceGroups(context: IActionContext, subscription: AzureSubscription): Promise<ResourceGroup[]> {
+            const client = await createClient(context, subscription);
+            return uiUtils.listAllIterator(client.resourceGroups.list());
+        },
+    }
+}
+
+export function getAzureResourcesService(): AzureResourcesService {
+    return defaultAzureResourcesServiceFactory();
+}


### PR DESCRIPTION
Splitting out changes from #563 to make that PR smaller.

These changes make it so the default Azure resource provider uses an `AzureResourcesService` for actually listing the resources. This way the underlying `AzureResourcesService` can be changed out for testing with a service that returns mock resources.