### PR TITLE
Fix bug that prevents resource groups from loading when there's a ghost resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Fixed
+* [[820]](https://github.com/microsoft/vscode-azureresourcegroups/pull/820) Fix bug that prevents resource groups from loading when there's a ghost resource
+
 ## 0.8.4 - 2024-02-07
 
 ### Added

--- a/src/tree/azure/grouping/AzureResourceGroupingManager.ts
+++ b/src/tree/azure/grouping/AzureResourceGroupingManager.ts
@@ -46,7 +46,15 @@ function groupBy({ allResources, keySelector, initialGrouping, groupingItemFacto
         },
         initialGrouping);
 
-    return Object.entries(map).map(([key, resources]) => groupingItemFactory(key, resources));
+    const groupingItems: GroupingItem[] = [];
+    Object.entries(map).forEach(([key, resources]) => {
+        try {
+            groupingItems.push(groupingItemFactory(key, resources));
+        } catch (e) {
+            ext.outputChannel.error(`Error creating grouping item for key: "${key}"`, e);
+        }
+    });
+    return groupingItems;
 }
 
 export class AzureResourceGroupingManager extends vscode.Disposable {


### PR DESCRIPTION
Fixes #819 

This bug occurs when a deleted or nonexistent resource is returned by the Azure REST API by mistake. Previous behavior is that no resource groups were displayed, now all resources are displayed and an error is logged in the console.

The error looks like
`
2024-02-13 13:21:44.375 [error] Error creating grouping item for key: "RGNAME-rg" Internal error: Expected value to be neither null nor undefined: resourceGroup for grouping item
`