### PR TITLE
Add revealWorkspaceResource function to expose resources in Workspaces

### DIFF
--- a/api/src/resources/resourcesApi.ts
+++ b/api/src/resources/resourcesApi.ts
@@ -62,6 +62,14 @@ export interface ResourcesApi {
     revealAzureResource(id: string, options?: VSCodeRevealOptions): Promise<void>;
 
     /**
+     * Reveal a resource in the Workspace tree view.
+     *
+     * @param id - The Workspace Resource ID to reveal in the Workspace tree view.
+     * @param options - Options for revealing the resource. See {@link vscode.TreeView.reveal}
+     */
+    revealWorkspaceResource(id: string, options?: VSCodeRevealOptions): Promise<void>;
+
+    /**
      * Gets a list of node IDs for nodes recently used/interacted with in the Azure tree view.
      *
      * @returns A promise that resolves to a list of node IDs.

--- a/src/api/createAzureResourcesHostApi.ts
+++ b/src/api/createAzureResourcesHostApi.ts
@@ -6,7 +6,7 @@
 import { callWithTelemetryAndErrorHandling } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { AzExtResourceType, AzureResource, BranchDataProvider, ResourceModelBase, VSCodeRevealOptions, WorkspaceResource, WorkspaceResourceProvider } from '../../api/src/index';
-import { revealResource } from '../commands/revealResource';
+import { revealResource, revealWorkspaceResource } from '../commands/revealResource';
 import { AzureResourceProvider, AzureResourcesHostApiInternal } from '../hostapi.v2.internal';
 import { AzureResourceBranchDataProviderManager } from '../tree/azure/AzureResourceBranchDataProviderManager';
 import { AzureResourceTreeDataProvider } from '../tree/azure/AzureResourceTreeDataProvider';
@@ -51,6 +51,15 @@ export function createAzureResourcesHostApi(
                 context.errorHandling.suppressDisplay = true;
                 context.errorHandling.suppressReportIssue = true;
                 return revealResource(context, id, options);
+            });
+        },
+
+        revealWorkspaceResource: (id: string, options?: VSCodeRevealOptions) => {
+            return callWithTelemetryAndErrorHandling('internalRevealWorkspaceResource', context => {
+                context.errorHandling.rethrow = true;
+                context.errorHandling.suppressDisplay = true;
+                context.errorHandling.suppressReportIssue = true;
+                return revealWorkspaceResource(context, id, options);
             });
         },
 

--- a/src/api/createWrappedAzureResourcesExtensionApi.ts
+++ b/src/api/createWrappedAzureResourcesExtensionApi.ts
@@ -26,6 +26,7 @@ export function createWrappedAzureResourcesExtensionApi(api: AzureResourcesApiIn
             workspaceResourceTreeDataProvider: api.resources.workspaceResourceTreeDataProvider,
             ...wrapFunctionsInTelemetry({
                 revealAzureResource: api.resources.revealAzureResource.bind(api) as typeof api.resources.revealAzureResource,
+                revealWorkspaceResource: api.resources.revealWorkspaceResource.bind(api) as typeof api.resources.revealWorkspaceResource,
             }, wrapOptions),
             ...wrapFunctionsInTelemetrySync({
                 registerAzureResourceBranchDataProvider: api.resources.registerAzureResourceBranchDataProvider.bind(api) as typeof api.resources.registerAzureResourceBranchDataProvider,

--- a/src/commands/revealResource.ts
+++ b/src/commands/revealResource.ts
@@ -23,6 +23,17 @@ export async function revealResource(context: IActionContext, resourceId: string
     }
 }
 
+export async function revealWorkspaceResource(context: IActionContext, resourceId: string, options?: VSCodeRevealOptions): Promise<void> {
+    try {
+        const item: ResourceGroupsItem | undefined = await (ext.v2.api.resources.workspaceResourceTreeDataProvider as ResourceTreeDataProviderBase).findItemById(resourceId);
+        if (item) {
+            await ext.workspaceTreeView.reveal(item as unknown as AzExtTreeItem, options ?? { expand: false, focus: true, select: true });
+        }
+    } catch (error) {
+        context.telemetry.properties.revealError = maskUserInfo(parseError(error).message, []);
+    }
+}
+
 function setTelemetryPropertiesForId(context: IActionContext, resourceId: string): void {
     const parsedAzureResourceId = parsePartialAzureResourceId(resourceId);
     const resourceKind = getResourceKindFromId(parsedAzureResourceId);


### PR DESCRIPTION
This pull request introduces a new public API feature to reveal a resource in the Workspace tree view. Similar to `revealAzureResource` this allows revealing items inside the Workspaces tree view.

Key changes include:

### New Functionality:
* [`api/src/resources/resourcesApi.ts`](diffhunk://#diff-5ec3e559ee39317faa20c32e1239f1bc34e9cce5dd7772f2d25ac42d236aed3cR64-R71): Added a new method `revealWorkspaceResource` to the `ResourcesApi` interface to reveal a resource in the Workspace tree view.
* [`src/commands/revealResource.ts`](diffhunk://#diff-aaa5d95043f7e29bf55520ba7850496f6b19b76396e87953d2f998baf1b0505fR26-R36): Implemented the `revealWorkspaceResource` function to handle the logic for revealing a resource in the Workspace tree view.

### Integration:
* [`src/api/createAzureResourcesHostApi.ts`](diffhunk://#diff-cf399355933bae8e2307f2be7d8c9a6780f8971a809769c7798e6b68289313deL9-R9): Imported the new `revealWorkspaceResource` function and added it to the `AzureResourcesHostApi` implementation. [[1]](diffhunk://#diff-cf399355933bae8e2307f2be7d8c9a6780f8971a809769c7798e6b68289313deL9-R9) [[2]](diffhunk://#diff-cf399355933bae8e2307f2be7d8c9a6780f8971a809769c7798e6b68289313deR57-R65)
* [`src/api/createWrappedAzureResourcesExtensionApi.ts`](diffhunk://#diff-00794a9fce53679b06efa59bb87670c74089dea81a53241b9f5c5924d1235ed4R29): Wrapped the new `revealWorkspaceResource` function in telemetry for the extension API.

This is a requirement for https://github.com/microsoft/vscode-cosmosdb/pull/2635 (specifically https://github.com/microsoft/vscode-cosmosdb/pull/2635/commits/a2822228a948ff9b1aff2da338760f3a32af5f4b#diff-e658a4603f6f310947489252c2deea4645903dc5b8fcf18c7f1ccc94ab9a21f8R216-R221)