### PR TITLE
Add a timeout before deciding to show the GHCP4A toast

### DIFF
--- a/src/gitHubCopilotForAzure.ts
+++ b/src/gitHubCopilotForAzure.ts
@@ -21,7 +21,7 @@ export function gitHubCopilotForAzureToast({ globalState }: ExtensionContext): v
     void callWithTelemetryAndErrorHandling('ghcpfaToast', async (context: IActionContext) => {
         context.telemetry.properties.isActivationEvent = 'true';
 
-        // Allow extra time for all startup tasks to complete, which may include startup installations.
+        // Allow extra time for all startup tasks to complete, which could include extension installations.
         // We want to ensure the most current data before deciding to show the toast
         await delay(5000);
 

--- a/src/gitHubCopilotForAzure.ts
+++ b/src/gitHubCopilotForAzure.ts
@@ -5,7 +5,7 @@
 
 import { callWithTelemetryAndErrorHandling, IActionContext, openUrl } from "@microsoft/vscode-azext-utils";
 import { commands, Extension, ExtensionContext, extensions, window } from "vscode";
-import { delay } from "./cloudConsole/cloudConsoleUtils";
+import { delay } from "./utils/delay";
 import { localize } from "./utils/localize";
 
 const ghcpExtensionId = 'github.copilot';

--- a/src/gitHubCopilotForAzure.ts
+++ b/src/gitHubCopilotForAzure.ts
@@ -23,7 +23,7 @@ export function gitHubCopilotForAzureToast({ globalState }: ExtensionContext): v
 
         // Allow extra time for all startup tasks to complete, which could include extension installations.
         // We want to ensure the most current data before deciding to show the toast
-        await delay(5000);
+        await delay(3000);
 
         const arePrecursorExtensionsInstalled: boolean = isExtensionInstalled(ghcpExtensionId) && isExtensionInstalled(ghcpChatExtensionId);
         if (!arePrecursorExtensionsInstalled || isExtensionInstalled(ghcpfaExtensionId)) {

--- a/src/gitHubCopilotForAzure.ts
+++ b/src/gitHubCopilotForAzure.ts
@@ -5,6 +5,7 @@
 
 import { callWithTelemetryAndErrorHandling, IActionContext, openUrl } from "@microsoft/vscode-azext-utils";
 import { commands, Extension, ExtensionContext, extensions, window } from "vscode";
+import { delay } from "./cloudConsole/cloudConsoleUtils";
 import { localize } from "./utils/localize";
 
 const ghcpExtensionId = 'github.copilot';
@@ -19,6 +20,10 @@ const dontShowKey = 'ghcpfa/dontShow';
 export function gitHubCopilotForAzureToast({ globalState }: ExtensionContext): void {
     void callWithTelemetryAndErrorHandling('ghcpfaToast', async (context: IActionContext) => {
         context.telemetry.properties.isActivationEvent = 'true';
+
+        // Allow extra time for all startup tasks to complete, which may include startup installations.
+        // We want to ensure the most current data before deciding to show the toast
+        await delay(5000);
 
         const arePrecursorExtensionsInstalled: boolean = isExtensionInstalled(ghcpExtensionId) && isExtensionInstalled(ghcpChatExtensionId);
         if (!arePrecursorExtensionsInstalled || isExtensionInstalled(ghcpfaExtensionId)) {

--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export async function delay(delayMs: number): Promise<void> {
+    await new Promise<void>((resolve: () => void): void => { setTimeout(resolve, delayMs); });
+}


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-dev-azure/issues/10

I haven't really been able to repro the original issue (even on /azure), however, I understand that a delay would likely prevent this edge case from happening.  

I'm not exactly sure which timeout length to use, so let me know if you prefer using a longer timeout length.  I chose the current one because it still keeps the timing looking natural on my machine... but it's possible the timeout may be too short.