### PR TITLE
Use a UUID for extension install tree items

### DIFF
--- a/src/tree/azure/DefaultAzureResourceItem.ts
+++ b/src/tree/azure/DefaultAzureResourceItem.ts
@@ -38,7 +38,7 @@ export class DefaultAzureResourceItem implements ResourceGroupsItem {
                         commandId: 'azureResourceGroups.installExtension',
                         contextValue: 'installExtension',
                         iconPath: new vscode.ThemeIcon('extensions'),
-                        id: uuidv4(),
+                        id: `${uuidv4()}/installExtension`,
                     })
             ]);
         } else {


### PR DESCRIPTION
Closes https://github.com/microsoft/vscode-azureresourcegroups/issues/1206

Just use a UUID for the install tree items.  We already pass the resource ID to the actual install command through a command arg anyway; we just need the ID to be unique in the tree view.