### PR TITLE
Remove createLoadCancellationToken to fix concurrent subscription load race condition

### DIFF
--- a/src/tree/ResourceTreeDataProviderBase.ts
+++ b/src/tree/ResourceTreeDataProviderBase.ts
@@ -21,12 +21,6 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
     private readonly resourceProviderManagerListener: vscode.Disposable;
     private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<void | TreeElementBase | TreeElementBase[] | null | undefined>();
 
-    /**
-     * Cancellation token source for the current tree load operation.
-     * When a new refresh is triggered, the previous operation is cancelled.
-     */
-    private loadCancellationTokenSource: vscode.CancellationTokenSource | undefined;
-
     constructor(
         protected readonly itemCache: BranchDataItemCache,
         onDidChangeBranchTreeData: vscode.Event<void | ResourceModelBase | ResourceModelBase[] | null | undefined>,
@@ -38,8 +32,6 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
             () => {
                 callOnDispose?.();
 
-                this.loadCancellationTokenSource?.cancel();
-                this.loadCancellationTokenSource?.dispose();
                 this.branchTreeDataChangeSubscription.dispose();
                 this.refreshSubscription.dispose();
                 this.resourceProviderManagerListener.dispose();
@@ -55,20 +47,6 @@ export abstract class ResourceTreeDataProviderBase extends vscode.Disposable imp
 
     protected statusSubscription: vscode.Disposable | undefined;
     private subscriptionProvider?: AzureSubscriptionProvider;
-
-    /**
-     * Creates a new cancellation token for the current load operation.
-     * Cancels any previous pending operation before creating the new token.
-     */
-    protected createLoadCancellationToken(): vscode.CancellationToken {
-        // Cancel any previous pending operation
-        this.loadCancellationTokenSource?.cancel();
-        this.loadCancellationTokenSource?.dispose();
-
-        // Create new token source for this operation
-        this.loadCancellationTokenSource = new vscode.CancellationTokenSource();
-        return this.loadCancellationTokenSource.token;
-    }
 
     protected async getAzureSubscriptionProvider(): Promise<AzureSubscriptionProvider> {
         // override for testing

--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -77,9 +77,6 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
      * Wrapped in telemetry to measure initial load performance.
      */
     private async getRootChildren(): Promise<ResourceGroupsItem[] | null | undefined> {
-        // Create cancellation token for this load operation - cancels any pending previous load
-        const cancellationToken = this.createLoadCancellationToken();
-
         return await callWithTelemetryAndErrorHandling('azureResourceGroups.loadSubscriptions', async (context: IActionContext) => {
             context.errorHandling.suppressDisplay = true;
 
@@ -100,7 +97,7 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
 
             try {
                 await vscode.commands.executeCommand('setContext', 'azureResourceGroups.needsTenantAuth', false);
-                const subscriptions = await subscriptionProvider.getAvailableSubscriptions({ noCache: shouldClearCache, token: cancellationToken });
+                const subscriptions = await subscriptionProvider.getAvailableSubscriptions({ noCache: shouldClearCache });
                 this.sendSubscriptionTelemetryIfNeeded(); // Don't send until the above call is done, to avoid cache missing
 
                 context.telemetry.measurements.subscriptionCount = subscriptions.length;

--- a/src/tree/azure/FocusViewTreeDataProvider.ts
+++ b/src/tree/azure/FocusViewTreeDataProvider.ts
@@ -54,16 +54,13 @@ export class FocusViewTreeDataProvider extends AzureResourceTreeDataProviderBase
                 return [];
             }
 
-            // Create cancellation token for this load operation - cancels any pending previous load
-            const cancellationToken = this.createLoadCancellationToken();
-
             const provider = await this.getAzureSubscriptionProvider();
 
             // Atomically consume the clear cache flag - only the first tree to load will get true
             const shouldClearCache = ext.consumeClearCacheFlag();
 
             try {
-                const subscriptions = await provider.getAvailableSubscriptions({ noCache: shouldClearCache, token: cancellationToken });
+                const subscriptions = await provider.getAvailableSubscriptions({ noCache: shouldClearCache });
                 if (subscriptions.length === 0) {
                     return [];
                 }

--- a/src/tree/tenants/TenantResourceTreeDataProvider.ts
+++ b/src/tree/tenants/TenantResourceTreeDataProvider.ts
@@ -53,9 +53,6 @@ export class TenantResourceTreeDataProvider extends ResourceTreeDataProviderBase
      * Wrapped in telemetry to measure initial load performance.
      */
     private async getRootChildren(): Promise<ResourceGroupsItem[] | null | undefined> {
-        // Create cancellation token for this load operation - cancels any pending previous load
-        const cancellationToken = this.createLoadCancellationToken();
-
         return await callWithTelemetryAndErrorHandling('azureTenantsView.getChildren', async (context: IActionContext) => {
             context.errorHandling.suppressDisplay = true;
 
@@ -74,13 +71,13 @@ export class TenantResourceTreeDataProvider extends ResourceTreeDataProviderBase
             const shouldClearCache = ext.consumeClearCacheFlag();
 
             try {
-                const accounts = await subscriptionProvider.getAccounts({ filter: false, noCache: shouldClearCache, token: cancellationToken });
+                const accounts = await subscriptionProvider.getAccounts({ filter: false, noCache: shouldClearCache });
                 context.telemetry.properties.isSignedIn = 'true';
                 context.telemetry.properties.accountCount = accounts.length.toString();
 
                 // Process accounts in parallel for better performance with multiple accounts
                 const accountItems = await Promise.all(
-                    accounts.map(account => this.getTenantsForAccountSafe(subscriptionProvider, account, shouldClearCache, cancellationToken))
+                    accounts.map(account => this.getTenantsForAccountSafe(subscriptionProvider, account, shouldClearCache))
                 );
 
                 // Filter out undefined items (accounts that failed to load)
@@ -104,10 +101,10 @@ export class TenantResourceTreeDataProvider extends ResourceTreeDataProviderBase
      * Gets tenants for an account, handling NotSignedInError gracefully.
      * If the account can't be accessed (e.g., session expired), returns undefined to skip it.
      */
-    private async getTenantsForAccountSafe(subscriptionProvider: AzureSubscriptionProvider, account: AzureAccount, shouldClearCache: boolean, token?: vscode.CancellationToken): Promise<ResourceGroupsItem | undefined> {
+    private async getTenantsForAccountSafe(subscriptionProvider: AzureSubscriptionProvider, account: AzureAccount, shouldClearCache: boolean): Promise<ResourceGroupsItem | undefined> {
         try {
-            const allTenants = await subscriptionProvider.getTenantsForAccount(account, { filter: false, noCache: shouldClearCache, token });
-            const unauthenticatedTenants = await subscriptionProvider.getUnauthenticatedTenantsForAccount(account, { token });
+            const allTenants = await subscriptionProvider.getTenantsForAccount(account, { filter: false, noCache: shouldClearCache });
+            const unauthenticatedTenants = await subscriptionProvider.getUnauthenticatedTenantsForAccount(account);
             const unauthenticatedTenantIds = new Set(unauthenticatedTenants.map(uat => uat.tenantId));
             const tenantItems: ResourceGroupsItem[] = [];
 


### PR DESCRIPTION
Concurrent getRootChildren() calls (e.g., from revealResource + deployRevisionDraftTemplate) would cancel each other's tokens, causing CancellationError to be swallowed as an empty array, resulting in 'No subscriptions found'.

Removing the cancellation token also re-enables the auth package's promise coalescence, which safely handles concurrent subscription load calls by sharing a single promise.

Fixes microsoft/vscode-azurecontainerapps#1036 and https://github.com/microsoft/vscode-azurefunctions/issues/4921