### PR TITLE
Only run component detection on main branch

### DIFF
--- a/.azure-pipelines/common/lint.yml
+++ b/.azure-pipelines/common/lint.yml
@@ -4,7 +4,3 @@ steps:
   inputs:
     command: custom
     customCommand: run lint
-
-- task: ComponentGovernanceComponentDetection@0
-  displayName: 'Component Detection'
-  condition: ne(variables['System.PullRequest.IsFork'], 'True')

--- a/.azure-pipelines/compliance/compliance.yml
+++ b/.azure-pipelines/compliance/compliance.yml
@@ -34,3 +34,7 @@ steps:
   inputs:
     AllTools: true
   condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+
+- task: ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
+  condition: ne(variables['Build.SourceBranchName'], 'main')


### PR DESCRIPTION
I hope this will prevent CG alerts from appearing for branches other than main.