### PR TITLE
Prevent tree item ids from having double slash

### DIFF
--- a/src/tree/BranchDataItemWrapper.ts
+++ b/src/tree/BranchDataItemWrapper.ts
@@ -7,9 +7,9 @@ import { isAzExtTreeItem } from '@microsoft/vscode-azext-utils';
 import { v4 as uuidv4 } from "uuid";
 import * as vscode from 'vscode';
 import { AzureResourceModel, BranchDataProvider, ResourceBase, ResourceModelBase, ViewPropertiesModel, Wrapper } from '../../api/src/index';
-import { DefaultAzureResourceBranchDataProvider } from './azure/DefaultAzureResourceBranchDataProvider';
 import { BranchDataItemCache } from './BranchDataItemCache';
 import { ResourceGroupsItem } from './ResourceGroupsItem';
+import { DefaultAzureResourceBranchDataProvider } from './azure/DefaultAzureResourceBranchDataProvider';
 
 export type BranchDataItemOptions = {
     contextValues?: string[];
@@ -123,13 +123,12 @@ export class BranchDataItemWrapper implements ResourceGroupsItem, Wrapper {
 export type BranchDataItemFactory = (branchItem: ResourceModelBase, branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>, options?: BranchDataItemOptions) => BranchDataItemWrapper;
 
 export function createBranchDataItemFactory(itemCache: BranchDataItemCache): BranchDataItemFactory {
-    return (branchItem, branchDataProvider, options) => {
-        return itemCache.createOrGetItem(
+    return (branchItem, branchDataProvider, options) =>
+        itemCache.createOrGetItem(
             branchItem,
             () => new BranchDataItemWrapper(branchItem, branchDataProvider, itemCache, options),
             createBranchItemId(branchItem.id, options?.idPrefix),
         )
-    }
 }
 
 function createBranchItemId(id?: string, prefix?: string): string {

--- a/src/tree/BranchDataItemWrapper.ts
+++ b/src/tree/BranchDataItemWrapper.ts
@@ -50,7 +50,7 @@ export class BranchDataItemWrapper implements ResourceGroupsItem, Wrapper {
         } else {
             this.id = this.branchItem.id ?? this?.options?.defaultId ?? uuidv4();
         }
-        this.id = this.options?.idPrefix ? `${this.options.idPrefix}/${this.id}` : this.id;
+        this.id = createBranchItemId(this.id, this.options?.idPrefix);
     }
 
     public readonly id: string;
@@ -123,10 +123,19 @@ export class BranchDataItemWrapper implements ResourceGroupsItem, Wrapper {
 export type BranchDataItemFactory = (branchItem: ResourceModelBase, branchDataProvider: BranchDataProvider<ResourceBase, ResourceModelBase>, options?: BranchDataItemOptions) => BranchDataItemWrapper;
 
 export function createBranchDataItemFactory(itemCache: BranchDataItemCache): BranchDataItemFactory {
-    return (branchItem, branchDataProvider, options) =>
-        itemCache.createOrGetItem(
+    return (branchItem, branchDataProvider, options) => {
+        return itemCache.createOrGetItem(
             branchItem,
             () => new BranchDataItemWrapper(branchItem, branchDataProvider, itemCache, options),
-            `${options?.idPrefix ?? ''}${branchItem.id}`,
+            createBranchItemId(branchItem.id, options?.idPrefix),
         )
+    }
+}
+
+function createBranchItemId(id?: string, prefix?: string): string {
+    if (prefix?.endsWith('/') && id?.startsWith('/')) {
+        return `${prefix}${id.substring(1)}`;
+    } else {
+        return `${prefix ?? ''}${id}`;
+    }
 }

--- a/src/tree/ResourceTreeDataProviderBase.ts
+++ b/src/tree/ResourceTreeDataProviderBase.ts
@@ -134,5 +134,5 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
 }
 
 function removePrefix(id: string): string {
-    return id.replace(/\/accounts\/.+\/tenants\/[^/]+\/+/i, '/')
+    return id.replace(/\/accounts\/.+\/tenants\/[^/]+\//i, '/')
 }

--- a/src/tree/ResourceTreeDataProviderBase.ts
+++ b/src/tree/ResourceTreeDataProviderBase.ts
@@ -134,5 +134,5 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
 }
 
 function removePrefix(id: string): string {
-    return id.replace(/\/accounts\/.+\/tenants\/[^/]+\//i, '/')
+    return id.replace(/\/accounts\/.+\/tenants\/[^/]+\/+/i, '/')
 }


### PR DESCRIPTION
This breaks find item by id which causes issues in some extensions.

The bad ids look like: `/accounts/<accountId>/tenants/<tenantId>//subscriptions/<subscriptionId>/resourceGroups/...`