### PR TITLE
Use `process.execPath` instead of `process.argv0` to fix launching Cloud Shell on Linux

### DIFF
--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -287,7 +287,7 @@ export function createCloudConsole(subscriptionProvider: AzureSubscriptionProvid
                 cloudConsoleLauncherPath = cloudConsoleLauncherPath.replace(/\\/g, '\\\\');
             }
             const shellArgs: string[] = [
-                process.argv0,
+                process.execPath,
                 '-e',
                 `require('${cloudConsoleLauncherPath}').main()`,
             ];


### PR DESCRIPTION
This fix addresses https://github.com/microsoft/vscode-azure-account/issues/719

For some reason only on Linux (in my case Ubuntu desktop 22.04.2) `process.execPath` and `process.argv0` are different. We are using the `process.argv0` value as the shell args that start up the child process to control the custom cloud shell shell. And for linux, `/proc/self/exe` wasn't working, but when I change it to `process.execPath` it's happy.

I'd love for some info on this if anyone knows what's going on here.

on Linux:
<img width="484" alt="Pasted Graphic" src="https://github.com/microsoft/vscode-azureresourcegroups/assets/12476526/c0b7116e-1170-47f0-bb45-147b20818907">

on macOS:
<img width="1166" alt="Pasted Graphic 1" src="https://github.com/microsoft/vscode-azureresourcegroups/assets/12476526/159bdf9a-a632-4a8b-aec3-79039e0e84ae">
