### PR TITLE
Stop using external bash script to start cloud shell

### DIFF
--- a/bin/node.bat
+++ b/bin/node.bat
@@ -1,6 +1,0 @@
-@echo off 
-setlocal 
-set ELECTRON_NO_ASAR=1
-set ELECTRON_RUN_AS_NODE=1
-%*
-endlocal

--- a/bin/node.sh
+++ b/bin/node.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-ELECTRON_NO_ASAR=1 ELECTRON_RUN_AS_NODE=1 "$@"


### PR DESCRIPTION
Fixes #930 

Turns out somewhere in the new build pipeline we setup for signing some files are being rewritten with CRLF line endings instead of LF line endings. This caused the bash script we use to help fork the child process that cloud shell relies on to fail.

I've known for a while that we could get rid of these scripts so I just went ahead and made that change. IMO that's way easier than trying to figure out why the line endings are changing in our pipeline.

Other than removing the scripts, my goal was to keep all other behavior the same. As far as I can tell the .bat script wasn't being used.