### PR TITLE
Update activity log collapsible state and log total duration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@azure/ms-rest-js": "^2.7.0",
                 "@microsoft/vscode-azext-azureauth": "^4.0.3",
                 "@microsoft/vscode-azext-azureutils": "^3.1.4",
-                "@microsoft/vscode-azext-utils": "^2.6.3",
+                "@microsoft/vscode-azext-utils": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-2.6.6.tgz",
                 "buffer": "^6.0.3",
                 "form-data": "^4.0.1",
                 "jsonc-parser": "^2.2.1",
@@ -1172,9 +1172,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-utils": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.6.3.tgz",
-            "integrity": "sha512-eogbgZH1KQkGWstl9qb1Tq4DQH+JJCHLHZelIbnzIKE8JKxr8Et/byn3OuL5nL1qeITQQn3+AYVsbj2hbljM7w==",
+            "version": "2.6.6",
+            "resolved": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-2.6.6.tgz",
+            "integrity": "sha512-vjlr3AuuaTkEG027WUrAZGKN9y6a0NAPmXlz/bNIt1LlFuCDN8ERwGDnAbDwyV4zeePIjla184t+NDsFp1gA4w==",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",
@@ -11110,9 +11110,8 @@
             }
         },
         "@microsoft/vscode-azext-utils": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.6.3.tgz",
-            "integrity": "sha512-eogbgZH1KQkGWstl9qb1Tq4DQH+JJCHLHZelIbnzIKE8JKxr8Et/byn3OuL5nL1qeITQQn3+AYVsbj2hbljM7w==",
+            "version": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-2.6.6.tgz",
+            "integrity": "sha512-vjlr3AuuaTkEG027WUrAZGKN9y6a0NAPmXlz/bNIt1LlFuCDN8ERwGDnAbDwyV4zeePIjla184t+NDsFp1gA4w==",
             "requires": {
                 "@microsoft/vscode-azureresources-api": "^2.3.1",
                 "@vscode/extension-telemetry": "^0.9.6",

--- a/package.json
+++ b/package.json
@@ -915,7 +915,7 @@
         "@azure/ms-rest-js": "^2.7.0",
         "@microsoft/vscode-azext-azureauth": "^4.0.3",
         "@microsoft/vscode-azext-azureutils": "^3.1.4",
-        "@microsoft/vscode-azext-utils": "^2.6.3",
+        "@microsoft/vscode-azext-utils": "file:../vscode-azuretools/utils/microsoft-vscode-azext-utils-2.6.6.tgz",
         "buffer": "^6.0.3",
         "form-data": "^4.0.1",
         "jsonc-parser": "^2.2.1",

--- a/src/activityLog/ActivityTreeItem.ts
+++ b/src/activityLog/ActivityTreeItem.ts
@@ -53,7 +53,7 @@ export class ActivityTreeItem extends AzExtParentTreeItem implements Disposable 
         label: localize('loading', 'Loading...')
     }
 
-    public initialCollapsibleState: TreeItemCollapsibleState = TreeItemCollapsibleState.None;
+    public initialCollapsibleState: TreeItemCollapsibleState = TreeItemCollapsibleState.Expanded;
 
     public status?: ActivityStatus;
     public error?: unknown;


### PR DESCRIPTION
WIP... 
Relies on upcoming Azure Tools PRs, may be out of sync with changes proposed there, but illustrates the basic ideas.

This PR:
- Makes the initial collapsible state expanded so that progress items are now shown by default
- Shows the duration of an activity in the description of the ActivityTreeItem