### PR TITLE
Remove Preview from stand-in chat participant name

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -44,7 +44,7 @@
     "azureResourceGroups.toggleShowAllResources": "Show/Hide Filtered Resources",
     "azureResourceGroups.showGroupOptions": "Show Grouping Options",
     "azureResourceGroups.enableChatStandIn": "Enable the @azure chat stand-in",
-    "chatParticipants.azure.fullName": "Azure (Preview)",
+    "chatParticipants.azure.fullName": "Azure",
     "azureResourceGroups.loadAllSubscriptionRoleAssignments": "Load all role assignments across subscriptions...",
     "azureResourceGroups.askAzure": {
         "message": "Ask @azure",


### PR DESCRIPTION
We forgot to update this name and found this bug.