### PR TITLE
Use welcome view for resources sign in to tenant state

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,6 +302,11 @@
                 "view": "azureWorkspace",
                 "contents": "No local workspace resource providers exist.",
                 "when": "azureWorkspace.state == 'noWorkspaceResourceProviders'"
+            },
+            {
+                "view": "azureResourceGroups",
+                "contents": "Please sign in to a specific tenant (directory) to continue. \n [Sign in to Tenant (Directory)...](command:azureResourceGroups.signInToTenant)",
+                "when": "azureResourceGroups.needsTenantAuth == true"
             }
         ],
         "menus": {

--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -79,16 +79,16 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
                 } else if (await subscriptionProvider.isSignedIn()) {
                     this.sendSubscriptionTelemetryIfNeeded();
                     let subscriptions: AzureSubscription[];
+                    await vscode.commands.executeCommand('setContext', 'azureResourceGroups.needsTenantAuth', false);
                     if ((subscriptions = await subscriptionProvider.getSubscriptions(true)).length === 0) {
                         if (
                             // If there are no subscriptions at all (ignoring filters) AND if unauthenicated tenants exist
                             (await subscriptionProvider.getSubscriptions(false)).length === 0 &&
                             (await getUnauthenticatedTenants(subscriptionProvider)).length > 0
                         ) {
-                            // Subscriptions might exist in an unauthenticated tenant
-                            return [new GenericItem(localize('signInToDirectory', 'Sign in to Directory...'), {
-                                commandId: 'azureResourceGroups.signInToTenant'
-                            })];
+                            // Subscriptions might exist in an unauthenticated tenant. Show welcome view.
+                            await vscode.commands.executeCommand('setContext', 'azureResourceGroups.needsTenantAuth', true);
+                            return [];
                         } else {
                             return [new GenericItem(localize('noSubscriptions', 'Select Subscriptions...'), {
                                 commandId: 'azureResourceGroups.selectSubscriptions'


### PR DESCRIPTION
On first time sign in for accounts with multiple tenants, users will need to sign in to a specific tenant. [A customer pointed out that our clickable "Sign in to Directory..." tree item doesn't really look clickable](https://github.com/microsoft/vscode-azureresourcegroups/issues/899#issuecomment-2489498875). I agree, we can improve it by using a welcome view.

Here's the result:

Before:
<img width="458" alt="image" src="https://github.com/user-attachments/assets/8b6e2b82-03f3-42a0-8755-345594eac583">

After:
<img width="458" alt="image" src="https://github.com/user-attachments/assets/f9a3de0f-d292-45a9-a9d2-80325ed6f2c1">

Steps to reproduce (need an account with multiple tenants to test):
1. Sign out of your account on the Azure Portal in your browser.
2. Close and reopen the browser
3. Sign out of all Microsoft accounts in VS Code
4. Sign in using the Azure Resources view "Sign in..." button
You should see the "sign in to tenant/directory" view now.