### PR TITLE
api: Support challenges when getting sessions from VS Code

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Unreleased
 
+## [2.6.0] - 2025-08-19
+
+- Support challenges in `AzureAuthentication.getSessionWithScopes`. This relies on the proposed authenticationChallenges VS Code API.
+
 ## [2.5.1] - 2025-08-06
 
 * Add `DurableTaskHub` resource type

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [2.6.0] - 2025-08-19
 
-- Support challenges in `AzureAuthentication.getSessionWithScopes`. This relies on the proposed authenticationChallenges VS Code API.
+- Support challenges in `AzureAuthentication.getSessionWithScopes`. This relies on the proposed authenticationChallenges VS Code API. https://github.com/microsoft/vscode-azureresourcegroups/issues/1200
 
 ## [2.5.1] - 2025-08-06
 

--- a/api/docs/vscode-azureresources-api.d.ts
+++ b/api/docs/vscode-azureresources-api.d.ts
@@ -121,11 +121,12 @@ export declare interface AzureAuthentication {
     /**
      * Gets a VS Code authentication session for an Azure subscription.
      *
-     * @param scopes - The scopes for which the authentication is needed.
+     * @param scopes - The scopes for which the authentication is needed. Use AuthenticationSessionRequest for supporting challenge requests.
+     * Note: use of AuthenticationSessionRequest requires VS Code v1.104
      *
      * @returns A VS Code authentication session or undefined, if none could be obtained.
      */
-    getSessionWithScopes(scopes: string[]): vscode.ProviderResult<vscode.AuthenticationSession>;
+    getSessionWithScopes(scopes: string[] | vscode.AuthenticationSessionRequest): vscode.ProviderResult<vscode.AuthenticationSession>;
 }
 
 export declare interface AzureExtensionApi {
@@ -491,5 +492,4 @@ export declare interface Wrapper {
     unwrap<T>(): T;
 }
 
-export { };
-
+export { }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^16.0.0",
-                "@types/vscode": "^1.90.0"
+                "@types/vscode": "1.90.0"
             },
             "peerDependencies": {
                 "@azure/ms-rest-azure-env": "^2.0.0"
@@ -29,9 +29,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.103.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.103.0.tgz",
-            "integrity": "sha512-o4hanZAQdNfsKecexq9L3eHICd0AAvdbLk6hA60UzGXbGH/q8b/9xv2RgR7vV3ZcHuyKVq7b37IGd/+gM4Tu+Q==",
+            "version": "1.90.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
+            "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
             "dev": true,
             "license": "MIT"
         }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@microsoft/vscode-azureresources-api",
