### PR TITLE
Add telemetry for subscription information

### DIFF
--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -78,7 +78,7 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
                         }
                     )];
                 } else if (await subscriptionProvider.isSignedIn()) {
-                    void this.sendSubscriptionTelemetryIfNeeded();
+                    this.sendSubscriptionTelemetryIfNeeded();
                     let subscriptions: AzureSubscription[];
                     if ((subscriptions = await subscriptionProvider.getSubscriptions(true)).length === 0) {
                         if (
@@ -138,7 +138,7 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
     }
 
     private hasSentSubscriptionTelemetry = false;
-    private async sendSubscriptionTelemetryIfNeeded(): Promise<void> {
+    private sendSubscriptionTelemetryIfNeeded(): void {
         if (this.hasSentSubscriptionTelemetry) {
             return;
         }

--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureSubscription, getUnauthenticatedTenants } from '@microsoft/vscode-azext-azureauth';
-import { IActionContext, registerEvent } from '@microsoft/vscode-azext-utils';
+import { IActionContext, callWithTelemetryAndErrorHandling, registerEvent } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ResourceModelBase } from '../../../api/src/index';
 import { AzureResourceProviderManager } from '../../api/ResourceProviderManagers';
@@ -78,6 +78,7 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
                         }
                     )];
                 } else if (await subscriptionProvider.isSignedIn()) {
+                    void this.sendSubscriptionTelemetryIfNeeded();
                     let subscriptions: AzureSubscription[];
                     if ((subscriptions = await subscriptionProvider.getSubscriptions(true)).length === 0) {
                         if (
@@ -134,5 +135,35 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
         }
 
         return undefined;
+    }
+
+    private hasSentSubscriptionTelemetry = false;
+    private async sendSubscriptionTelemetryIfNeeded(): Promise<void> {
+        if (this.hasSentSubscriptionTelemetry) {
+            return;
+        }
+        this.hasSentSubscriptionTelemetry = true;
+
+        // This event is relied upon by the DevDiv Analytics and Growth Team
+        void callWithTelemetryAndErrorHandling('updateSubscriptionsAndTenants', async (context: IActionContext) => {
+            context.telemetry.properties.isActivationEvent = 'true';
+            context.errorHandling.suppressDisplay = true;
+
+            const subscriptionProvider = await this.getAzureSubscriptionProvider();
+            const subscriptions = await subscriptionProvider.getSubscriptions(false);
+
+            const tenantSet = new Set<string>();
+            const subscriptionSet = new Set<string>();
+            subscriptions.forEach(sub => {
+                tenantSet.add(sub.tenantId);
+                subscriptionSet.add(sub.subscriptionId);
+            });
+
+            // Number of tenants and subscriptions really belong in Measurements but for backwards compatibility
+            // they will be put into Properties instead.
+            context.telemetry.properties.numtenants = tenantSet.size.toString();
+            context.telemetry.properties.numsubscriptions = subscriptionSet.size.toString();
+            context.telemetry.properties.subscriptions = JSON.stringify(Array.from(subscriptionSet));
+        });
     }
 }


### PR DESCRIPTION
The Azure Account extension is no longer used by the Azure Resources extension and the `updateSubscriptionsAndTenants` event it had is relied upon to generate Azure-subscription-related telemetry. We need to mimic the old event so that Kusto queries can be minimally changed.