### PR TITLE
Check to see if resolve threw an error and use that rather than the generic one

### DIFF
--- a/src/api/compatibility/application/CompatibleApplicationResourceBranchDataProvider.ts
+++ b/src/api/compatibility/application/CompatibleApplicationResourceBranchDataProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtTreeItem, createSubscriptionContext, ISubscriptionContext } from '@microsoft/vscode-azext-utils';
+import { AzExtTreeItem, createSubscriptionContext, ISubscriptionContext, parseError } from '@microsoft/vscode-azext-utils';
 import type { AppResource, AppResourceResolver } from '@microsoft/vscode-azext-utils/hostapi';
 import { l10n } from 'vscode';
 import type { AzureResource, ResourceModelBase } from '../../../../api/src/index';
@@ -26,8 +26,16 @@ export class CompatibleApplicationResourceBranchDataProvider<TResource extends A
             kind: element.azureResourceType.kinds?.join(';'),
         };
         const subscriptionContext: ISubscriptionContext = createSubscriptionContext(element.subscription);
+        let resolved = undefined;
+        try {
+            resolved = await this.resolver.resolveResource(subscriptionContext, oldAppResource);
+        } catch (error) {
+            const pError = parseError(error);
+            ext.outputChannel.appendLog(l10n.t('Error resolving "{0}": {1}', element.id, pError.message));
+            throw new Error(pError.message);
+        }
 
-        const resolved = await this.resolver.resolveResource(subscriptionContext, oldAppResource);
+        // if the resolver returns undefined without throwing an error, we treat it as a failure to resolve
         if (!resolved) {
             const noResolveError = l10n.t('Could not resolve resource "{0}"', element.id);
             ext.outputChannel.appendLog(noResolveError);


### PR DESCRIPTION
Our extensions all just swallow the error from the resolve and return undefined so Resources had just been throwing a generic error. It's super unhelpful for figuring out why the user can't load resources.

This is wrapping the resolve call in a try/catch. If it does actually throw an error, we can display that instead. If it returns undefined, then we can just fallback to the old behavior as well.