### PR TITLE
Upgrade @microsoft/vscode-azext-azureauth to 6.0.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@azure/arm-resources": "^5.2.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
-                "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.3",
+                "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.4",
                 "@microsoft/vscode-azext-azureutils": "^4.0.0",
                 "@microsoft/vscode-azext-utils": "^4.0.4",
                 "form-data": "^4.0.4",
@@ -1466,9 +1466,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureauth": {
-            "version": "6.0.0-alpha.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.0.0-alpha.3.tgz",
-            "integrity": "sha512-8q3vw8N/nrsSKHaHptBv3tKbQjpuyz64WMLX1C+nmuioossyg8PVfYRo34hxklsN7nABdYORULvpic7cn3Km7w==",
+            "version": "6.0.0-alpha.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.0.0-alpha.4.tgz",
+            "integrity": "sha512-LntccsZs+Fdd1p47e7QoLCSCe4QdrlYVBVmXXkhoF2g6/TeNBOP0pP9rzfZ3rzBocW6Rsi2iSHXJwGhxBoTE7A==",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -926,7 +926,7 @@
     "dependencies": {
         "@azure/arm-resources": "^5.2.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
-        "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.3",
+        "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.4",
         "@microsoft/vscode-azext-azureutils": "^4.0.0",
         "@microsoft/vscode-azext-utils": "^4.0.4",
         "form-data": "^4.0.4",


### PR DESCRIPTION
Upgrades `@microsoft/vscode-azext-azureauth` from `^6.0.0-alpha.3` to `^6.0.0-alpha.4`.

Build verified — no breaking changes.