### PR TITLE
Preparing for the migration of Azure Cosmos DB for MongoDB (RU and vCore) support to a new extension [Stage 1 of 2]

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Unreleased
 
+## Unreleased: [2.6.2]
+
+* Add new resource types to prepare for Azure Cosmos DB for MongoDB (RU) and (vCore) extension migration
+
 ## [2.6.1] - 2025-08-27
 
 * Adjust to changes in the authentication challenges typings in VS Code.

--- a/api/docs/vscode-azureresources-api.d.ts
+++ b/api/docs/vscode-azureresources-api.d.ts
@@ -40,6 +40,8 @@ export declare enum AzExtResourceType {
     AppServices = "AppServices",
     ArcEnabledMachines = "ArcEnabledMachines",
     AzureCosmosDb = "AzureCosmosDb",
+    AzureCosmosDbForMongoDbRu = "AzureCosmosDbForMongoDbRu",
+    AzureDocumentDb = "AzureDocumentDb",
     ContainerApps = "ContainerApps",
     ContainerAppsEnvironment = "ContainerAppsEnvironment",
     FunctionApp = "FunctionApp",
@@ -492,4 +494,4 @@ export declare interface Wrapper {
     unwrap<T>(): T;
 }
 
-export { };
+export { }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/vscode-azureresources-api",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/vscode-azureresources-api",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^16.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/vscode-azureresources-api",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "description": "Type declarations and client library for the Azure Resources extension API",
     "repository": {
         "type": "git",

--- a/api/src/AzExtResourceType.ts
+++ b/api/src/AzExtResourceType.ts
@@ -11,6 +11,8 @@ export enum AzExtResourceType {
     AppServices = 'AppServices',
     ArcEnabledMachines = 'ArcEnabledMachines',
     AzureCosmosDb = 'AzureCosmosDb',
+    AzureCosmosDbForMongoDbRu = 'AzureCosmosDbForMongoDbRu',
+    AzureDocumentDb = 'AzureDocumentDb',
     ContainerApps = 'ContainerApps',
     ContainerAppsEnvironment = 'ContainerAppsEnvironment',
     FunctionApp = 'FunctionApp',


### PR DESCRIPTION
This PR introduces two new Resource types as part of the migration of support for **Azure Cosmos DB for MongoDB (RU and vCore)** from the **Azure Databases (Azure Cosmos DB) Extension** to the **DocumentDB for VS Code Extension**.

---

## Migration Plan

The migration will be carried out in two stages:

### Stage 1 [this PR]: Introduce new Resource types to Azure Resources API**
- Enables extensions to prepare for transition  
- Allows registration of appropriate branch data providers  
- Supports releasing updated extension logic

### Stage 2 [follow-up PR]: Finalize migration
- Once database support migration is complete and released, a follow-up PR will:
  - Assign existing resources to the new Resource types  
  - Complete support transition

---

## Reference

A future PR will link back to this one for context and traceability.
