### PR TITLE
api: require vscode 1.93 types

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^16.0.0",
-                "@types/vscode": "1.90.0"
+                "@types/vscode": "1.93.0"
             },
             "peerDependencies": {
                 "@azure/ms-rest-azure-env": "^2.0.0"
@@ -29,9 +29,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.90.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
-            "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
+            "version": "1.93.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.93.0.tgz",
+            "integrity": "sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==",
             "dev": true,
             "license": "MIT"
         }

--- a/api/package.json
+++ b/api/package.json
@@ -18,7 +18,7 @@
     "license": "MIT",
     "devDependencies": {
         "@types/node": "^16.0.0",
-        "@types/vscode": "1.90.0"
+        "@types/vscode": "1.93.0"
     },
     "peerDependencies": {
         "@azure/ms-rest-azure-env": "^2.0.0"


### PR DESCRIPTION
Once I pinned the version in #1205  I didn't realize that it no longer satisfied the typings. I went back and found the actual version we need to fix it which is 1.93.