### PR TITLE
Updated the resource display name for vCore ahead of the upcoming release

### DIFF
--- a/src/utils/azureUtils.ts
+++ b/src/utils/azureUtils.ts
@@ -101,7 +101,7 @@ const azExtDisplayInfo: Partial<Record<AzExtResourceType, AzExtResourceTypeDispl
     Images: { displayName: localize('images', 'Images') },
     LoadBalancers: { displayName: localize('loadBalancers', 'Load balancers') },
     LogicApp: { displayName: localize('logicApp', 'Logic App') },
-    MongoClusters: { displayName: localize('mongoclusters', 'Azure Cosmos DB for MongoDB vCore') },
+    MongoClusters: { displayName: localize('mongoclusters', 'Azure Cosmos DB for MongoDB (vCore)') },
     MysqlServers: { displayName: localize('mysqlServers', 'MySql servers') },
     NetworkInterfaces: { displayName: localize('networkInterfaces', 'Network interfaces') },
     NetworkSecurityGroups: { displayName: localize('networkSecurityGroups', 'Network security groups') },


### PR DESCRIPTION
The resource display name for **Azure Cosmos DB for MongoDB (vCore)** needs to be formatted correctly as:

`Azure Cosmos DB for MongoDB (vCore)`

The display name has been updated to match the official resource name.