### PR TITLE
Update @microsoft/vscode-azext-azureauth to 6.0.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@azure/arm-resources": "^5.2.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
-                "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.2",
+                "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.3",
                 "@microsoft/vscode-azext-azureutils": "^4.0.0",
                 "@microsoft/vscode-azext-utils": "^4.0.4",
                 "form-data": "^4.0.4",
@@ -414,8 +414,7 @@
         "node_modules/@azure/ms-rest-azure-env": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
-            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==",
-            "peer": true
+            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
         },
         "node_modules/@azure/msal-browser": {
             "version": "4.28.1",
@@ -1490,9 +1489,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureauth": {
-            "version": "6.0.0-alpha.2",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.0.0-alpha.2.tgz",
-            "integrity": "sha512-FffOh/eq83VBGfoYEpSjPI+fSO8bgfyj87Pv2B+9rGmL/KJnb3nMlTkGm7dHzXQe5LP9qNd/NqaqKWi+rfd1qw==",
+            "version": "6.0.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.0.0-alpha.3.tgz",
+            "integrity": "sha512-8q3vw8N/nrsSKHaHptBv3tKbQjpuyz64WMLX1C+nmuioossyg8PVfYRo34hxklsN7nABdYORULvpic7cn3Km7w==",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",
@@ -2151,7 +2150,6 @@
             "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -2244,7 +2242,6 @@
             "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.54.0",
                 "@typescript-eslint/types": "8.54.0",
@@ -2464,7 +2461,6 @@
             "integrity": "sha512-iYN0fDg29+a2Xelle/Y56Xvv7Nc8Thzq4VwpzAF/SIE6918rDicqfsQxV6w1ttr2+SOm+10laGuY9FG2ptEKsQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/mocha": "^10.0.10",
                 "c8": "^10.1.3",
@@ -2489,7 +2485,6 @@
             "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "http-proxy-agent": "^7.0.2",
                 "https-proxy-agent": "^7.0.5",
@@ -2507,7 +2502,6 @@
             "integrity": "sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@azure/identity": "^4.1.0",
                 "@secretlint/node": "^10.1.2",
@@ -2814,7 +2808,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3251,7 +3244,6 @@
             "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -4011,7 +4003,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -4053,7 +4044,6 @@
             "integrity": "sha512-Bk66jpevTcV8KMFzZI1P7MZKZ+uDcrZm2G2egZ2jNIvVnivDpodZI+/KnpL3Jnap0PBdIHU7HwFGB8r+vV5CVw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "chalk": "^4.1.2",
                 "chokidar": "^3.5.3",
@@ -4131,7 +4121,6 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -7640,7 +7629,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -7688,8 +7676,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD",
-            "peer": true
+            "license": "0BSD"
         },
         "node_modules/tsx": {
             "version": "4.21.0",
@@ -7779,7 +7766,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -926,7 +926,7 @@
     "dependencies": {
         "@azure/arm-resources": "^5.2.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
-        "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.2",
+        "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.3",
         "@microsoft/vscode-azext-azureutils": "^4.0.0",
         "@microsoft/vscode-azext-utils": "^4.0.4",
         "form-data": "^4.0.4",

--- a/src/tree/tenants/TenantTreeItem.ts
+++ b/src/tree/tenants/TenantTreeItem.ts
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { TenantIdDescription } from '@azure/arm-resources-subscriptions';
+import { AzureAccount } from '@microsoft/vscode-azext-azureauth';
 import { nonNullValue } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { GenericItemOptions } from "../GenericItem";
@@ -16,7 +17,7 @@ export interface TenantItemOptions extends GenericItemOptions {
 export class TenantTreeItem implements ResourceGroupsItem {
     public label: string;
     public tenantId: string;
-    constructor(public readonly tenant: TenantIdDescription, public readonly account: vscode.AuthenticationSessionAccountInformation, private readonly options?: TenantItemOptions) {
+    constructor(public readonly tenant: TenantIdDescription, public readonly account: AzureAccount, private readonly options?: TenantItemOptions) {
         this.label = nonNullValue(this.tenant.displayName);
         this.tenantId = nonNullValue(this.tenant.tenantId);
     }

--- a/test/api/MockAzureSubscriptionProvider.ts
+++ b/test/api/MockAzureSubscriptionProvider.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { AzureAccount, AzureSubscription, AzureSubscriptionProvider, AzureTenant, TenantIdAndAccount } from '@microsoft/vscode-azext-azureauth';
+import { getConfiguredAzureEnv } from '@microsoft/vscode-azext-azureauth';
 import type * as vscode from 'vscode';
 import type { MockResources } from './mockServiceFactory';
 
@@ -39,6 +40,7 @@ export class MockAzureSubscriptionProvider implements AzureSubscriptionProvider 
         return [{
             id: 'accountId',
             label: 'Mock Account',
+            environment: getConfiguredAzureEnv(),
         }];
     }
 


### PR DESCRIPTION
Updates `@microsoft/vscode-azext-azureauth` from `^6.0.0-alpha.2` to `^6.0.0-alpha.3`.

### Changes
- Updated `TenantTreeItem.account` type from `AuthenticationSessionAccountInformation` to `AzureAccount` to match the new type contract
- Updated `MockAzureSubscriptionProvider` to include the `environment` property now required on `AzureAccount`