### PR TITLE
Add feature to scope select subscriptions prompt by tenant

### DIFF
--- a/src/commands/accounts/selectSubscriptions.ts
+++ b/src/commands/accounts/selectSubscriptions.ts
@@ -12,7 +12,7 @@ import { settingUtils } from "../../utils/settingUtils";
 
 interface SelectSubscriptionOptions {
     /**
-     * If provided, only subscriptions in this tenant will be shown in the picker. Only subscriptions shown in the picker will be rempved or added to the selected subscriptions setting.
+     * If provided, only subscriptions in this tenant will be shown in the picker. Only subscriptions shown in the picker will be removed or added to the selected subscriptions setting.
      */
     tenantId?: string;
     /**

--- a/src/commands/accounts/selectSubscriptions.ts
+++ b/src/commands/accounts/selectSubscriptions.ts
@@ -10,7 +10,7 @@ import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
 import { settingUtils } from "../../utils/settingUtils";
 
-interface SelectSubscriptionOptions {
+export interface SelectSubscriptionOptions {
     /**
      * If provided, only subscriptions in this tenant will be shown in the picker. Only subscriptions shown in the picker will be removed or added to the selected subscriptions setting.
      */

--- a/src/commands/accounts/selectSubscriptions.ts
+++ b/src/commands/accounts/selectSubscriptions.ts
@@ -10,16 +10,33 @@ import { ext } from "../../extensionVariables";
 import { localize } from "../../utils/localize";
 import { settingUtils } from "../../utils/settingUtils";
 
-export async function selectSubscriptions(context: IActionContext): Promise<void> {
+interface SelectSubscriptionOptions {
+    /**
+     * If provided, only subscriptions in this tenant will be shown in the picker. Only subscriptions shown in the picker will be rempved or added to the selected subscriptions setting.
+     */
+    tenantId?: string;
+    /**
+     * TODO: implement filtering at the account level as well as the tenant level
+     */
+    account?: vscode.AuthenticationSessionAccountInformation;
+}
+
+export async function selectSubscriptions(context: IActionContext, options?: SelectSubscriptionOptions): Promise<void> {
     const provider = await ext.subscriptionProviderFactory();
     if (await provider.isSignedIn()) {
 
-        const selectedSubscriptionIds = await getSelectedSubscriptionIds();
+        const selectedSubscriptionsWithFullId = await getSelectedTenantAndSubscriptionIds();
+        const selectedSubscriptionIds = selectedSubscriptionsWithFullId.map(id => id.split('/')[1]);
+
+        let subscriptionsShownInPicker: string[] = [];
+
         const subscriptionQuickPickItems: () => Promise<IAzureQuickPickItem<AzureSubscription>[]> = async () => {
 
             const allSubscriptions = await provider.getSubscriptions(false);
+            const subscriptionsFilteredByTenant = options?.tenantId ? allSubscriptions.filter(subscription => subscription.tenantId === options.tenantId) : allSubscriptions;
 
-            return allSubscriptions
+            subscriptionsShownInPicker = subscriptionsFilteredByTenant.map(sub => `${sub.tenantId}/${sub.subscriptionId}`);
+            return subscriptionsFilteredByTenant
                 .map(subscription => ({
                     label: subscription.name,
                     description: subscription.subscriptionId,
@@ -39,7 +56,17 @@ export async function selectSubscriptions(context: IActionContext): Promise<void
             });
 
         if (picks) {
-            await setSelectedTenantAndSubscriptionIds(picks.map(s => `${s.data.tenantId}/${s.data.subscriptionId}`));
+            // get previously selected subscriptions
+            const previouslySelectedSubscriptionsSettingValue = new Set(selectedSubscriptionsWithFullId);
+
+            // remove any that were shown in the picker
+            subscriptionsShownInPicker.forEach(pick => previouslySelectedSubscriptionsSettingValue.delete(pick));
+
+            // add any that were selected in the picker
+            picks.forEach(pick => previouslySelectedSubscriptionsSettingValue.add(`${pick.data.tenantId}/${pick.data.subscriptionId}`));
+
+            // update the setting
+            await setSelectedTenantAndSubscriptionIds(Array.from(previouslySelectedSubscriptionsSettingValue));
         }
 
         ext.actions.refreshAzureTree();
@@ -51,11 +78,6 @@ export async function selectSubscriptions(context: IActionContext): Promise<void
             }
         });
     }
-}
-
-async function getSelectedSubscriptionIds(): Promise<string[]> {
-    const selectedTenantAndSubscriptionIds = await getSelectedTenantAndSubscriptionIds();
-    return selectedTenantAndSubscriptionIds.map(id => id.split('/')[1]);
 }
 
 export async function getSelectedTenantAndSubscriptionIds(): Promise<string[]> {

--- a/src/commands/accounts/selectSubscriptions.ts
+++ b/src/commands/accounts/selectSubscriptions.ts
@@ -16,7 +16,7 @@ interface SelectSubscriptionOptions {
      */
     tenantId?: string;
     /**
-     * TODO: implement filtering at the account level as well as the tenant level
+     * TODO: implement filtering at the account level
      */
     account?: vscode.AuthenticationSessionAccountInformation;
 }

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -12,7 +12,7 @@ import { BranchDataItemWrapper } from '../tree/BranchDataItemWrapper';
 import { ResourceGroupsItem } from '../tree/ResourceGroupsItem';
 import { GroupingItem } from '../tree/azure/grouping/GroupingItem';
 import { logIn } from './accounts/logIn';
-import { selectSubscriptions } from './accounts/selectSubscriptions';
+import { SelectSubscriptionOptions, selectSubscriptions } from './accounts/selectSubscriptions';
 import { clearActivities } from './activities/clearActivities';
 import { maintainCloudShellConnection } from './cloudShell';
 import { createResource } from './createResource';
@@ -67,7 +67,7 @@ export function registerCommands(): void {
     registerCommand('azureResourceGroups.unfocusGroup', unfocusGroup);
 
     registerCommand('azureResourceGroups.logIn', (context: IActionContext) => logIn(context));
-    registerCommand('azureResourceGroups.selectSubscriptions', (context: IActionContext) => selectSubscriptions(context));
+    registerCommand('azureResourceGroups.selectSubscriptions', (context: IActionContext, options: SelectSubscriptionOptions) => selectSubscriptions(context, options));
     registerCommand('azureResourceGroups.signInToTenant', async () => signInToTenant(await ext.subscriptionProviderFactory()));
 
     registerCommand('azureResourceGroups.createResourceGroup', createResourceGroup);


### PR DESCRIPTION
This adds the ability to scope the select subscriptions prompt by tenant. It also adds the option to filter by account, but that's not implemented in this PR.

If a prompt is scoped to a tenant, it won't change any selected subscriptions that aren't in that tenant. Only subscriptions shown in the picker will be removed or added to the selected subscriptions setting.