### PR TITLE
Add subscriptionId and resourceId to telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@azure/ms-rest-js": "^2.7.0",
                 "@microsoft/vscode-azext-azureauth": "^4.0.3",
                 "@microsoft/vscode-azext-azureutils": "^3.1.4",
-                "@microsoft/vscode-azext-utils": "^2.5.12",
+                "@microsoft/vscode-azext-utils": "^2.6.2",
                 "buffer": "^6.0.3",
                 "form-data": "^4.0.1",
                 "jsonc-parser": "^2.2.1",
@@ -1172,9 +1172,10 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "2.5.14",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.5.14.tgz",
-            "integrity": "sha512-PyfPy4FjX3EPkZzxI185xrOUcB9CKXJSCcO+26jjlEJDLu26v3YOrgSn75VbZVRBkH9zerh1XWdgHCDUQPQrNg==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.6.2.tgz",
+            "integrity": "sha512-sNwPxZbhiVKPtkMf55MeRXBgu84u9mjEwEv1eG1s73jdw/ZVBa6dhEHE9aJoMaMKO8pZnVQzccHey17d/CMiaQ==",
+            "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",
                 "@vscode/extension-telemetry": "^0.9.6",
@@ -11109,9 +11110,9 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "2.5.14",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.5.14.tgz",
-            "integrity": "sha512-PyfPy4FjX3EPkZzxI185xrOUcB9CKXJSCcO+26jjlEJDLu26v3YOrgSn75VbZVRBkH9zerh1XWdgHCDUQPQrNg==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.6.2.tgz",
+            "integrity": "sha512-sNwPxZbhiVKPtkMf55MeRXBgu84u9mjEwEv1eG1s73jdw/ZVBa6dhEHE9aJoMaMKO8pZnVQzccHey17d/CMiaQ==",
             "requires": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",
                 "@vscode/extension-telemetry": "^0.9.6",

--- a/package.json
+++ b/package.json
@@ -917,7 +917,7 @@
         "@azure/ms-rest-js": "^2.7.0",
         "@microsoft/vscode-azext-azureauth": "^4.0.3",
         "@microsoft/vscode-azext-azureutils": "^3.1.4",
-        "@microsoft/vscode-azext-utils": "^2.5.12",
+        "@microsoft/vscode-azext-utils": "^2.6.2",
         "buffer": "^6.0.3",
         "form-data": "^4.0.1",
         "jsonc-parser": "^2.2.1",

--- a/src/api/compatibility/pickAppResource.ts
+++ b/src/api/compatibility/pickAppResource.ts
@@ -18,6 +18,11 @@ export function createCompatibilityPickAppResource() {
             childItemFilter: convertExpectedChildContextValueToContextValueFilter(options?.expectedChildContextValue)
         });
 
+        context.telemetry.properties.resourceId = result.id;
+        if (result.subscription) {
+            context.telemetry.properties.subscriptionId = result.subscription.subscriptionId;
+        }
+
         return result;
     }
 }


### PR DESCRIPTION
Update utils to 2.6.2 to use the updated `registerCommand` function that records subscriptionId and resourceId automatically.

Also adds logic to `pickAppResource` (used by v1 extensions) to record subscriptionId and resourceId in telemetry