### PR TITLE
Improve tenant selection for cloud shell

### DIFF
--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -362,7 +362,8 @@ export function createCloudConsole(subscriptionProvider: AzureSubscriptionProvid
                 serverQueue.push({ type: 'log', args: [localize('foundTenants', `Found ${tenantsWithSubs.length} authenticated tenant${tenants.length > 1 ? 's' : ''}. Please use the "Sign in to directory..." command to sign in to additional tenants.`)] });
 
                 if (tenantsWithSubs.length <= 1) {
-                    selectedTenant = tenantsWithSubs[0];
+                    // If they have only one tenant with subscriptions, use it. If there's no tenant with subscriptions, use the first tenant.
+                    selectedTenant = tenantsWithSubs[0] ?? tenants[0];
                 } else {
                     // Multipe tenants with subscriptions, user must pick a tenant
                     serverQueue.push({ type: 'log', args: [localize('selectingTenant', `Selecting tenant...`)] });

--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -5,7 +5,7 @@
 
 import { TenantIdDescription } from '@azure/arm-resources-subscriptions';
 import { AzureSubscriptionProvider, getConfiguredAzureEnv } from '@microsoft/vscode-azext-azureauth';
-import { IActionContext, IAzureQuickPickItem, IParsedError, callWithTelemetryAndErrorHandlingSync, parseError } from '@microsoft/vscode-azext-utils';
+import { IActionContext, IAzureQuickPickItem, IParsedError, callWithTelemetryAndErrorHandlingSync, nonNullProp, parseError } from '@microsoft/vscode-azext-utils';
 import * as cp from 'child_process';
 import * as FormData from 'form-data';
 import { ReadStream } from 'fs';
@@ -343,36 +343,53 @@ export function createCloudConsole(subscriptionProvider: AzureSubscriptionProvid
             liveServerQueue = serverQueue;
 
             const tenants = await subscriptionProvider.getTenants();
-            serverQueue.push({ type: 'log', args: [localize('foundTenants', `Found ${tenants.length} tenant${tenants.length > 1 ? 's' : ''}.`)] });
             let selectedTenant: TenantIdDescription | undefined = undefined;
-            // handle multi tenant scenario, user must pick a tenant
-            if (tenants.length > 1) {
-                serverQueue.push({ type: 'log', args: [localize('selectingTenant', `Selecting tenant...`)] });
-                const picks = tenants.map(tenant => {
-                    const defaultDomainName: string | undefined = tenant.defaultDomain;
-                    return <IAzureQuickPickItem<TenantIdDescription>>{
-                        label: tenant.displayName,
-                        description: defaultDomainName,
-                        data: tenant,
-                    };
-                }).sort((a, b) => a.label.localeCompare(b.label));
 
-                const pick = await window.showQuickPick<IAzureQuickPickItem<TenantIdDescription>>(picks, {
-                    placeHolder: localize('selectDirectoryPlaceholder', "Select tenant"),
-                    ignoreFocusOut: true // The terminal opens concurrently and can steal focus (https://github.com/microsoft/vscode-azure-account/issues/77).
-                });
-
-                if (!pick) {
-                    context.telemetry.properties.outcome = 'noTenantPicked';
-                    serverQueue.push({ type: 'exit' });
-                    updateStatus('Disconnected');
-                    return;
-                }
-
-                selectedTenant = pick.data;
-            } else {
+            if (tenants.length <= 1) {
+                serverQueue.push({ type: 'log', args: [localize('foundOneTenant', `Found 1 tenant.`)] });
+                // if they have only one tenant, use it
                 selectedTenant = tenants[0];
+            } else {
+                // If the user has multiple tenants, then we check which tenants have subscriptions.
+                // This also checks if this tenant is authenticated.
+                // If a tenant is not authenticated, users will have to use the "Sign in to Directory..." command before launching cloud shell.
+                const tenantsIdsWithSubs = new Set<string>();
+                const subscriptions = await subscriptionProvider.getSubscriptions(false);
+                subscriptions.forEach((sub) => {
+                    tenantsIdsWithSubs.add(sub.tenantId);
+                });
+                const tenantsWithSubs = tenants.filter(tenant => tenantsIdsWithSubs.has(nonNullProp(tenant, 'tenantId')));
+                serverQueue.push({ type: 'log', args: [localize('foundTenants', `Found ${tenantsWithSubs.length} authenticated tenant${tenants.length > 1 ? 's' : ''}. Please use the "Sign in to directory..." command to sign in to additional tenants.`)] });
+
+                if (tenantsWithSubs.length <= 1) {
+                    selectedTenant = tenantsWithSubs[0];
+                } else {
+                    // Multipe tenants with subscriptions, user must pick a tenant
+                    serverQueue.push({ type: 'log', args: [localize('selectingTenant', `Selecting tenant...`)] });
+                    const picks = tenantsWithSubs.map(tenant => {
+                        const defaultDomainName: string | undefined = tenant.defaultDomain;
+                        return <IAzureQuickPickItem<TenantIdDescription>>{
+                            label: tenant.displayName,
+                            description: defaultDomainName,
+                            data: tenant,
+                        };
+                    }).sort((a, b) => a.label.localeCompare(b.label));
+
+                    const pick = await window.showQuickPick<IAzureQuickPickItem<TenantIdDescription>>(picks, {
+                        placeHolder: localize('selectDirectoryPlaceholder', "Select tenant"),
+                        ignoreFocusOut: true // The terminal opens concurrently and can steal focus (https://github.com/microsoft/vscode-azure-account/issues/77).
+                    });
+
+                    if (!pick) {
+                        context.telemetry.properties.outcome = 'noTenantPicked';
+                        serverQueue.push({ type: 'exit' });
+                        updateStatus('Disconnected');
+                        return;
+                    }
+                    selectedTenant = pick.data;
+                }
             }
+            serverQueue.push({ type: 'log', args: [localize('usingTenant', `Using "${selectedTenant.displayName}" tenant.`)] });
 
             const session = await authentication.getSession('microsoft', ['https://management.core.windows.net//.default', `VSCODE_TENANT:${selectedTenant.tenantId}`], {
                 createIfNone: false,


### PR DESCRIPTION
The diff is misleading. There aren't that many changes here. I think because of the whitespace changes...

I'll do my best to explain what's going on here:

The Azure Account behavior was to get all authenticated tenants that have >0 subscriptions and let the user pick if there's more than one. The current behavior is to get all tenants and let the user pick if there's more than one. I'd like to make the experience mimic that of Azure Account.

The new behavior is the same as Azure Account, however a shortcut step 1. has been added that wasn't present before.

1. We list all tenants, if we find only one, we select it.
2. If they have multiple tenants, we check which are authenticated and have at least one subscription, if there's only one, we select it. (If there are zero, we still select the first tenant because later it'll show they need to setup their account if they have no subs)
3. If we get here, it means they have multiple authenticated tenants, we ask the user to select one.

In the future we might want to simplify this and just check if the tenant is authenticated and not if it has subscriptions. But for now I want to keep the experience unchanged from Azure Account to avoid any unnecessary UX changes for users.