### PR TITLE
Fix duplicate id issue for Install extension tree items

### DIFF
--- a/src/tree/azure/DefaultAzureResourceItem.ts
+++ b/src/tree/azure/DefaultAzureResourceItem.ts
@@ -33,7 +33,8 @@ export class DefaultAzureResourceItem implements ResourceGroupsItem {
                         commandArgs: [this.resourceTypeExtension.id],
                         commandId: 'azureResourceGroups.installExtension',
                         contextValue: 'installExtension',
-                        iconPath: new vscode.ThemeIcon('extensions')
+                        iconPath: new vscode.ThemeIcon('extensions'),
+                        id: `${this.resource.id}/installExtension`
                     })
             ]);
         } else {


### PR DESCRIPTION
Just needed to give the "Install extension to enable additional features..." tree items unique ids to fix it.
<img width="421" alt="image" src="https://github.com/user-attachments/assets/151c8ef9-f933-4f68-9299-a28841875da9" />

Fixes #1051 