### PR TITLE
Prep for 0.9.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
-## 0.9.3 - 2024-08-20
-
+## 0.9.4 - 2024-08-27
 ### Added
 * [[894]](https://github.com/microsoft/vscode-azureresourcegroups/pull/894) Add staged support for MongoClusters
+
+## 0.9.3 - 2024-08-20
+
+Skipped
 
 ## 0.9.2 - 2024-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
-## 0.9.4 - 2024-08-27
+## 0.9.4 - 2024-08-28
 ### Added
 * [[894]](https://github.com/microsoft/vscode-azureresourcegroups/pull/894) Add staged support for MongoClusters
 
 ## 0.9.3 - 2024-08-20
 
-Skipped
+Skipped due to failed marketplace release
 
 ## 0.9.2 - 2024-08-08
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azureresourcegroups",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azureresourcegroups",
-            "version": "0.9.3",
+            "version": "0.9.4",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-resources": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azureresourcegroups",
     "displayName": "Azure Resources",
     "description": "%azureResourceGroups.description%",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "publisher": "ms-azuretools",
     "icon": "resources/resourceGroup.png",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",


### PR DESCRIPTION
We had to skip 0.9.3 because of a marketplace issue. I'm going to try to overwrite that release by bumping the version to 0.9.4.