### PR TITLE
Add per-tree cache invalidation to fix #1413

### DIFF
--- a/src/commands/accounts/logIn.ts
+++ b/src/commands/accounts/logIn.ts
@@ -20,9 +20,12 @@ export async function logIn(_context: IActionContext, options?: SignInOptions): 
     } finally {
         _isLoggingIn = false;
         // Clear cache to ensure fresh data is fetched after sign-in
-        ext.setClearCacheOnNextLoad();
+        ext.setClearCacheOnNextLoad('azure');
         ext.actions.refreshAzureTree(); // Refresh now that sign in is complete
+        ext.setClearCacheOnNextLoad('tenant');
         ext.actions.refreshTenantTree(); // Refresh now that sign in is complete
+        ext.setClearCacheOnNextLoad('focus');
+        ext.actions.refreshFocusTree(); // Refresh Focus view with fresh subscriptions
     }
 }
 

--- a/src/commands/accounts/selectSubscriptions.ts
+++ b/src/commands/accounts/selectSubscriptions.ts
@@ -84,12 +84,12 @@ export async function selectSubscriptions(context: IActionContext, options?: Sel
             // add any that were selected in the picker
             picks.forEach(pick => previouslySelectedSubscriptionsSettingValue.add(`${pick.data.tenantId}/${pick.data.subscriptionId}`));
 
+            // Set the cache-clear flag before updating the setting so that
+            // the provider-triggered refresh (via onDidChangeConfiguration)
+            // already sees noCache: true.
+            ext.setClearCacheOnNextLoad('azure');
+
             // update the setting
-            // This triggers VSCodeAzureSubscriptionProvider.onRefreshSuggested (via
-            // onDidChangeConfiguration for selectedSubscriptions), which fires
-            // notifyTreeDataChanged on the Azure tree automatically. No need
-            // to call ext.actions.refreshAzureTree() explicitly — doing so would
-            // cause a redundant second full-tree reload.
             await setSelectedTenantAndSubscriptionIds(Array.from(previouslySelectedSubscriptionsSettingValue));
         }
     } catch (error) {

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -42,16 +42,16 @@ export function registerCommands(): void {
 
     // Special-case refresh that ignores the selected/focused node and always refreshes the entire tree. Used by the refresh button in the tree title.
     registerCommand('azureResourceGroups.refreshTree', () => {
-        ext.setClearCacheOnNextLoad();
+        ext.setClearCacheOnNextLoad('azure');
         ext.actions.refreshAzureTree();
     });
     registerCommand('azureWorkspace.refreshTree', () => ext.actions.refreshWorkspaceTree());
     registerCommand('azureFocusView.refreshTree', () => {
-        ext.setClearCacheOnNextLoad();
+        ext.setClearCacheOnNextLoad('focus');
         ext.actions.refreshFocusTree();
     });
     registerCommand('azureTenantsView.refreshTree', () => {
-        ext.setClearCacheOnNextLoad();
+        ext.setClearCacheOnNextLoad('tenant');
         ext.actions.refreshTenantTree();
     });
 
@@ -88,9 +88,12 @@ export function registerCommands(): void {
 
     registerCommand('azureTenantsView.signInToTenant', async (_context, node: TenantTreeItem) => {
         await (await ext.subscriptionProviderFactory()).signIn(node);
-        ext.setClearCacheOnNextLoad();
+        ext.setClearCacheOnNextLoad('tenant');
         ext.actions.refreshTenantTree();
+        ext.setClearCacheOnNextLoad('azure');
         ext.actions.refreshAzureTree();
+        ext.setClearCacheOnNextLoad('focus');
+        ext.actions.refreshFocusTree();
     });
 
     registerCommand('azureResourceGroups.focusGroup', focusGroup);
@@ -101,9 +104,12 @@ export function registerCommands(): void {
     registerCommand('azureResourceGroups.selectSubscriptions', (context: IActionContext, options: SelectSubscriptionOptions) => selectSubscriptions(context, options));
     registerCommand('azureResourceGroups.signInToTenant', async () => {
         await signInToTenant(await ext.subscriptionProviderFactory());
-        ext.setClearCacheOnNextLoad();
+        ext.setClearCacheOnNextLoad('tenant');
         ext.actions.refreshTenantTree();
+        ext.setClearCacheOnNextLoad('azure');
         ext.actions.refreshAzureTree();
+        ext.setClearCacheOnNextLoad('focus');
+        ext.actions.refreshFocusTree();
     });
 
     registerCommand('azureResourceGroups.createResourceGroup', createResourceGroup);

--- a/src/commands/sovereignCloud/configureSovereignCloud.ts
+++ b/src/commands/sovereignCloud/configureSovereignCloud.ts
@@ -28,7 +28,10 @@ export async function configureSovereignCloud(context: ConfigureSovereignCloudCo
 
     // Clear cache and refresh views to reflect the selected sovereign cloud
     // This ensures accounts from the previous environment are not shown
-    ext.setClearCacheOnNextLoad();
+    ext.setClearCacheOnNextLoad('azure');
     ext.actions.refreshAzureTree();
+    ext.setClearCacheOnNextLoad('tenant');
     ext.actions.refreshTenantTree();
+    ext.setClearCacheOnNextLoad('focus');
+    ext.actions.refreshFocusTree();
 }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -53,27 +53,32 @@ export namespace ext {
     export let subscriptionProviderFactory: () => Promise<AzureSubscriptionProvider>;
     export let managedIdentityBranchDataProvider: ManagedIdentityBranchDataProvider;
 
-    /**
-     * Cache invalidation flag. When set to true, the next call to `consumeClearCacheFlag()`
-     * will return true and atomically reset the flag to false. This prevents race conditions
-     * where multiple trees might read and reset the flag independently.
-     */
-    let clearCacheOnNextLoadFlag: boolean = false;
+    export type TreeViewId = 'azure' | 'tenant' | 'focus';
 
     /**
-     * Sets the flag to clear auth caches on the next load.
+     * Per-tree cache invalidation flags. Each tree view has its own flag so that
+     * clearing the cache for one tree doesn't affect (or get consumed by) another.
      */
-    export function setClearCacheOnNextLoad(): void {
-        clearCacheOnNextLoadFlag = true;
+    const clearCacheFlags: Record<TreeViewId, boolean> = {
+        azure: false,
+        tenant: false,
+        focus: false,
+    };
+
+    /**
+     * Marks the given tree's cache as needing a clear on its next load.
+     */
+    export function setClearCacheOnNextLoad(tree: TreeViewId): void {
+        clearCacheFlags[tree] = true;
     }
 
     /**
-     * Atomically consumes the clear cache flag. Returns true if caches should be cleared,
-     * and resets the flag to false. This ensures only the first consumer gets `true`.
+     * Atomically consumes the cache-clear flag for the given tree.
+     * Returns true if the tree should clear its caches, then resets the flag.
      */
-    export function consumeClearCacheFlag(): boolean {
-        const shouldClear = clearCacheOnNextLoadFlag;
-        clearCacheOnNextLoadFlag = false;
+    export function consumeClearCacheFlag(tree: TreeViewId): boolean {
+        const shouldClear = clearCacheFlags[tree];
+        clearCacheFlags[tree] = false;
         return shouldClear;
     }
 

--- a/src/tree/azure/AzureResourceTreeDataProvider.ts
+++ b/src/tree/azure/AzureResourceTreeDataProvider.ts
@@ -92,8 +92,7 @@ export class AzureResourceTreeDataProvider extends AzureResourceTreeDataProvider
 
             const subscriptionProvider = await this.getAzureSubscriptionProvider();
 
-            // Atomically consume the clear cache flag - only the first tree to load will get true
-            const shouldClearCache = ext.consumeClearCacheFlag();
+            const shouldClearCache = ext.consumeClearCacheFlag('azure');
 
             try {
                 await vscode.commands.executeCommand('setContext', 'azureResourceGroups.needsTenantAuth', false);

--- a/src/tree/azure/FocusViewTreeDataProvider.ts
+++ b/src/tree/azure/FocusViewTreeDataProvider.ts
@@ -56,8 +56,7 @@ export class FocusViewTreeDataProvider extends AzureResourceTreeDataProviderBase
 
             const provider = await this.getAzureSubscriptionProvider();
 
-            // Atomically consume the clear cache flag - only the first tree to load will get true
-            const shouldClearCache = ext.consumeClearCacheFlag();
+            const shouldClearCache = ext.consumeClearCacheFlag('focus');
 
             try {
                 const subscriptions = await provider.getAvailableSubscriptions({ noCache: shouldClearCache });

--- a/src/tree/tenants/TenantResourceTreeDataProvider.ts
+++ b/src/tree/tenants/TenantResourceTreeDataProvider.ts
@@ -54,10 +54,9 @@ export class TenantResourceTreeDataProvider extends ResourceTreeDataProviderBase
         if (this.statusSubscription && !this._filteredStatusSubscription) {
             this.statusSubscription.dispose();
             this._filteredStatusSubscription = provider.onRefreshSuggested((evt: RefreshSuggestedEvent) => {
-                if (evt.reason === 'sessionChange') {
+                if (evt.reason !== 'subscriptionFilterChange') {
                     this.notifyTreeDataChanged();
                 }
-                // Ignore 'subscriptionFilterChange' — tenant list is unaffected.
             });
             this.statusSubscription = this._filteredStatusSubscription;
         }
@@ -93,8 +92,7 @@ export class TenantResourceTreeDataProvider extends ResourceTreeDataProviderBase
 
             const subscriptionProvider = await this.getAzureSubscriptionProvider();
 
-            // Atomically consume the clear cache flag - only the first tree to load will get true
-            const shouldClearCache = ext.consumeClearCacheFlag();
+            const shouldClearCache = ext.consumeClearCacheFlag('tenant');
 
             try {
                 const accounts = await subscriptionProvider.getAccounts({ filter: false, noCache: shouldClearCache });


### PR DESCRIPTION
## Bug Fix

### #1413 — Accounts & Tenants view does not auto-refresh after adding a second account
The cache-clear mechanism was a shared one-shot boolean. Whichever tree called `consumeClearCacheFlag()` first got `noCache: true`; subsequent trees got `false` and loaded from stale cache (missing the newly added account).

### Fix
Replace the shared boolean with **per-tree flags** (`azure | tenant | focus`). Each tree has its own independent flag via a `TreeViewId`-keyed record, so:
- Trees can't consume each other's cache-clear signals
- A collapsed tree won't leave a stale flag for another tree to accidentally consume later

### Additional improvements
- **selectSubscriptions**: Set cache-clear flag *before* updating the setting, so the provider-triggered refresh (via `onDidChangeConfiguration`) already sees `noCache: true` — avoids a redundant second refresh
- **Tenant tree**: Refresh on any `onRefreshSuggested` reason except `subscriptionFilterChange`, making it forward-compatible with new reasons (e.g. `cloudChange` from microsoft/vscode-azuretools#2248)

### Root cause
Regression introduced by PR #1383 ("Performance improvements", commit b76bfd8).

Fixes #1413