### PR TITLE
Fix compatibility issue in `BranchDataItemCache`

### DIFF
--- a/src/tree/BranchDataItemWrapper.ts
+++ b/src/tree/BranchDataItemWrapper.ts
@@ -115,13 +115,9 @@ export class BranchDataItemWrapper implements ResourceGroupsItem, Wrapper {
 export type BranchDataItemFactory = (branchItem: ResourceModelBase, branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>, options?: BranchDataItemOptions) => BranchDataItemWrapper;
 
 export function createBranchDataItemFactory(itemCache: BranchDataItemCache): BranchDataItemFactory {
-    return (branchItem, branchDataProvider, options) => {
-        const cachedItem = itemCache.getItemForId(branchItem.id) as BranchDataItemWrapper | undefined;
-        if (cachedItem) {
-            cachedItem.branchItem = branchItem;
-            itemCache.addBranchItem(branchItem, cachedItem);
-            return cachedItem;
-        }
-        return new BranchDataItemWrapper(branchItem, branchDataProvider, itemCache, options);
-    }
+    return (branchItem, branchDataProvider, options) =>
+        itemCache.createOrGetItem(
+            branchItem,
+            () => new BranchDataItemWrapper(branchItem, branchDataProvider, itemCache, options),
+        )
 }

--- a/src/tree/azure/AzureResourceItem.ts
+++ b/src/tree/azure/AzureResourceItem.ts
@@ -54,13 +54,9 @@ export class AzureResourceItem<T extends AzureResource> extends BranchDataItemWr
 export type ResourceItemFactory<T extends AzureResource> = (resource: T, branchItem: ResourceModelBase, branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>, parent?: ResourceGroupsItem, options?: BranchDataItemOptions) => AzureResourceItem<T>;
 
 export function createResourceItemFactory<T extends AzureResource>(itemCache: BranchDataItemCache): ResourceItemFactory<T> {
-    return (resource, branchItem, branchDataProvider, parent, options) => {
-        const cachedItem = itemCache.getItemForId(branchItem.id) as AzureResourceItem<T> | undefined;
-        if (cachedItem) {
-            cachedItem.branchItem = branchItem;
-            itemCache.addBranchItem(branchItem, cachedItem);
-            return cachedItem;
-        }
-        return new AzureResourceItem(resource, branchItem, branchDataProvider, itemCache, parent, options);
-    }
+    return (resource, branchItem, branchDataProvider, parent, options) =>
+        itemCache.createOrGetItem(
+            branchItem,
+            () => new AzureResourceItem(resource, branchItem, branchDataProvider, itemCache, parent, options)
+        );
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3670

For compatibility, if a branch item is an `AzExtTreeItem`, make sure to use the `fullId` instead of the `id` as a cache key. Often `AzExtTreeItem`s have a single simple word as the `id`, and store the real id in `fullId`. This causes issues if we cache based on `id` alone since items will share an `id`.