### PR TITLE
Fix subscription expansion for sovereign clouds in duplicate subscription mode

### DIFF
--- a/src/services/AzureResourcesService.ts
+++ b/src/services/AzureResourcesService.ts
@@ -21,14 +21,12 @@ export const defaultAzureResourcesServiceFactory = (): AzureResourcesService => 
     async function createClient(context: IActionContext, subscription: AzureSubscription): Promise<ResourceManagementClient> {
         // If there are duplicate subscriptions in the same account we need to directly call getSessionFromVSCode with the tenantId to ensure we get the correct session
         const duplicateSubsMode: boolean = getDuplicateSubscriptionModeSetting();
+        const subContext = createSubscriptionContext(subscription);
         if (duplicateSubsMode) {
             const session = await getSessionFromVSCode(undefined, subscription.tenantId, { createIfNone: false, silent: true, account: subscription.account });
-            const credential = createCredential(() => session);
-            return new ResourceManagementClient(credential, subscription.subscriptionId);
-        } else {
-            const subContext = createSubscriptionContext(subscription);
-            return await createResourceClient([context, subContext]);
+            subContext.credentials = createCredential(() => session);
         }
+        return await createResourceClient([context, subContext]);
     }
     return {
         async listResources(context: IActionContext, subscription: AzureSubscription): Promise<GenericResource[]> {


### PR DESCRIPTION
## Issue

Fixes #1400 — Expanding a subscription node fails with "The subscription could not be found" for Azure China accounts.

## Root Cause

When `duplicateSubscriptionMode` is enabled (a per-machine setting that gets auto-enabled when duplicate subscriptions are detected across tenants), the code in `AzureResourcesService.ts` creates a `ResourceManagementClient` directly without specifying an `endpoint`:

```ts
return new ResourceManagementClient(credential, subscription.subscriptionId);
```

Without an explicit endpoint, the client defaults to `https://management.azure.com` (the public Azure cloud). For sovereign clouds like Azure China (`https://management.chinacloudapi.cn`), the ARM request goes to the wrong cloud, and the subscription cannot be found there.

This explains the intermittent nature of the bug — different machines may have different values for the `duplicateSubscriptionMode` setting, so the same account works on some machines (setting off → uses the correct `createResourceClient` path) but fails on others (setting on → hits this bug).

The non-duplicate-subscription code path correctly uses `createAzureClient`, which passes `context.environment.resourceManagerEndpointUrl` as the endpoint.

## Fix

Pass `subscription.environment.resourceManagerEndpointUrl` as the endpoint when constructing the `ResourceManagementClient` in the duplicate subscription mode path. The `subscription.environment` already contains the correct endpoint URL for whichever cloud the subscription belongs to.