### PR TITLE
Suppress progress for `createResourceGroup` & remove unnecessary chat open call for copilot activity log

### DIFF
--- a/src/chat/askAgentAboutActivityLog.ts
+++ b/src/chat/askAgentAboutActivityLog.ts
@@ -8,8 +8,6 @@ import * as vscode from "vscode";
 const genericActivityLogPrompt: string = vscode.l10n.t('Help explain important information from my Azure activity log.');
 
 export async function askAgentAboutActivityLog(): Promise<void> {
-    // It appears you need to have the chat already open before you call `newChat`, otherwise it won't actually reset to a new dialogue
-    await vscode.commands.executeCommand("workbench.action.chat.open");
     await vscode.commands.executeCommand("workbench.action.chat.newChat");
     await vscode.commands.executeCommand("workbench.action.chat.open", { mode: 'agent', query: genericActivityLogPrompt });
 }

--- a/src/commands/createResourceGroup.ts
+++ b/src/commands/createResourceGroup.ts
@@ -22,8 +22,9 @@ export async function createResourceGroup(context: IActionContext, node?: Subscr
     const wizardContext: IResourceGroupWizardContext & ExecuteActivityContext = {
         ...context,
         ...createSubscriptionContext(subscription),
+        ...await createActivityContext(),
         suppress403Handling: true,
-        ...(await createActivityContext()),
+        suppressNotification: true,
     };
 
     const title: string = localize('createResourceGroup', 'Create Resource Group');

--- a/src/commands/createResourceGroup.ts
+++ b/src/commands/createResourceGroup.ts
@@ -24,7 +24,7 @@ export async function createResourceGroup(context: IActionContext, node?: Subscr
         ...createSubscriptionContext(subscription),
         ...await createActivityContext(),
         suppress403Handling: true,
-        suppressNotification: true,
+        suppressProgress: true,
     };
 
     const title: string = localize('createResourceGroup', 'Create Resource Group');


### PR DESCRIPTION
Closes #1182  

Suppress progress hides the progress.report messages, leaving only the live timer.

Also remove the initial open call for `askAgentAboutActivityLog`.  I thought this had fixed the issue where sometimes the chat is not refreshed, but the issue seems to still happen on occasion, so I'm removing the extra open call since it seems to have not fixed the issue.