### PR TITLE
Upgrade @microsoft/vscode-azext-azureauth to 6.0.0-alpha.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@azure/arm-resources": "^5.2.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
-                "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.5",
+                "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.8",
                 "@microsoft/vscode-azext-azureutils": "^4.0.0",
                 "@microsoft/vscode-azext-utils": "^4.0.4",
                 "form-data": "^4.0.4",
@@ -1466,12 +1466,13 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureauth": {
-            "version": "6.0.0-alpha.5",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.0.0-alpha.5.tgz",
-            "integrity": "sha512-VZaFu5JEFhcDifMeu8zQEiE1IU05pXI2ccH6BX274WFSSaM4jFz9K6MYnJ9TDQq6btnDJrqqGfCVv3Lb0X2LpA==",
+            "version": "6.0.0-alpha.8",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.0.0-alpha.8.tgz",
+            "integrity": "sha512-oOZpeTe4tOupKzQpeKxyHOSG10Bxsyp8YhCeyadQMsz1wICR/JZEdSMKPR0GnXpXYlYSsEDFbSzJWqZUZ/3+Yw==",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-resources-subscriptions": "^2.1.0",
+                "@azure/core-rest-pipeline": "^1.22.2",
                 "@azure/identity": "^4.13.0",
                 "@azure/ms-rest-azure-env": "^2.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -926,7 +926,7 @@
     "dependencies": {
         "@azure/arm-resources": "^5.2.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
-        "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.5",
+        "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.8",
         "@microsoft/vscode-azext-azureutils": "^4.0.0",
         "@microsoft/vscode-azext-utils": "^4.0.4",
         "form-data": "^4.0.4",


### PR DESCRIPTION
Updates `@microsoft/vscode-azext-azureauth` from `6.0.0-alpha.5` to `6.0.0-alpha.8`.

## Bug fixes included in this upgrade

- **Fix subscription filter change events suppressed during debounce** ([vscode-azuretools#2245](https://github.com/microsoft/vscode-azuretools/pull/2245)) — `subscriptionFilterChange` events could be silently dropped when they occurred during the debounce window, causing the Azure tree to not refresh after changing subscription filters. Fixes #1412.

- **Add BearerChallengePolicy for MFA step-up during subscription listing** ([vscode-azuretools#2231](https://github.com/microsoft/vscode-azuretools/pull/2231)) — When users hit an MFA step-up challenge (401 with `WWW-Authenticate` header) during tenant/subscription listing, the request would simply fail. The auth package now includes a `BearerChallengePolicy` on the subscription client pipeline to handle these challenges.

## Other changes

- **Reduce auth event debounce from 5s to 2s** ([vscode-azuretools#2246](https://github.com/microsoft/vscode-azuretools/pull/2246)) — Reduces the `onRefreshSuggested` debounce interval from 5 seconds to 2 seconds for faster tree refresh after auth state changes.

- **Watch sovereign cloud config and fire onRefreshSuggested** ([vscode-azuretools#2248](https://github.com/microsoft/vscode-azuretools/pull/2248)) — The auth provider now watches the `microsoft-sovereign-cloud` config section for changes. When the cloud environment is switched, it clears all cached auth data and fires `onRefreshSuggested` with a new `cloudChange` reason, so trees refresh automatically without manual cache clearing.