### PR TITLE
Allow revealResource to reveal deep resources beyond known ResourceGroupsItem

### DIFF
--- a/src/commands/revealResource.ts
+++ b/src/commands/revealResource.ts
@@ -33,15 +33,16 @@ function setTelemetryPropertiesForId(context: IActionContext, resourceId: string
     }
 }
 
-function parsePartialAzureResourceId(id: string): Partial<ParsedAzureResourceId> & Pick<ParsedAzureResourceId, 'rawId'> {
-    const matches = id.match(/^\/subscriptions\/([^\/]*)(\/resourceGroups\/([^\/]*)(\/providers\/([^\/]*\/[^\/]*)\/([^\/]*))?)?$/i);
+function parsePartialAzureResourceId(id: string): Partial<ParsedAzureResourceId> & Pick<ParsedAzureResourceId, 'rawId'> & { subResourcePath?: string } {
+    const matches = id.match(/^\/subscriptions\/([^\/]*)(\/resourceGroups\/([^\/]*)(\/providers\/([^\/]*\/[^\/]*)\/([^\/]*)(\/(.*))?)?)?$/i);
     return {
         rawId: id,
         subscriptionId: matches?.[1],
         resourceGroup: matches?.[3],
         provider: matches?.[5],
-        resourceName: matches?.[6]
-    }
+        resourceName: matches?.[6],
+        subResourcePath: matches?.[8]
+    };
 }
 
 function getResourceKindFromId(parsedId: Partial<ParsedAzureResourceId>): 'subscription' | 'resourceGroup' | 'resource' {


### PR DESCRIPTION
This pull request adds the capability to the `revealResource` command to reveal deep resources beyond the known `ResourceGroupsItem` if the registered `BranchDataProvider` generates `TreeElementWithId` and implements `getParent()`.

As in `/subscriptions/[subscriptionId]/resourceGroups/[resourceGroup]/providers/Microsoft.DocumentDB/databaseAccounts/[accountName]/[databaseName]/[collectionName]` would no longer throw but rather `ResourceTreeDataProviderBase.findItemById` would properly find the nodes underneth the actual `/subscriptions/[subscriptionId]/resourceGroups/[resourceGroup]/providers/Microsoft.DocumentDB/databaseAccounts/[accountName]` resource and – if the custom `BranchDataProvider` properly implements `getParent()` – reveal the deep node.

Enhancements to resource ID parsing:

* [`src/commands/revealResource.ts`](diffhunk://#diff-aaa5d95043f7e29bf55520ba7850496f6b19b76396e87953d2f998baf1b0505fL36-R45): Modified the `parsePartialAzureResourceId` function to include a new `subResourcePath` property in the returned object. This change allows the function to capture additional sub-resource information from the resource ID instead of failing if the resource ID contains a sub-resource path beyond the known `ResourceGroupsItem`

This is a requirement for https://github.com/microsoft/vscode-cosmosdb/pull/2635 (specifically https://github.com/microsoft/vscode-cosmosdb/pull/2635/commits/25e0b1be9270fc7eba0ce6b18ffc26b2f8207167#diff-e658a4603f6f310947489252c2deea4645903dc5b8fcf18c7f1ccc94ab9a21f8R162)