### PR TITLE
Add account name + tenant name to subscription description

### DIFF
--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -127,7 +127,7 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
                                         this.resourceGroupingManager,
                                         this.resourceProviderManager,
                                         subscription,
-                                        `(${nonNullValueAndProp(subscription.account, 'label')}/${subscription.tenantId})`);
+                                        `${nonNullValueAndProp(subscription.account, 'label')} (${subscription.tenantId})`);
                                 } else if (duplicates.includes(subscription)) {
                                     return new SubscriptionItem(
                                         {
@@ -138,7 +138,7 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
                                         this.resourceGroupingManager,
                                         this.resourceProviderManager,
                                         subscription,
-                                        `(${nonNullValueAndProp(subscription.account, 'label')})`);
+                                        `${nonNullValueAndProp(subscription.account, 'label')}`);
                                 }
                                 return new SubscriptionItem(
                                     {


### PR DESCRIPTION
Fixes #1326.

This is specifically for subs that are duplicates within the same sub but different tenants so they can be differentiated. Here is how it looks now: 
<img width="686" height="142" alt="image" src="https://github.com/user-attachments/assets/eba7b05d-98f9-4dfd-923a-a86ab05f2f43" />
not the best but hopefully shouldn't be a situation many users should be in. 