### PR TITLE
Change internal RGs API version back to 0.0.1

### DIFF
--- a/src/api/compatibility/AzureResourceGroupsExtensionApi.ts
+++ b/src/api/compatibility/AzureResourceGroupsExtensionApi.ts
@@ -9,7 +9,7 @@ import { AzureSubscription } from 'api/src';
 import { Disposable, TreeView } from 'vscode';
 
 export class InternalAzureResourceGroupsExtensionApi implements AzureHostExtensionApi, AzureResourceGroupsExtensionApi {
-    public static apiVersion = '0.0.2';
+    public static apiVersion = '0.0.1';
 
     #appResourceTree: AzExtTreeDataProvider;
     #appResourceTreeView: TreeView<unknown>;

--- a/test/api/v1.test.ts
+++ b/test/api/v1.test.ts
@@ -7,7 +7,7 @@ suite('v1 API tests', async () => {
 
         assert.ok(apiProvider, 'API provider is undefined');
 
-        const v1Api = apiProvider.getApi('0.0.2', {
+        const v1Api = apiProvider.getApi('0.0.1', {
             extensionId: 'ms-azuretools.vscode-azureresourcegroups-tests',
         });
 


### PR DESCRIPTION
We wanted to bump the API version for minor updates that aren't breaking, but bumping the version from 0.0.1 to 0.0.2 requires updating all of the requested versions in each extension. This outweighs the purpose of bumping for minor changes. Next time we create breaking changes to this API, we will update it to 1.0.0 so in the future we can bump the minor version and avoid this.

The mistake we made was starting the API at 0.0.1 instead of 1.0.0.