### PR TITLE
Stop using `--ms-enable-electron-run-as-node` flag to fix launching Cloud Shell on macOS

### DIFF
--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -14,7 +14,7 @@ import { Socket } from 'net';
 import * as path from 'path';
 import * as semver from 'semver';
 import { UrlWithStringQuery, parse } from 'url';
-import { CancellationToken, EventEmitter, MessageItem, Terminal, TerminalOptions, TerminalProfile, ThemeIcon, UIKind, Uri, authentication, commands, env, version, window, workspace } from 'vscode';
+import { CancellationToken, EventEmitter, MessageItem, Terminal, TerminalOptions, TerminalProfile, ThemeIcon, Uri, authentication, commands, env, window, workspace } from 'vscode';
 import { ext } from '../extensionVariables';
 import { localize } from '../utils/localize';
 import { fetchWithLogging } from '../utils/logging/nodeFetch/nodeFetch';
@@ -296,14 +296,6 @@ export function createCloudConsole(subscriptionProvider: AzureSubscriptionProvid
                 // Work around https://github.com/electron/electron/issues/4218 https://github.com/nodejs/node/issues/11656
                 shellPath = 'node.exe';
                 shellArgs.shift();
-            }
-
-            // // Only add flag if in Electron process https://github.com/microsoft/vscode-azure-account/pull/684
-            // // and not on Windows or macOS
-            if (!isWindows && !!process.versions['electron'] && env.uiKind === UIKind.Desktop && semver.gte(version, '1.62.1')) {
-                // https://github.com/microsoft/vscode/issues/136987
-                // This fix can't be applied to all versions of VS Code. An error is thrown in versions less than the one specified
-                shellArgs.push('--ms-enable-electron-run-as-node');
             }
 
             const terminalOptions: TerminalOptions = {


### PR DESCRIPTION
This fix addresses https://github.com/microsoft/vscode-azure-account/issues/959

Stop using `--ms-enable-electron-run-as-node` flag since it's no longer supported.

I reached out to the VS Code team for more clarification on this flag and what it does:

> The flag was added originally as a fix for an MSRC case reported against VS Code desktop application on macOS. The attack used the ELECTRON_RUN_AS_NODE mode to start VS Code application as a node process to execute malicious scripts from within an sandboxed application using NODE_REQUIRE env flags. Mac app sandbox disallows command line flags when launching external applications but does allow env variables hence the attack became possible. So this also provided a way for us to disable the attack by only the ELECTRON_RUN_AS_NODE mode be available when
--ms-enable-electron-run-as-node is passed alongside. This was a patch we carried on top of Electron for a while and eventually upstreamed it with a different solution
https://github.com/electron/electron/commit/f842ead6bc627afdf5b945305abb3e1872b558ef
. Hence the flag is now obsolete.

I also asked why `ELECTRON_RUN_AS_NODE` is still needed, when the flag is not:

> If we want to fork a child process as a node.js process from within the application then the env variable is needed.

Some reference PRs on the VS Code side:
https://github.com/microsoft/vscode/pull/202053
https://github.com/microsoft/vscode-remote-ssh/pull/397