-    "version": "2.5.1",
+    "version": "2.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azureresources-api",
-            "version": "2.5.1",
+            "version": "2.6.0",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^16.0.0",
-                "@types/vscode": "^1.64.0"
+                "@types/vscode": "^1.90.0"
             },
             "peerDependencies": {
                 "@azure/ms-rest-azure-env": "^2.0.0"
@@ -29,10 +29,11 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.77.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
-            "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
-            "dev": true
+            "version": "1.103.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.103.0.tgz",
+            "integrity": "sha512-o4hanZAQdNfsKecexq9L3eHICd0AAvdbLk6hA60UzGXbGH/q8b/9xv2RgR7vV3ZcHuyKVq7b37IGd/+gM4Tu+Q==",
+            "dev": true,
+            "license": "MIT"
         }
     }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -18,7 +18,7 @@
     "license": "MIT",
     "devDependencies": {
         "@types/node": "^16.0.0",
-        "@types/vscode": "^1.90.0"
+        "@types/vscode": "1.90.0"
     },
     "peerDependencies": {
         "@azure/ms-rest-azure-env": "^2.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/vscode-azureresources-api",
-    "version": "2.5.1",
+    "version": "2.6.0",
     "description": "Type declarations and client library for the Azure Resources extension API",
     "repository": {
         "type": "git",
@@ -18,7 +18,7 @@
     "license": "MIT",
     "devDependencies": {
         "@types/node": "^16.0.0",
-        "@types/vscode": "^1.64.0"
+        "@types/vscode": "^1.90.0"
     },
     "peerDependencies": {
         "@azure/ms-rest-azure-env": "^2.0.0"

--- a/api/src/resources/azure.ts
+++ b/api/src/resources/azure.ts
@@ -23,6 +23,7 @@ export interface AzureAuthentication {
      * Gets a VS Code authentication session for an Azure subscription.
      *
      * @param scopes - The scopes for which the authentication is needed. Use AuthenticationSessionRequest for supporting challenge requests.
+     * Note: use of AuthenticationSessionRequest requires VS Code v1.104
      *
      * @returns A VS Code authentication session or undefined, if none could be obtained.
      */

--- a/api/src/resources/azure.ts
+++ b/api/src/resources/azure.ts
@@ -22,11 +22,11 @@ export interface AzureAuthentication {
     /**
      * Gets a VS Code authentication session for an Azure subscription.
      *
-     * @param scopes - The scopes for which the authentication is needed.
+     * @param scopes - The scopes for which the authentication is needed. Use AuthenticationSessionRequest for supporting challenge requests.
      *
      * @returns A VS Code authentication session or undefined, if none could be obtained.
      */
-    getSessionWithScopes(scopes: string[]): vscode.ProviderResult<vscode.AuthenticationSession>;
+    getSessionWithScopes(scopes: string[] | vscode.AuthenticationSessionRequest): vscode.ProviderResult<vscode.AuthenticationSession>;
 }
 
 /**

--- a/api/src/vscode.proposed.authLearnMore.d.ts
+++ b/api/src/vscode.proposed.authLearnMore.d.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+    // https://github.com/microsoft/vscode/issues/206587
+
+    export interface AuthenticationGetSessionPresentationOptions {
+        /**
+         * An optional Uri to open in the browser to learn more about this authentication request.
+         */
+        learnMore?: Uri;
+    }
+}
+
+// this proposed api is only included because vscode.proposed.authenticationChallenges.d.ts depends on it

--- a/api/src/vscode.proposed.authenticationChallenges.d.ts
+++ b/api/src/vscode.proposed.authenticationChallenges.d.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+    // https://github.com/microsoft/vscode/issues/260156
+
+    /**********
+     * "Extension asking for auth" API
+     *******/
+
+    /**
+     * Represents parameters for creating a session based on an authentication challenge.
+     * This is used when an API returns a 401 with a WWW-Authenticate header indicating
+     * that additional authentication steps or claims are required.
+     */
+    export interface AuthenticationSessionRequest {
+        /**
+         * The raw WWW-Authenticate header value that triggered this challenge.
+         * This will be parsed by the authentication provider to extract the necessary
+         * challenge information.
+         */
+        readonly challenge: string;
+
+        /**
+         * Optional scopes for the session. If not provided, the authentication provider
+         * may use default scopes or extract them from the challenge.
+         */
+        readonly scopes?: readonly string[];
+    }
+
+    export namespace authentication {
+        /**
+         * Get an authentication session matching the desired scopes. Rejects if a provider with providerId is not
+         * registered, or if the user does not consent to sharing authentication information with
+         * the extension. If there are multiple sessions with the same scopes, the user will be shown a
+         * quickpick to select which account they would like to use.
+         *
+         * Currently, there are only two authentication providers that are contributed from built in extensions
+         * to the editor that implement GitHub and Microsoft authentication: their providerId's are 'github' and 'microsoft'.
+         * @param providerId The id of the provider to use
+         * @param scopes A list of scopes representing the permissions requested. These are dependent on the authentication provider
+         * @param options The {@link AuthenticationGetSessionOptions} to use
+         * @returns A thenable that resolves to an authentication session
+         */
+        export function getSession(providerId: string, scopeListOrRequest: ReadonlyArray<string> | AuthenticationSessionRequest, options: AuthenticationGetSessionOptions & { /** */createIfNone: true | AuthenticationGetSessionPresentationOptions }): Thenable<AuthenticationSession>;
+
+        /**
+         * Get an authentication session matching the desired scopes. Rejects if a provider with providerId is not
+         * registered, or if the user does not consent to sharing authentication information with
+         * the extension. If there are multiple sessions with the same scopes, the user will be shown a
+         * quickpick to select which account they would like to use.
+         *
+         * Currently, there are only two authentication providers that are contributed from built in extensions
+         * to the editor that implement GitHub and Microsoft authentication: their providerId's are 'github' and 'microsoft'.
+         * @param providerId The id of the provider to use
+         * @param scopes A list of scopes representing the permissions requested. These are dependent on the authentication provider
+         * @param options The {@link AuthenticationGetSessionOptions} to use
+         * @returns A thenable that resolves to an authentication session
+         */
+        export function getSession(providerId: string, scopeListOrRequest: ReadonlyArray<string> | AuthenticationSessionRequest, options: AuthenticationGetSessionOptions & { /** literal-type defines return type */forceNewSession: true | AuthenticationGetSessionPresentationOptions | AuthenticationForceNewSessionOptions }): Thenable<AuthenticationSession>;
+
+        /**
+         * Get an authentication session matching the desired scopes. Rejects if a provider with providerId is not
+         * registered, or if the user does not consent to sharing authentication information with
+         * the extension. If there are multiple sessions with the same scopes, the user will be shown a
+         * quickpick to select which account they would like to use.
+         *
+         * Currently, there are only two authentication providers that are contributed from built in extensions
+         * to the editor that implement GitHub and Microsoft authentication: their providerId's are 'github' and 'microsoft'.
+         * @param providerId The id of the provider to use
+         * @param scopes A list of scopes representing the permissions requested. These are dependent on the authentication provider
+         * @param options The {@link AuthenticationGetSessionOptions} to use
+         * @returns A thenable that resolves to an authentication session if available, or undefined if there are no sessions
+         */
+        export function getSession(providerId: string, scopeListOrRequest: ReadonlyArray<string> | AuthenticationSessionRequest, options?: AuthenticationGetSessionOptions): Thenable<AuthenticationSession | undefined>;
+    }
+
+
+    /**********
+     * "Extension providing auth" API
+     * NOTE: This doesn't need to be finalized with the above
+     *******/
+
+    /**
+     * Represents an authentication challenge from a WWW-Authenticate header.
+     * This is used to handle cases where additional authentication steps are required,
+     * such as when mandatory multi-factor authentication (MFA) is enforced.
+     */
+    export interface AuthenticationChallenge {
+        /**
+         * The authentication scheme (e.g., 'Bearer').
+         */
+        readonly scheme: string;
+
+        /**
+         * Parameters for the authentication challenge.
+         * For Bearer challenges, this may include 'claims', 'scope', 'realm', etc.
+         */
+        readonly params: Record<string, string>;
+    }
+
+    /**
+     * Represents constraints for authentication, including challenges and optional scopes.
+     * This is used when creating or retrieving sessions that must satisfy specific authentication
+     * requirements from WWW-Authenticate headers.
+     */
+    export interface AuthenticationConstraint {
+        /**
+         * Array of authentication challenges parsed from WWW-Authenticate headers.
+         */
+        readonly challenges: readonly AuthenticationChallenge[];
+
+        /**
+         * Optional scopes for the session. If not provided, the authentication provider
+         * may extract scopes from the challenges or use default scopes.
+         */
+        readonly scopes?: readonly string[];
+    }
+
+    /**
+     * An authentication provider that supports challenge-based authentication.
+     * This extends the base AuthenticationProvider with methods to handle authentication
+     * challenges from WWW-Authenticate headers.
+     *
+     * TODO: Enforce that both of these functions should be defined by creating a new AuthenticationProviderWithChallenges interface.
+     * But this can be done later since this part doesn't need finalization.
+     */
+    export interface AuthenticationProvider {
+        /**
+         * Get existing sessions that match the given authentication constraints.
+         *
+         * @param constraint The authentication constraint containing challenges and optional scopes
+         * @param options Options for the session request
+         * @returns A thenable that resolves to an array of existing authentication sessions
+         */
+        getSessionsFromChallenges?(constraint: AuthenticationConstraint, options: AuthenticationProviderSessionOptions): Thenable<readonly AuthenticationSession[]>;
+
+        /**
+         * Create a new session based on authentication constraints.
+         * This is called when no existing session matches the constraint requirements.
+         *
+         * @param constraint The authentication constraint containing challenges and optional scopes
+         * @param options Options for the session creation
+         * @returns A thenable that resolves to a new authentication session
+         */
+        createSessionFromChallenges?(constraint: AuthenticationConstraint, options: AuthenticationProviderSessionOptions): Thenable<AuthenticationSession>;
+    }
+
+    export interface AuthenticationProviderOptions {
+        supportsChallenges?: boolean;
+    }
+}


### PR DESCRIPTION
This is the first change that must be released in order to work towards closing https://github.com/microsoft/vscode-azureresourcegroups/issues/1200. This release will be consumed in utils.

Challenge support is currently a proposed api available in Insiders. It will be released in the next Stable release 1.104.