### PR TITLE
Update @microsoft/vscode-azext-azureauth to 6.0.0-alpha.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@azure/arm-resources": "^5.2.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
-                "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.4",
+                "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.5",
                 "@microsoft/vscode-azext-azureutils": "^4.0.0",
                 "@microsoft/vscode-azext-utils": "^4.0.4",
                 "form-data": "^4.0.4",
@@ -1466,9 +1466,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureauth": {
-            "version": "6.0.0-alpha.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.0.0-alpha.4.tgz",
-            "integrity": "sha512-LntccsZs+Fdd1p47e7QoLCSCe4QdrlYVBVmXXkhoF2g6/TeNBOP0pP9rzfZ3rzBocW6Rsi2iSHXJwGhxBoTE7A==",
+            "version": "6.0.0-alpha.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.0.0-alpha.5.tgz",
+            "integrity": "sha512-VZaFu5JEFhcDifMeu8zQEiE1IU05pXI2ccH6BX274WFSSaM4jFz9K6MYnJ9TDQq6btnDJrqqGfCVv3Lb0X2LpA==",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -926,7 +926,7 @@
     "dependencies": {
         "@azure/arm-resources": "^5.2.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
-        "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.4",
+        "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.5",
         "@microsoft/vscode-azext-azureutils": "^4.0.0",
         "@microsoft/vscode-azext-utils": "^4.0.4",
         "form-data": "^4.0.4",


### PR DESCRIPTION
Updates `@microsoft/vscode-azext-azureauth` from `6.0.0-alpha.4` to `6.0.0-alpha.5`.

## Bug fixes included in this upgrade

- **Skip failing tenants instead of aborting subscription listing** ([microsoft/vscode-azuretools#2208](https://github.com/microsoft/vscode-azuretools/pull/2208)) — When listing subscriptions across tenants, a failing tenant (e.g., locked account) would cause `Promise.all` to reject, skipping all remaining tenants. Now these errors are caught, logged, and the tenant is skipped so other tenants can still be listed.

- **Improve error message for `platform_broker_error`** ([microsoft/vscode-azuretools#2215](https://github.com/microsoft/vscode-azuretools/pull/2215)) — Fixes [#1393](https://github.com/microsoft/vscode-azureresourcegroups/issues/1393). Previously, when a tenant was expired or invalid, users saw a generic `platform_broker_error` message. Now the error message clearly indicates the issue.

## Other changes

- **Switch debug logs to info** ([microsoft/vscode-azuretools#2214](https://github.com/microsoft/vscode-azuretools/pull/2214)) — Auth debug logs are now logged at info level so users see them by default, making it easier to share logs for troubleshooting.