### PR TITLE
Hook up Copilot for the activity log and expose basic commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,20 @@
                 ]
             }
         ],
+        "languageModelTools": [
+            {
+                "displayName": "Azure Resources: Get Azure Activity Log",
+                "icon": "$(azure)",
+                "inputSchema": {},
+                "modelDescription": "Gets the Azure activity log",
+                "name": "azureResources_getAzureActivityLog",
+                "canBeReferencedInPrompt": true,
+                "toolReferenceName": "azureActivityLog",
+                "tags": [
+                    "azure"
+                ]
+            }
+        ],
         "terminal": {
             "profiles": [
                 {
@@ -315,6 +329,12 @@
                 "category": "Azure"
             },
             {
+                "command": "azureResourceGroups.askAgentAboutActivityLog",
+                "title": "%azureResourceGroups.askAgentAboutActivityLog%",
+                "category": "Azure",
+                "icon": "$(sparkle)"
+            },
+            {
                 "command": "azureTenantsView.refresh",
                 "title": "%azureResourceGroups.refresh%",
                 "category": "Azure",
@@ -459,6 +479,11 @@
                     "command": "azureResourceGroups.refreshTree",
                     "when": "view == azureResourceGroups",
                     "group": "navigation@3"
+                },
+                {
+                    "command": "azureResourceGroups.askAgentAboutActivityLog",
+                    "when": "view == azureActivityLog",
+                    "group": "navigation@1"
                 },
                 {
                     "command": "azureWorkspace.refreshTree",

--- a/package.nls.json
+++ b/package.nls.json
@@ -46,7 +46,7 @@
     "azureResourceGroups.enableChatStandIn": "Enable the @azure chat stand-in",
     "chatParticipants.azure.fullName": "Azure",
     "azureResourceGroups.loadAllSubscriptionRoleAssignments": "Load all role assignments across subscriptions...",
-    "azureResourceGroups.askAgentAboutActivityLog": "Ask Copilot about the Activity Log",
+    "azureResourceGroups.askAgentAboutActivityLog": "Ask Copilot about the Azure Activity Log",
     "azureResourceGroups.askAzure": {
         "message": "Ask @azure",
         "comment": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -46,6 +46,7 @@
     "azureResourceGroups.enableChatStandIn": "Enable the @azure chat stand-in",
     "chatParticipants.azure.fullName": "Azure",
     "azureResourceGroups.loadAllSubscriptionRoleAssignments": "Load all role assignments across subscriptions...",
+    "azureResourceGroups.askAgentAboutActivityLog": "Ask Copilot about the Activity Log",
     "azureResourceGroups.askAzure": {
         "message": "Ask @azure",
         "comment": [

--- a/src/chat/askAgentAboutActivityLog.ts
+++ b/src/chat/askAgentAboutActivityLog.ts
@@ -8,6 +8,7 @@ import * as vscode from "vscode";
 const genericActivityLogPrompt: string = vscode.l10n.t('Help explain important information from my Azure activity log.');
 
 export async function askAgentAboutActivityLog(): Promise<void> {
+    await vscode.commands.executeCommand("workbench.action.chat.open");
     await vscode.commands.executeCommand("workbench.action.chat.newChat");
     await vscode.commands.executeCommand("workbench.action.chat.open", { mode: 'agent', query: genericActivityLogPrompt });
 }

--- a/src/chat/askAgentAboutActivityLog.ts
+++ b/src/chat/askAgentAboutActivityLog.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from "vscode";
+
+const genericActivityLogPrompt: string = vscode.l10n.t('Help explain important information from my Azure activity log.');
+
+export async function askAgentAboutActivityLog(): Promise<void> {
+    await vscode.commands.executeCommand("workbench.action.chat.newChat");
+    await vscode.commands.executeCommand("workbench.action.chat.open", { mode: 'agent', query: genericActivityLogPrompt });
+}

--- a/src/chat/askAgentAboutActivityLog.ts
+++ b/src/chat/askAgentAboutActivityLog.ts
@@ -8,6 +8,7 @@ import * as vscode from "vscode";
 const genericActivityLogPrompt: string = vscode.l10n.t('Help explain important information from my Azure activity log.');
 
 export async function askAgentAboutActivityLog(): Promise<void> {
+    // It appears you need to have the chat already open before you call `newChat`, otherwise it won't actually reset to a new dialogue
     await vscode.commands.executeCommand("workbench.action.chat.open");
     await vscode.commands.executeCommand("workbench.action.chat.newChat");
     await vscode.commands.executeCommand("workbench.action.chat.open", { mode: 'agent', query: genericActivityLogPrompt });

--- a/src/chat/tools/GetAzureActivityLog/GetAzureActivityLog.ts
+++ b/src/chat/tools/GetAzureActivityLog/GetAzureActivityLog.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzExtLMTool, IActionContext } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+import { convertActivityTreeToSimpleObjectArray, ConvertedActivityItem } from './convertActivityTree';
+
+export class GetAzureActivityLog implements AzExtLMTool<void> {
+    public async invoke(context: IActionContext): Promise<vscode.LanguageModelToolResult> {
+        const convertedActivityItems: ConvertedActivityItem[] = await convertActivityTreeToSimpleObjectArray(context);
+        context.telemetry.properties.activityCount = String(convertedActivityItems.length);
+        context.telemetry.properties.failedActivityCount = String(convertedActivityItems.filter(item => !!item.error).length);
+
+        if (convertedActivityItems.length === 0) {
+            return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart('No activity log items found.')]);
+        }
+
+        return new vscode.LanguageModelToolResult(convertedActivityItems.map(item => new vscode.LanguageModelTextPart(JSON.stringify(item))));
+    }
+}

--- a/src/chat/tools/GetAzureActivityLog/convertActivityTree.ts
+++ b/src/chat/tools/GetAzureActivityLog/convertActivityTree.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ActivityChildItemBase, ActivityChildType, IActionContext } from "@microsoft/vscode-azext-utils";
+import { ext } from "../../../extensionVariables";
+import { ActivityItem, ActivityStatus } from "../../../tree/activityLog/ActivityItem";
+import { TreeDataItem } from "../../../tree/ResourceGroupsItem";
+
+export type ConvertedActivityItem = {
+    label?: string;
+    description?: string;
+    status?: ActivityStatus;
+    error?: unknown;
+    children?: ConvertedActivityChildItem[];
+}
+
+type ConvertedActivityChildItem = {
+    label?: string;
+    description?: string;
+    type?: ActivityChildType;
+    children?: ConvertedActivityChildItem[];
+};
+
+export async function convertActivityTreeToSimpleObjectArray(context: IActionContext): Promise<ConvertedActivityItem[]> {
+    const treeItems: TreeDataItem[] = await ext.activityLogTree.getChildren() ?? [];
+    return Promise.all(treeItems.map(treeItem => convertItemToSimpleActivityObject(context, treeItem)));
+}
+
+async function convertItemToSimpleActivityObject(context: IActionContext, item: TreeDataItem): Promise<ConvertedActivityItem> {
+    if (!(item instanceof ActivityItem)) {
+        return {};
+    }
+
+    const convertedItem: ConvertedActivityItem = {
+        label: item.label,
+        description: item.description,
+        status: item.status,
+        error: item.error,
+    };
+
+    if (item.getChildren) {
+        const children = await item.getChildren() ?? [];
+        if (children.length > 0) {
+            convertedItem.children = await Promise.all(children.map(child => convertItemToSimpleActivityChildObject(context, child as ActivityChildItemBase)));
+        }
+    }
+
+    return convertedItem;
+}
+
+async function convertItemToSimpleActivityChildObject(context: IActionContext, item: ActivityChildItemBase): Promise<ConvertedActivityChildItem> {
+    const convertedItem: ConvertedActivityChildItem = {
+        label: item.label,
+        type: item.activityType,
+        description: item.description,
+    };
+
+    if (item.getChildren) {
+        // If there are more children, recursively convert them
+        const children = await item.getChildren() ?? [];
+        if (children.length > 0) {
+            convertedItem.children = await Promise.all(children.map(child => convertItemToSimpleActivityChildObject(context, child)));
+        }
+    }
+
+    return convertedItem;
+}

--- a/src/chat/tools/registerLMTools.ts
+++ b/src/chat/tools/registerLMTools.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { registerLMTool } from '@microsoft/vscode-azext-utils';
+import { GetAzureActivityLog } from './GetAzureActivityLog/GetAzureActivityLog';
+
+export function registerLMTools(): void {
+    // Contextual tools
+    registerLMTool('azureResources_getAzureActivityLog', new GetAzureActivityLog());
+
+    // Functional tools
+}

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -6,6 +6,7 @@
 import { signInToTenant } from '@microsoft/vscode-azext-azureauth';
 import { AzExtTreeItem, IActionContext, isAzExtTreeItem, nonNullValue, openUrl, registerCommand, registerCommandWithTreeNodeUnwrapping, registerErrorHandler, registerReportIssueCommand } from '@microsoft/vscode-azext-utils';
 import { commands } from 'vscode';
+import { askAgentAboutActivityLog } from '../chat/askAgentAboutActivityLog';
 import { askAgentAboutResource } from '../chat/askAgentAboutResource';
 import { askAzureInCommandPalette } from '../chat/askAzure';
 import { uploadFileToCloudShell } from '../cloudConsole/uploadFileToCloudShell';
@@ -129,6 +130,7 @@ export function registerCommands(): void {
         node.setAllSubscriptionsLoaded();
         ext.azureTreeState.notifyChildrenChanged(node.id);
     });
+    registerCommand("azureResourceGroups.askAgentAboutActivityLog", askAgentAboutActivityLog);
     registerCommandWithTreeNodeUnwrapping<{ id?: string }>("azureResourceGroups.askAgentAboutResource", (context, node) => askAgentAboutResource(context, node));
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { registerWorkspaceResourceProvider } from './api/compatibility/registerW
 import { createAzureResourcesHostApi } from './api/createAzureResourcesHostApi';
 import { createWrappedAzureResourcesExtensionApi } from './api/createWrappedAzureResourcesExtensionApi';
 import { registerChatStandInParticipantIfNeeded } from './chat/chatStandIn';
+import { registerLMTools } from './chat/tools/registerLMTools';
 import { createCloudConsole } from './cloudConsole/cloudConsole';
 import { registerActivity } from './commands/activities/registerActivity';
 import { registerActivityLogTree } from './commands/activities/registerActivityLogTree';
@@ -113,6 +114,7 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
         survey(context);
 
         registerChatStandInParticipantIfNeeded(context);
+        registerLMTools();
     });
 
     const extensionManager = new ResourceGroupsExtensionManager()


### PR DESCRIPTION
Keeping this first pass fairly simple.  This does not include custom command context yet.

Example of the view:
<img width="1209" alt="image" src="https://github.com/user-attachments/assets/d3d71029-2c9b-4992-b8f9-2cb80bb2b584" />

Clicking on the sparkle icon will open up the chat window with a special prompt to activate the LM tool which parses the entire raw activity log as json for use as copilot context. 

Expect a follow up PR to add more command context once this or similar gets added: https://github.com/microsoft/vscode-azuretools/pull/2005