### PR TITLE
Stop importing from docs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
-    "extends": "@microsoft/eslint-config-azuretools"
+    "extends": "@microsoft/eslint-config-azuretools",
+    "rules": {
+        "no-restricted-imports": ["error", { "patterns": ["*api/docs*"] }],
+    }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,13 @@
 module.exports = {
     "extends": "@microsoft/eslint-config-azuretools",
     "rules": {
-        "no-restricted-imports": ["error", { "patterns": ["*api/docs*"] }],
+        "no-restricted-imports": ["error", {
+            patterns: [
+                {
+                    group: ["*api/docs*"],
+                    message: "Don't import from docs. Import from src instead."
+                }
+            ]
+        }],
     }
 };

--- a/src/commands/focus/focusGroup.ts
+++ b/src/commands/focus/focusGroup.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { contextValueExperience, IActionContext } from "@microsoft/vscode-azext-utils";
-import { AzExtResourceType } from "api/docs/vscode-azureresources-api";
+import { AzExtResourceType } from "api/src/AzExtResourceType";
 import * as vscode from 'vscode';
 import { canFocusContextValue, hasFocusedGroupContextKey } from "../../constants";
 import { ext } from "../../extensionVariables";

--- a/src/commands/viewProperties.ts
+++ b/src/commands/viewProperties.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { azureResourceExperience, IActionContext, openReadOnlyJson } from '@microsoft/vscode-azext-utils';
-import { ViewPropertiesModelAsync } from 'api/docs/vscode-azureresources-api';
 import { v4 as uuidv4 } from "uuid";
-import { ViewPropertiesModel } from '../../api/src/index';
+import { ViewPropertiesModel, ViewPropertiesModelAsync } from '../../api/src/index';
 import { ext } from '../extensionVariables';
 import { ResourceGroupsItem } from '../tree/ResourceGroupsItem';
 import { localize } from '../utils/localize';

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -5,7 +5,7 @@
 
 import { AzureSubscriptionProvider } from "@microsoft/vscode-azext-azureauth";
 import { AzExtTreeDataProvider, IAzExtLogOutputChannel } from "@microsoft/vscode-azext-utils";
-import { AzExtResourceType } from "api/docs/vscode-azureresources-api";
+import { AzExtResourceType } from "api/src/AzExtResourceType";
 import { DiagnosticCollection, Disposable, ExtensionContext, TreeView, UIKind, env } from "vscode";
 import { ActivityLogTreeItem } from "./activityLog/ActivityLogsTreeItem";
 import { TagFileSystem } from "./commands/tags/TagFileSystem";

--- a/src/tree/azure/FocusViewTreeDataProvider.ts
+++ b/src/tree/azure/FocusViewTreeDataProvider.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureSubscription } from '@microsoft/vscode-azext-azureauth';
-import { AzureResource } from 'api/docs/vscode-azureresources-api';
 import * as vscode from 'vscode';
-import { AzExtResourceType, ResourceModelBase } from '../../../api/src/index';
+import { AzExtResourceType, AzureResource, ResourceModelBase } from '../../../api/src/index';
 import { AzureResourceProviderManager } from '../../api/ResourceProviderManagers';
 import { azureExtensions } from '../../azureExtensions';
 import { showHiddenTypesSettingKey } from '../../constants';

--- a/src/tree/azure/grouping/ResourceTypeGroupingItem.ts
+++ b/src/tree/azure/grouping/ResourceTypeGroupingItem.ts
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { AzExtResourceType } from "api/docs/vscode-azureresources-api";
+import { AzExtResourceType } from "api/src/AzExtResourceType";
 import { canFocusContextValue } from "../../../constants";
 import { GroupingItem, GroupingItemOptions } from "./GroupingItem";
 import { GroupingItemFactoryOptions } from "./GroupingItemFactory";


### PR DESCRIPTION
Fixing where we were importing from the types file meant for documentation only. I also added an eslint rule to prevent this in the future.

We should only import this stuff from the src itself.