### PR TITLE
Fix issues caused by telemetry change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@azure/ms-rest-js": "^2.7.0",
                 "@microsoft/vscode-azext-azureauth": "^4.0.3",
                 "@microsoft/vscode-azext-azureutils": "^3.1.4",
-                "@microsoft/vscode-azext-utils": "^2.6.2",
+                "@microsoft/vscode-azext-utils": "^2.6.3",
                 "buffer": "^6.0.3",
                 "form-data": "^4.0.1",
                 "jsonc-parser": "^2.2.1",
@@ -1172,9 +1172,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.6.2.tgz",
-            "integrity": "sha512-sNwPxZbhiVKPtkMf55MeRXBgu84u9mjEwEv1eG1s73jdw/ZVBa6dhEHE9aJoMaMKO8pZnVQzccHey17d/CMiaQ==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.6.3.tgz",
+            "integrity": "sha512-eogbgZH1KQkGWstl9qb1Tq4DQH+JJCHLHZelIbnzIKE8JKxr8Et/byn3OuL5nL1qeITQQn3+AYVsbj2hbljM7w==",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",
@@ -11110,9 +11110,9 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.6.2.tgz",
-            "integrity": "sha512-sNwPxZbhiVKPtkMf55MeRXBgu84u9mjEwEv1eG1s73jdw/ZVBa6dhEHE9aJoMaMKO8pZnVQzccHey17d/CMiaQ==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.6.3.tgz",
+            "integrity": "sha512-eogbgZH1KQkGWstl9qb1Tq4DQH+JJCHLHZelIbnzIKE8JKxr8Et/byn3OuL5nL1qeITQQn3+AYVsbj2hbljM7w==",
             "requires": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",
                 "@vscode/extension-telemetry": "^0.9.6",

--- a/package.json
+++ b/package.json
@@ -917,7 +917,7 @@
         "@azure/ms-rest-js": "^2.7.0",
         "@microsoft/vscode-azext-azureauth": "^4.0.3",
         "@microsoft/vscode-azext-azureutils": "^3.1.4",
-        "@microsoft/vscode-azext-utils": "^2.6.2",
+        "@microsoft/vscode-azext-utils": "^2.6.3",
         "buffer": "^6.0.3",
         "form-data": "^4.0.1",
         "jsonc-parser": "^2.2.1",

--- a/src/api/compatibility/pickAppResource.ts
+++ b/src/api/compatibility/pickAppResource.ts
@@ -19,8 +19,14 @@ export function createCompatibilityPickAppResource() {
         });
 
         context.telemetry.properties.resourceId = result.id;
-        if (result.subscription) {
+
+        try {
+            // AzExtTreeItems throw when subscription is undefined. It's unlikely to happen here, but better safe than sorry.
+            // see https://github.com/microsoft/vscode-azuretools/blob/cc1feb3a819dd503eb59ebcc1a70051d4e9a3432/utils/src/tree/AzExtTreeItem.ts#L154
             context.telemetry.properties.subscriptionId = result.subscription.subscriptionId;
+        } catch (e) {
+            // don't block execution just because we can't set the telemetry properties
+            // see https://github.com/microsoft/vscode-azureresourcegroups/issues/1080
         }
 
         return result;


### PR DESCRIPTION
Consume utils v2.6.3 https://github.com/microsoft/vscode-azuretools/releases/tag/microsoft-vscode-azext-utils-v2.6.3

I also put another try/catch in pickAppResource. I'm pretty sure no AzExtTreeItems that don't have subscriptions should ever make it to that code path, but better be safe than sorry.

Read more about the cause of the issues in https://github.com/microsoft/vscode-azuretools/pull/1918

Fixes #1080 and #1081 