### PR TITLE
Bump version to 0.8.0-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureresourcegroups",
-    "version": "0.7.6-alpha.0",
+    "version": "0.8.0-alpha.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureresourcegroups",
-            "version": "0.7.6-alpha.0",
+            "version": "0.8.0-alpha.0",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-resources": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azureresourcegroups",
     "displayName": "Azure Resources",
     "description": "%azureResourceGroups.description%",
-    "version": "0.7.6-alpha.0",
+    "version": "0.8.0-alpha.0",
     "publisher": "ms-azuretools",
     "icon": "resources/resourceGroup.png",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",


### PR DESCRIPTION
We'll release this as 0.8.0, but for CTIs testing it's nice to have it match so I'll bump it before I give them the RC.