### PR TITLE
Refactor getAzureSubscriptionProvider

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,6 @@ import { survey } from './nps';
 import { getSubscriptionProviderFactory } from './services/getSubscriptionProviderFactory';
 import { BranchDataItemCache } from './tree/BranchDataItemCache';
 import { HelpTreeItem } from './tree/HelpTreeItem';
-import { getAzureSubscriptionProvider } from './tree/OnGetChildrenBase';
 import { ResourceGroupsItem } from './tree/ResourceGroupsItem';
 import { AzureResourceBranchDataProviderManager } from './tree/azure/AzureResourceBranchDataProviderManager';
 import { DefaultAzureResourceBranchDataProvider } from './tree/azure/DefaultAzureResourceBranchDataProvider';
@@ -195,7 +194,7 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
     ext.workspaceTree = new CompatibleAzExtTreeDataProvider(workspaceResourceTreeDataProvider);
 
     const getSubscriptions: (filter: boolean) => Promise<AzureSubscription[]> =
-        async (filter: boolean) => { return await (await getAzureSubscriptionProvider(azureResourceTreeDataProvider)).getSubscriptions(filter) };
+        async (filter: boolean) => { return await (await ext.subscriptionProviderFactory()).getSubscriptions(filter) };
 
     return createApiProvider(
         [

--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -14,9 +14,9 @@ import { ext } from '../../extensionVariables';
 import { localize } from '../../utils/localize';
 import { BranchDataItemCache } from '../BranchDataItemCache';
 import { GenericItem } from '../GenericItem';
-import { OnGetChildrenBase, getAzureSubscriptionProvider } from '../OnGetChildrenBase';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { TreeItemStateStore } from '../TreeItemState';
+import { onGetAzureChildrenBase } from '../onGetAzureChildrenBase';
 import { AzureResourceTreeDataProviderBase } from './AzureResourceTreeDataProviderBase';
 import { SubscriptionItem } from './SubscriptionItem';
 import { AzureResourceGroupingManager } from './grouping/AzureResourceGroupingManager';
@@ -66,9 +66,9 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
         if (element) {
             return await element.getChildren();
         } else {
-            const subscriptionProvider = await getAzureSubscriptionProvider(this);
+            const subscriptionProvider = await this.getAzureSubscriptionProvider();
             // When a user is signed in 'OnGetChildrenBase' will return no children
-            const children: ResourceGroupsItem[] = await OnGetChildrenBase(subscriptionProvider, this);
+            const children: ResourceGroupsItem[] = await onGetAzureChildrenBase(subscriptionProvider, this);
 
             if (children.length === 0) {
                 this.sendSubscriptionTelemetryIfNeeded();
@@ -162,7 +162,7 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
             context.telemetry.properties.isActivationEvent = 'true';
             context.errorHandling.suppressDisplay = true;
 
-            const subscriptionProvider = await getAzureSubscriptionProvider(this);
+            const subscriptionProvider = await this.getAzureSubscriptionProvider();
             const subscriptions = await subscriptionProvider.getSubscriptions(false);
 
             const tenantSet = new Set<string>();

--- a/src/tree/azure/AzureResourceTreeDataProviderBase.ts
+++ b/src/tree/azure/AzureResourceTreeDataProviderBase.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureSubscriptionProvider } from '@microsoft/vscode-azext-azureauth';
 import * as vscode from 'vscode';
 import { ResourceModelBase } from '../../../api/src/index';
 import { AzureResourceProviderManager } from '../../api/ResourceProviderManagers';
@@ -15,11 +14,6 @@ import { AzureResourceGroupingManager } from './grouping/AzureResourceGroupingMa
 import { GroupingItem } from './grouping/GroupingItem';
 
 export abstract class AzureResourceTreeDataProviderBase extends ResourceTreeDataProviderBase {
-    public subscriptionProvider: AzureSubscriptionProvider | undefined;
-    public statusSubscription: vscode.Disposable | undefined;
-    public nextSessionChangeMessageMinimumTime = 0;
-    public sessionChangeMessageInterval = 1 * 1000; // 1 second
-
     constructor(
         itemCache: BranchDataItemCache,
         onDidChangeBranchTreeData: vscode.Event<void | ResourceModelBase | ResourceModelBase[] | null | undefined>,

--- a/src/tree/azure/FocusViewTreeDataProvider.ts
+++ b/src/tree/azure/FocusViewTreeDataProvider.ts
@@ -12,7 +12,6 @@ import { showHiddenTypesSettingKey } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { settingUtils } from '../../utils/settingUtils';
 import { BranchDataItemCache } from '../BranchDataItemCache';
-import { getAzureSubscriptionProvider } from '../OnGetChildrenBase';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { TreeItemStateStore } from '../TreeItemState';
 import { AzureResourceTreeDataProviderBase } from './AzureResourceTreeDataProviderBase';
@@ -54,7 +53,7 @@ export class FocusViewTreeDataProvider extends AzureResourceTreeDataProviderBase
                 return [];
             }
 
-            const provider = await getAzureSubscriptionProvider(this);
+            const provider = await this.getAzureSubscriptionProvider();
             let subscriptions: AzureSubscription[] | undefined;
             if (await provider.isSignedIn() && (subscriptions = await provider.getSubscriptions(true)).length > 0) {
                 const showHiddenTypes = settingUtils.getWorkspaceSetting<boolean>(showHiddenTypesSettingKey);

--- a/src/tree/tenants/TenantResourceTreeDataProvider.ts
+++ b/src/tree/tenants/TenantResourceTreeDataProvider.ts
@@ -3,26 +3,21 @@
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { AzureSubscriptionProvider, getConfiguredAuthProviderId } from '@microsoft/vscode-azext-azureauth';
+import { getConfiguredAuthProviderId } from '@microsoft/vscode-azext-azureauth';
 import { IActionContext, callWithTelemetryAndErrorHandling, nonNullProp, nonNullValueAndProp } from '@microsoft/vscode-azext-utils';
 import { ResourceModelBase } from 'api/src';
 import * as vscode from 'vscode';
 import { TenantResourceProviderManager } from '../../api/ResourceProviderManagers';
 import { BranchDataItemCache } from '../BranchDataItemCache';
 import { GenericItem } from '../GenericItem';
-import { OnGetChildrenBase, getAzureSubscriptionProvider } from '../OnGetChildrenBase';
 import { ResourceGroupsItem } from '../ResourceGroupsItem';
 import { ResourceTreeDataProviderBase } from "../ResourceTreeDataProviderBase";
+import { onGetAzureChildrenBase } from '../onGetAzureChildrenBase';
 import { TenantResourceBranchDataProviderManager } from "./TenantResourceBranchDataProviderManager";
 import { TenantTreeItem } from './TenantTreeItem';
 import { isTenantFilteredOut } from './registerTenantTree';
 
 export class TenantResourceTreeDataProvider extends ResourceTreeDataProviderBase {
-    public subscriptionProvider: AzureSubscriptionProvider | undefined;
-    public statusSubscription: vscode.Disposable | undefined;
-    public nextSessionChangeMessageMinimumTime = 0;
-    public sessionChangeMessageInterval = 1 * 1000; // 1 second
-
     constructor(
         protected readonly branchDataProviderManager: TenantResourceBranchDataProviderManager,
         onDidChangeBranchTreeData: vscode.Event<void | ResourceModelBase | ResourceModelBase[] | null | undefined>,
@@ -47,8 +42,8 @@ export class TenantResourceTreeDataProvider extends ResourceTreeDataProviderBase
             if (element) {
                 return await element.getChildren();
             } else {
-                const subscriptionProvider = await getAzureSubscriptionProvider(this);
-                const children: ResourceGroupsItem[] = await OnGetChildrenBase(subscriptionProvider);
+                const subscriptionProvider = await this.getAzureSubscriptionProvider();
+                const children: ResourceGroupsItem[] = await onGetAzureChildrenBase(subscriptionProvider);
 
                 if (children.length === 0) {
                     const accounts = Array.from((await vscode.authentication.getAccounts(getConfiguredAuthProviderId()))).sort((a, b) => a.label.localeCompare(b.label));


### PR DESCRIPTION
* Refactor the `getAzureSubscriptionProvider` method that should only be used by tree data providers to be a class method on `ResourceTreeDataProviderBase`.

* Renaming the `OnGetChildrenBase` function to `onGetAzureChildrenBase` for consistency