### PR TITLE
Stop caching resource list in focus view

### DIFF
--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -33,10 +33,7 @@ export function registerCommands(): void {
     // Special-case refresh that ignores the selected/focused node and always refreshes the entire tree. Used by the refresh button in the tree title.
     registerCommand('azureResourceGroups.refreshTree', () => ext.actions.refreshAzureTree());
     registerCommand('azureWorkspace.refreshTree', () => ext.actions.refreshWorkspaceTree());
-    registerCommand('azureFocusView.refreshTree', () => {
-        ext.focusViewTreeDataProvider.clearResourcesCache();
-        ext.actions.refreshFocusTree();
-    });
+    registerCommand('azureFocusView.refreshTree', () => ext.actions.refreshFocusTree());
 
     // v1.5 client extensions attach these commands to tree item context menus for refreshing their tree items
     registerCommand('azureResourceGroups.refresh', async (context, node?: ResourceGroupsItem) => {


### PR DESCRIPTION
Originally added to make the focus/unfocus operations snappier. Was causing more problems than it was worth.

Fixes https://github.com/microsoft/vscode-azureresourcegroups/issues/688, https://github.com/microsoft/vscode-azureresourcegroups/issues/694