### PR TITLE
Fix Cloud Shell in sovereign clouds

### DIFF
--- a/src/cloudConsole/cloudConsole.ts
+++ b/src/cloudConsole/cloudConsole.ts
@@ -14,7 +14,7 @@ import { Socket } from 'net';
 import * as path from 'path';
 import * as semver from 'semver';
 import { UrlWithStringQuery, parse } from 'url';
-import { CancellationToken, EventEmitter, MessageItem, Terminal, TerminalOptions, TerminalProfile, ThemeIcon, Uri, authentication, commands, env, window, workspace } from 'vscode';
+import { CancellationToken, EventEmitter, MessageItem, Terminal, TerminalOptions, TerminalProfile, ThemeIcon, Uri, commands, env, window, workspace } from 'vscode';
 import { ext } from '../extensionVariables';
 import { localize } from '../utils/localize';
 import { fetchWithLogging } from '../utils/logging/nodeFetch/nodeFetch';
@@ -345,6 +345,7 @@ export function createCloudConsole(subscriptionProvider: AzureSubscriptionProvid
             const tenants = await subscriptionProvider.getTenants();
             let selectedTenant: TenantIdDescription | undefined = undefined;
 
+            const subscriptions = await subscriptionProvider.getSubscriptions(false);
             if (tenants.length <= 1) {
                 serverQueue.push({ type: 'log', args: [localize('foundOneTenant', `Found 1 tenant.`)] });
                 // if they have only one tenant, use it
@@ -354,7 +355,6 @@ export function createCloudConsole(subscriptionProvider: AzureSubscriptionProvid
                 // This also checks if this tenant is authenticated.
                 // If a tenant is not authenticated, users will have to use the "Sign in to Directory..." command before launching cloud shell.
                 const tenantsIdsWithSubs = new Set<string>();
-                const subscriptions = await subscriptionProvider.getSubscriptions(false);
                 subscriptions.forEach((sub) => {
                     tenantsIdsWithSubs.add(sub.tenantId);
                 });
@@ -392,10 +392,24 @@ export function createCloudConsole(subscriptionProvider: AzureSubscriptionProvid
             }
             serverQueue.push({ type: 'log', args: [localize('usingTenant', `Using "${selectedTenant.displayName}" tenant.`)] });
 
-            const session = await authentication.getSession('microsoft', ['https://management.core.windows.net//.default', `VSCODE_TENANT:${selectedTenant.tenantId}`], {
-                createIfNone: false,
-            });
-            const result = session && await findUserSettings(session.accessToken);
+            // get all subscriptions for the selected tenant
+            const subscriptionsInSelectedTenant = subscriptions.filter(sub => sub.tenantId === selectedTenant?.tenantId);
+            if (subscriptionsInSelectedTenant.length === 0) {
+                // cloud shell requires at least one subscription to work
+                serverQueue.push({ type: 'log', args: [localize('noSubscriptions', `Error: No subscriptions found for the selected account and tenant.`)] });
+                updateStatus('Disconnected');
+                return;
+            }
+
+            // get session from the first subscription for the selected tenant
+            const session = await subscriptionsInSelectedTenant[0].authentication.getSession();
+            if (!session) {
+                serverQueue.push({ type: 'log', args: [localize('failedToGetSession', `Failed to get session.`)] });
+                updateStatus('Disconnected');
+                return;
+            }
+
+            const result = await findUserSettings(session.accessToken);
             if (!result) {
                 serverQueue.push({ type: 'log', args: [localize('setupNeeded', "Setup needed.")] });
                 await requiresSetUp(context);


### PR DESCRIPTION
Fixes #911 

We weren't properly handling sovereign clouds in the Cloud Shell when getting the session to use for the requests related to Cloud Shell.

My solution is to get the session from a subscription because that will handle getting a session for the proper tenant and sovereign cloud for us thanks to the auth package.

Since we're getting the session from the subscription, we now have a check for if the selected tenant has no subscriptions we don't continue. I confirmed with the cloud shell team that they don't plan on supporting cases where the user has no subscriptions.