### PR TITLE
Allow service and target resources to openInPortal and add tooltips to role defintions

### DIFF
--- a/src/api/DefaultAzureResourceProvider.ts
+++ b/src/api/DefaultAzureResourceProvider.ts
@@ -51,7 +51,7 @@ export class DefaultAzureResourceProvider implements AzureResourceProvider {
     }
 }
 
-function createAzureResource(subscription: AzureSubscription, resource: GenericResource): AzureResource {
+export function createAzureResource(subscription: AzureSubscription, resource: GenericResource): AzureResource {
     const resourceId = nonNullProp(resource, 'id');
 
     return {

--- a/src/managedIdentity/ManagedIdentityItem.ts
+++ b/src/managedIdentity/ManagedIdentityItem.ts
@@ -8,8 +8,9 @@ import { uiUtils } from "@microsoft/vscode-azext-azureutils";
 import { callWithTelemetryAndErrorHandling, createContextValue, createSubscriptionContext, nonNullProp, type IActionContext } from "@microsoft/vscode-azext-utils";
 import { type AzureResource, type AzureSubscription, type ViewPropertiesModel } from "@microsoft/vscode-azureresources-api";
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from "vscode";
-import { getAzExtResourceType } from "../../api/src/index";
+import { createAzureResource } from "../api/DefaultAzureResourceProvider";
 import { getAzureResourcesService } from "../services/AzureResourcesService";
+import { DefaultAzureResourceItem } from "../tree/azure/DefaultAzureResourceItem";
 import { GenericItem } from "../tree/GenericItem";
 import { ResourceGroupsItem } from "../tree/ResourceGroupsItem";
 import { createAuthorizationManagementClient, createManagedServiceIdentityClient } from "../utils/azureClients";
@@ -64,7 +65,8 @@ export class ManagedIdentityItem implements ResourceGroupsItem {
 
                 return userAssignedIdentities[msi.id] !== undefined
             }).map((r) => {
-                return new GenericItem(nonNullProp(r, 'name'), { id: `${msi.id}/${r.name}`, iconPath: getIconPath(r.type ? getAzExtResourceType({ type: r.type }) : undefined) });
+                const azureResoure = createAzureResource(this.subscription, r);
+                return new DefaultAzureResourceItem(azureResoure);
             });
 
             const authClient = await createAuthorizationManagementClient([context, subContext]);

--- a/src/managedIdentity/RoleAssignmentsItem.ts
+++ b/src/managedIdentity/RoleAssignmentsItem.ts
@@ -16,14 +16,14 @@ import { RoleDefinitionsItem } from "./RoleDefinitionsItem";
 export class RoleAssignmentsItem implements ResourceGroupsItem {
     public id: string;
     public label: string;
-    private children: (RoleDefinitionsItem | GenericItem)[] = [];
+    private children: (ResourceGroupsItem | GenericItem)[] = [];
 
     constructor(label: string, readonly subscription: AzureSubscription, readonly msi: Identity) {
         this.label = label;
         this.id = `${msi.id}/${label}`;
     }
 
-    getChildren(): ProviderResult<ResourceGroupsItem[]> {
+    getChildren(): ProviderResult<(ResourceGroupsItem | GenericItem)[]> {
         return this.children;
     }
 
@@ -35,11 +35,11 @@ export class RoleAssignmentsItem implements ResourceGroupsItem {
         }
     }
 
-    addChild(child: RoleDefinitionsItem | GenericItem): void {
+    addChild(child: ResourceGroupsItem | GenericItem): void {
         this.children.push(child);
     }
 
-    addChildren(children: (RoleDefinitionsItem | GenericItem)[]): void {
+    addChildren(children: (ResourceGroupsItem | GenericItem)[]): void {
         this.children.push(...children);
     }
 
@@ -63,7 +63,7 @@ export class RoleAssignmentsItem implements ResourceGroupsItem {
                     const roleDefinition = await authClient.roleDefinitions.getById(ra.roleDefinitionId);
                     // if the role defition is not found, create a new one and push the role definition to it
                     if (!roleDefinitionsItems.some((rdi) => rdi.label === name)) {
-                        const rdi = await RoleDefinitionsItem.createRoleDefinitionsItem(ra.scope, roleDefinition, this.msi.id, fromOtherSubs);
+                        const rdi = await RoleDefinitionsItem.createRoleDefinitionsItem(ra.scope, roleDefinition, this.msi.id, this.subscription, fromOtherSubs);
                         roleDefinitionsItems.push(rdi);
                     } else {
                         // if the role definition is found, add the role definition to the existing role definition item

--- a/src/tree/GenericItem.ts
+++ b/src/tree/GenericItem.ts
@@ -15,6 +15,7 @@ export interface GenericItemOptions {
     readonly contextValue?: string;
     readonly iconPath?: TreeItemIconPath;
     readonly description?: string;
+    readonly tooltip?: string;
     readonly collapsibleState?: vscode.TreeItemCollapsibleState;
     readonly checkboxState?: vscode.TreeItemCheckboxState | {
         /**
@@ -55,6 +56,7 @@ export class GenericItem implements ResourceGroupsItem {
         }
 
         treeItem.description = this.options?.description;
+        treeItem.tooltip = this.options?.tooltip;
         treeItem.contextValue = this.options?.contextValue;
         treeItem.iconPath = this.options?.iconPath;
         treeItem.checkboxState = this.options?.checkboxState;


### PR DESCRIPTION
It was easier to convert the `GenericResources` to `DefaultAzureResources` to enable open in portal for them.
`RoleDefinitions` was easy enough to just build the portal url for.