### PR TITLE
Enable installing AI Foundry extension

### DIFF
--- a/src/azureExtensions.ts
+++ b/src/azureExtensions.ts
@@ -136,8 +136,7 @@ export const azureExtensions: IAzExtMetadata[] = [
         publisher: 'TeamsDevApp',
         label: 'Azure AI Foundry',
         resourceTypes: [AzExtResourceType.AiFoundry],
-        reportIssueCommandId: 'azure-ai-extension.reportIssue',
-        private: true
+        reportIssueCommandId: 'azure-ai-foundry.reportIssue'
     },
 ];
 


### PR DESCRIPTION
Since AI Foundry extension has been published, remove the private option to enable the installation.
![image](https://github.com/user-attachments/assets/c19c7ea8-70e2-4f58-9301-cbd0f7fd8e10)
