### PR TITLE
Improve signInToTenant command title

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -3,7 +3,7 @@
     "azureResourceGroups.cloudShellPowerShell": "Azure Cloud Shell (PowerShell)",
     "azureResourceGroups.uploadToCloudShell": "Upload to Cloud Shell",
     "azureResourceGroups.logIn": "Sign In",
-    "azureResourceGroups.signInToTenant": "Sign in to Directory...",
+    "azureResourceGroups.signInToTenant": "Sign in to Tenant (Directory)...",
     "azureResourceGroups.selectSubscriptions": "Select Subscriptions...",
     "azureResourceGroups.createResourceGroup": "Create Resource Group...",
     "azureResourceGroups.createResourceGroupDetail": "The logical grouping for your resources.",


### PR DESCRIPTION
We've received feedback that more users know it as tenants rather than directories. It was originally put as directory since that's what the portal uses. So now we'll use both.