### PR TITLE
Fix tree refresh regressions (#1412, #1413)

### DIFF
--- a/src/commands/accounts/logIn.ts
+++ b/src/commands/accounts/logIn.ts
@@ -19,9 +19,10 @@ export async function logIn(_context: IActionContext, options?: SignInOptions): 
         await provider.signIn(undefined, options);
     } finally {
         _isLoggingIn = false;
-        // Clear cache to ensure fresh data is fetched after sign-in
+        // Clear cache for each tree to ensure fresh data is fetched after sign-in
         ext.setClearCacheOnNextLoad();
         ext.actions.refreshAzureTree(); // Refresh now that sign in is complete
+        ext.setClearCacheOnNextLoad();
         ext.actions.refreshTenantTree(); // Refresh now that sign in is complete
     }
 }

--- a/src/commands/accounts/selectSubscriptions.ts
+++ b/src/commands/accounts/selectSubscriptions.ts
@@ -85,12 +85,12 @@ export async function selectSubscriptions(context: IActionContext, options?: Sel
             picks.forEach(pick => previouslySelectedSubscriptionsSettingValue.add(`${pick.data.tenantId}/${pick.data.subscriptionId}`));
 
             // update the setting
-            // This triggers VSCodeAzureSubscriptionProvider.onRefreshSuggested (via
-            // onDidChangeConfiguration for selectedSubscriptions), which fires
-            // notifyTreeDataChanged on the Azure tree automatically. No need
-            // to call ext.actions.refreshAzureTree() explicitly — doing so would
-            // cause a redundant second full-tree reload.
             await setSelectedTenantAndSubscriptionIds(Array.from(previouslySelectedSubscriptionsSettingValue));
+
+            // Explicitly refresh the Azure tree with a cache clear so the view
+            // reflects the updated subscription selection immediately.
+            ext.setClearCacheOnNextLoad();
+            ext.actions.refreshAzureTree();
         }
     } catch (error) {
         if (isNotSignedInError(error)) {

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -90,6 +90,7 @@ export function registerCommands(): void {
         await (await ext.subscriptionProviderFactory()).signIn(node);
         ext.setClearCacheOnNextLoad();
         ext.actions.refreshTenantTree();
+        ext.setClearCacheOnNextLoad();
         ext.actions.refreshAzureTree();
     });
 
@@ -103,6 +104,7 @@ export function registerCommands(): void {
         await signInToTenant(await ext.subscriptionProviderFactory());
         ext.setClearCacheOnNextLoad();
         ext.actions.refreshTenantTree();
+        ext.setClearCacheOnNextLoad();
         ext.actions.refreshAzureTree();
     });
 

