### PR TITLE
api: Extend `ViewPropertiesModel` to allow async loading of properties

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Extend `ViewPropertiesModel` to allow async loading of properties
+
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [2.0.4] - 2023-02-22

--- a/api/docs/vscode-azureresources-api.d.ts
+++ b/api/docs/vscode-azureresources-api.d.ts
@@ -364,11 +364,21 @@ export declare interface ResourcesApi {
 
 export declare function unwrapArgs<T>(args?: unknown[]): [node?: T, nodes?: T[], ...args: unknown[]];
 
-export declare interface ViewPropertiesModel {
+export declare type ViewPropertiesModel = {
     /**
      * File name displayed in VS Code.
      */
     label: string;
+} & (ViewPropertiesModelAsync | ViewPropertiesModelSync);
+
+export declare interface ViewPropertiesModelAsync {
+    /**
+     * Async function to get the raw data associated with the resource to populate the properties file.
+     */
+    getData: () => Promise<{}>;
+}
+
+export declare interface ViewPropertiesModelSync {
     /**
      * Raw data associated with the resource to populate the properties file.
      */

--- a/api/src/resources/azure.ts
+++ b/api/src/resources/azure.ts
@@ -116,17 +116,26 @@ export interface AzureResource extends ResourceBase {
     readonly raw: {};
 }
 
-export interface ViewPropertiesModel {
+export interface ViewPropertiesModelAsync {
     /**
-     * File name displayed in VS Code.
+     * Async function to get the raw data associated with the resource to populate the properties file.
      */
-    label: string;
+    getData: () => Promise<{}>;
+}
 
+export interface ViewPropertiesModelSync {
     /**
      * Raw data associated with the resource to populate the properties file.
      */
     data: {};
 }
+
+export type ViewPropertiesModel = {
+    /**
+    * File name displayed in VS Code.
+    */
+    label: string
+} & (ViewPropertiesModelAsync | ViewPropertiesModelSync);
 
 /**
  * Represents a model of an individual Azure resource or its child items.


### PR DESCRIPTION
A small change that extends the existing `ViewPropertiesModel` to allow async loading of properties. It is backwards compatible and requires no changes to client extensions. Client extensions can optionally utilize this feature once this API change is released in the extension.

This change is required so that we can stop making so many requests in `getResourceItem` for top level resources and decrease loading times.