### PR TITLE
Hide tenants view "Sign in to Tenant" command from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -537,6 +537,10 @@
                 {
                     "command": "azureTenantsView.addAccount",
                     "when": "never"
+                },
+                {
+                    "command": "azureTenantsView.signInToTenant",
+                    "when": "never"
                 }
             ],
             "azureResourceGroups.groupBy": [


### PR DESCRIPTION
There are two commands for signing in to tenants we only want the azureResourceGroups view one to appear. 

Fixes #966 