### PR TITLE
Removed obsolete `mongoClusters` feature flag

### DIFF
--- a/src/azureExtensions.ts
+++ b/src/azureExtensions.ts
@@ -4,31 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AppResource } from "@microsoft/vscode-azext-utils/hostapi";
-import { extensions } from "vscode";
 import { AzExtResourceType } from "../api/src/index";
 import { localize } from "./utils/localize";
-
-
-/**
- * This is a temporary function usend to optionaly enable support for MongoClusters in the Azure Resources extension.
- *
- * This solution is necessary for a staged release of the MongoClusters feature from the vscode-cosmosdb extension.
- * It will be removed once the MongoClusters feature is fully released.
- *
- * @returns
- */
-function enableMongoClustersSupport() {
-    const vsCodeCosmosDBConfiguration = extensions.getExtension('ms-azuretools.vscode-cosmosdb')?.packageJSON as ExtensionPackageMongoClustersEnabled;
-    return (vsCodeCosmosDBConfiguration && vsCodeCosmosDBConfiguration.enableMongoClusters);
-}
-
-/**
- * This is a temporary interface used to enable support for MongoClusters in the Azure Resources extension.
- * It will be removed once the MongoClusters feature is fully released.
- */
-interface ExtensionPackageMongoClustersEnabled {
-    readonly enableMongoClusters?: boolean;
-}
 
 export const azureExtensions: IAzExtMetadata[] = [
     {
@@ -101,23 +78,12 @@ export const azureExtensions: IAzExtMetadata[] = [
     {
         name: 'vscode-cosmosdb',
         label: 'Databases',
-        resourceTypes:
-            /**
-            * This is a temporary interface used to enable support for MongoClusters in the Azure Resources extension.
-            * It will be removed once the MongoClusters feature is fully released.
-            */
-            enableMongoClustersSupport() ?
-                [
-                    AzExtResourceType.AzureCosmosDb,
-                    AzExtResourceType.MongoClusters,
-                    AzExtResourceType.PostgresqlServersStandard,
-                    AzExtResourceType.PostgresqlServersFlexible,
-                ] :
-                [
-                    AzExtResourceType.AzureCosmosDb,
-                    AzExtResourceType.PostgresqlServersStandard,
-                    AzExtResourceType.PostgresqlServersFlexible,
-                ],
+        resourceTypes: [
+            AzExtResourceType.AzureCosmosDb,
+            AzExtResourceType.MongoClusters,
+            AzExtResourceType.PostgresqlServersStandard,
+            AzExtResourceType.PostgresqlServersFlexible,
+        ],
         reportIssueCommandId: 'azureDatabases.reportIssue'
     },
     {


### PR DESCRIPTION
The `Mongo Clusters / MongoDB (vCore)` feature has been fully shipped in Azure Databases VS Code Extension, the development-stage feature flag is no longer required.

---

This pull request includes changes to the `src/azureExtensions.ts` file to remove temporary support for MongoClusters in the Azure Resources extension. The main changes involve deleting the temporary function and interface used for enabling MongoClusters support and simplifying the resource types configuration for the `vscode-cosmosdb` extension.

Removal of temporary MongoClusters support:

* [`src/azureExtensions.ts`](diffhunk://#diff-0b490ed3eaa957d1045b981a579531e30c3da11c04a02b3e41f5cb7bf77b3627L7-L32): Removed the `enableMongoClustersSupport` function and the `ExtensionPackageMongoClustersEnabled` interface.
* [`src/azureExtensions.ts`](diffhunk://#diff-0b490ed3eaa957d1045b981a579531e30c3da11c04a02b3e41f5cb7bf77b3627L104-L119): Simplified the `resourceTypes` configuration for the `vscode-cosmosdb` extension by removing the conditional check for MongoClusters support.