### PR TITLE
Use cache to reveal resource

### DIFF
--- a/src/commands/revealResource.ts
+++ b/src/commands/revealResource.ts
@@ -9,6 +9,7 @@ import { VSCodeRevealOptions } from '../../api/src/index';
 import { ext } from '../extensionVariables';
 import { ResourceGroupsItem } from '../tree/ResourceGroupsItem';
 import { ResourceTreeDataProviderBase } from '../tree/ResourceTreeDataProviderBase';
+import { localize } from '../utils/localize';
 
 export async function revealResource(context: IActionContext, resourceId: string, options?: VSCodeRevealOptions): Promise<void> {
     setTelemetryPropertiesForId(context, resourceId);
@@ -17,6 +18,8 @@ export async function revealResource(context: IActionContext, resourceId: string
         const item: ResourceGroupsItem | undefined = await (ext.v2.api.resources.azureResourceTreeDataProvider as ResourceTreeDataProviderBase).findItemById(resourceId);
         if (item) {
             await ext.appResourceTreeView.reveal(item as unknown as AzExtTreeItem, options ?? { expand: false, focus: true, select: true });
+        } else {
+            void context.ui.showWarningMessage(localize('resourceNotFound', 'Resource with id "${0}" not found.', resourceId));
         }
     } catch (error) {
         context.telemetry.properties.revealError = parseError(error).message;

--- a/src/tree/BranchDataItemCache.ts
+++ b/src/tree/BranchDataItemCache.ts
@@ -29,8 +29,7 @@ export class BranchDataItemCache {
         return this.branchItemToResourceGroupsItemCache.get(branchItem);
     }
 
-    getItemForBranchItemById(branchItem: ResourceModelBase): ResourceGroupsItem | undefined {
-        const id = this.getIdForBranchItem(branchItem);
+    getItemForBranchItemById(id: string | undefined): ResourceGroupsItem | undefined {
         if (!id) {
             return undefined;
         }
@@ -39,7 +38,7 @@ export class BranchDataItemCache {
     }
 
     createOrGetItem<T extends BranchDataItemWrapper>(branchItem: ResourceModelBase, createItem: () => T): T {
-        const cachedItem = this.getItemForBranchItemById(branchItem) as T | undefined;
+        const cachedItem = this.getItemForBranchItemById(this.getIdForBranchItem(branchItem)) as T | undefined;
         if (cachedItem) {
             cachedItem.branchItem = branchItem;
             this.addBranchItem(branchItem, cachedItem);

--- a/src/tree/ResourceTreeDataProviderBase.ts
+++ b/src/tree/ResourceTreeDataProviderBase.ts
@@ -101,7 +101,10 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
     }
 
     async findItemById(id: string): Promise<ResourceGroupsItem | undefined> {
-        let element: ResourceGroupsItem | undefined = undefined;
+        let element: ResourceGroupsItem | undefined = this.itemCache.getItemForBranchItemById(id);
+        if (element) {
+            return element;
+        }
 
         outerLoop: while (true) {
             const children: ResourceGroupsItem[] | null | undefined = await this.getChildren(element);


### PR DESCRIPTION
There was already an item cache being used for storing the relationship data between parent and child. I was able to just leverage that to make reveal a lot faster if something has already been loaded before.

The next step to improving performance is to the do following across extensions:
1. Make resources resolve faster by not requiring the Azure API call until _after_ it is expanded
2. Change all extensions that resolve the resources with multi
ple `GET` calls use the `LIST` call. There is some concern about the caching that messes things up that we should consider, however, such as deleting too many resources at once and the cached list doesn't update to reflect that.

![reveal_cache](https://github.com/user-attachments/assets/9ceffdf8-1329-485a-aa0b-3dabe54ed8a7)