### PR TITLE
Fix finding items with slashes in the account id

### DIFF
--- a/src/tree/ResourceTreeDataProviderBase.ts
+++ b/src/tree/ResourceTreeDataProviderBase.ts
@@ -134,5 +134,5 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
 }
 
 function removePrefix(id: string): string {
-    return id.replace(/\/accounts\/[^/]+\/tenants\/[^/]+\//i, '/')
+    return id.replace(/\/accounts\/.+\/tenants\/[^/]+\//i, '/')
 }


### PR DESCRIPTION
When using the "Classic" Microsoft authentication implementation (vs. MSAL) there can be a slash in the account id. In this regex we assumed that wasn't the case.

This was making find tree item fail which is used by Function App deploy which was then failing.