--- a/src/commands/sovereignCloud/configureSovereignCloud.ts
+++ b/src/commands/sovereignCloud/configureSovereignCloud.ts
@@ -30,5 +30,6 @@ export async function configureSovereignCloud(context: ConfigureSovereignCloudCo
     // This ensures accounts from the previous environment are not shown
     ext.setClearCacheOnNextLoad();
     ext.actions.refreshAzureTree();
+    ext.setClearCacheOnNextLoad();
     ext.actions.refreshTenantTree();
 }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -54,27 +54,31 @@ export namespace ext {
     export let managedIdentityBranchDataProvider: ManagedIdentityBranchDataProvider;
 
     /**
-     * Cache invalidation flag. When set to true, the next call to `consumeClearCacheFlag()`
-     * will return true and atomically reset the flag to false. This prevents race conditions
-     * where multiple trees might read and reset the flag independently.
+     * Cache invalidation counter. Each call to `setClearCacheOnNextLoad()` increments
+     * the counter by one. Each call to `consumeClearCacheFlag()` decrements it (if > 0)
+     * and returns true. This allows multiple trees to each consume a cache-clear signal
+     * independently (e.g. after sign-in, both the Azure and Tenant trees need fresh data).
      */
-    let clearCacheOnNextLoadFlag: boolean = false;
+    let clearCacheOnNextLoadCount: number = 0;
 
     /**
-     * Sets the flag to clear auth caches on the next load.
+     * Requests a cache clear on the next tree load. Call once per tree that should
+     * receive a cache-clear signal.
      */
     export function setClearCacheOnNextLoad(): void {
-        clearCacheOnNextLoadFlag = true;
+        clearCacheOnNextLoadCount++;
     }
 
     /**
-     * Atomically consumes the clear cache flag. Returns true if caches should be cleared,
-     * and resets the flag to false. This ensures only the first consumer gets `true`.
+     * Atomically consumes one cache-clear token. Returns true if caches should be
+     * cleared, and decrements the counter so other trees can still consume theirs.
      */
     export function consumeClearCacheFlag(): boolean {
-        const shouldClear = clearCacheOnNextLoadFlag;
-        clearCacheOnNextLoadFlag = false;
-        return shouldClear;
+        if (clearCacheOnNextLoadCount > 0) {
+            clearCacheOnNextLoadCount--;
+            return true;
+        }
+        return false;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -92,7 +92,7 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
 
             const subscriptionProvider = await this.getAzureSubscriptionProvider();
 
-            // Atomically consume the clear cache flag - only the first tree to load will get true
+            // Consume a cache-clear token if one is available for this tree
             const shouldClearCache = ext.consumeClearCacheFlag();
 
             try {

--- a/src/tree/azure/FocusViewTreeDataProvider.ts
+++ b/src/tree/azure/FocusViewTreeDataProvider.ts
@@ -56,7 +56,7 @@ export class FocusViewTreeDataProvider extends AzureResourceTreeDataProviderBase
 
             const provider = await this.getAzureSubscriptionProvider();
 
-            // Atomically consume the clear cache flag - only the first tree to load will get true
+            // Consume a cache-clear token if one is available for this tree
             const shouldClearCache = ext.consumeClearCacheFlag();
 
             try {

--- a/src/tree/tenants/TenantResourceTreeDataProvider.ts
+++ b/src/tree/tenants/TenantResourceTreeDataProvider.ts
@@ -93,7 +93,7 @@ export class TenantResourceTreeDataProvider extends ResourceTreeDataProviderBase
 
             const subscriptionProvider = await this.getAzureSubscriptionProvider();
 
-            // Atomically consume the clear cache flag - only the first tree to load will get true
+            // Consume a cache-clear token if one is available for this tree
             const shouldClearCache = ext.consumeClearCacheFlag();
 
             try {


### PR DESCRIPTION
## Bug Fixes

### #1412 — Re-selecting subscription does not trigger Azure Resources view refresh
PR #1383 removed the explicit `ext.actions.refreshAzureTree()` from `selectSubscriptions.ts`, assuming the config-change event was sufficient. However, the config-change path doesn't clear the subscription cache, so re-selecting a subscription rendered stale data.

**Fix:** Restore explicit `setClearCacheOnNextLoad()` + `refreshAzureTree()` after updating the subscription selection setting.

### #1413 — Accounts & Tenants view does not auto-refresh after adding a second account
The cache-clear mechanism was a one-shot boolean — only the first tree to call `consumeClearCacheFlag()` received `true`. Since `logIn()` refreshed Azure Resources before Accounts & Tenants, the Azure tree always consumed the flag, leaving the tenant tree to load from stale cached data (missing the new account).

**Fix:** Convert the one-shot boolean to a **counter**. Each `setClearCacheOnNextLoad()` increments the counter; each `consumeClearCacheFlag()` decrements it and returns `true`. Callers now invoke `setClearCacheOnNextLoad()` once per tree that needs fresh data.

### Additional fixes (same pattern)
- `signInToTenant` commands in `registerCommands.ts` (2 places)
- `configureSovereignCloud` command

### Root cause
Both regressions were introduced by PR #1383 ("Performance improvements", commit b76bfd8, Mar 9).

Fixes #1412
Fixes #1413