### PR TITLE
Fix Sign In command not showing consent dialog when already signed in

### DIFF
--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -99,7 +99,7 @@ export function registerCommands(): void {
     registerCommand('azureResourceGroups.focusGroup', focusGroup);
     registerCommand('azureResourceGroups.unfocusGroup', unfocusGroup);
 
-    registerCommand('azureResourceGroups.logIn', (context: IActionContext) => logIn(context));
+    registerCommand('azureResourceGroups.logIn', (context: IActionContext) => logIn(context, { clearSessionPreference: true }));
     registerCommand('azureTenantsView.addAccount', (context: IActionContext) => logIn(context, { clearSessionPreference: true }));
     registerCommand('azureResourceGroups.selectSubscriptions', (context: IActionContext, options: SelectSubscriptionOptions) => selectSubscriptions(context, options));
     registerCommand('azureResourceGroups.signInToTenant', async () => {


### PR DESCRIPTION
## Problem
When a user is already signed in and runs **Azure: Sign In** (F1 → `Azure: Sign In`), no consent dialog appears. The views refresh silently with no feedback.

## Root Cause
The `azureResourceGroups.logIn` command called `logIn(context)` without `clearSessionPreference: true`, allowing VS Code to silently reuse the existing session instead of showing the account picker.

## Fix
Pass `{ clearSessionPreference: true }` to match the behavior of the **Add Account** command, which already works correctly.

Fixes #1414