### PR TITLE
Disable resource group walkthrough

### DIFF
--- a/package.json
+++ b/package.json
@@ -491,6 +491,7 @@
                 "id": "azure-get-started",
                 "title": "Get Started with Azure in VS Code",
                 "description": "Setup your account and get to know the Azure extension view.",
+                "when": "false",
                 "steps": [
                     {
                         "id": "sign-in",


### PR DESCRIPTION
We are currently using ExP flights to ensure that no user sees more than one walkthrough, which is not a long-term solution. Disabling this walkthrough so we can roll the azd walkthrough out to 100% of users and turn off the experiment.