### PR TITLE
Upgrade @microsoft/vscode-azext-azureutils to ^4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@azure/arm-resources": "^5.2.0",
                 "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
                 "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.8",
-                "@microsoft/vscode-azext-azureutils": "^4.0.0",
+                "@microsoft/vscode-azext-azureutils": "^4.1.0",
                 "@microsoft/vscode-azext-utils": "^4.0.4",
                 "form-data": "^4.0.4",
                 "fs-extra": "^11.3.0",
@@ -103,18 +103,19 @@
             }
         },
         "node_modules/@azure/arm-msi": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-msi/-/arm-msi-2.1.0.tgz",
-            "integrity": "sha512-qP2BXpXkZ/I5gO479Dj6HFVkgSrAlYOG2AGVTqxTu0YIVdZdmrlZLH7SNl1Um9id+p7uNGNRdVKIBO5rcQgeJw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-msi/-/arm-msi-2.2.0.tgz",
+            "integrity": "sha512-Wqg9j9qR+k1IxZXwKtegZWj6k1d6UUGOz4uHPmhyJOeiQrtZHXBcaWSZhtqJo5sy888TD6jVIQV/4znhbKYL9g==",
+            "license": "MIT",
             "dependencies": {
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.6.1",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-client": "^1.9.2",
+                "@azure/core-paging": "^1.6.2",
+                "@azure/core-rest-pipeline": "^1.19.0",
+                "tslib": "^2.8.1"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/arm-resources": {
@@ -167,45 +168,51 @@
             }
         },
         "node_modules/@azure/arm-storage": {
-            "version": "18.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-18.3.0.tgz",
-            "integrity": "sha512-iba1BroEL/PY1ZZg8SiqFkjB/NsXbgBCOIkOzp9pfWrukyuh96IDZCbRL+ASN2lWkXrZgbg9uuZ4zlX28xMYTQ==",
+            "version": "18.6.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-18.6.0.tgz",
+            "integrity": "sha512-dyN50fxts2xClCLIQY8qoDepYx2ql/eW5cVOy8XP+5zt9wIr1cgN2Mmv9/so2HDg6M/zOz8LhrvY+bS2blbhDQ==",
+            "license": "MIT",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.6.0",
-                "@azure/core-client": "^1.7.0",
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-client": "^1.9.3",
                 "@azure/core-lro": "^2.5.4",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.14.0",
-                "tslib": "^2.2.0"
+                "@azure/core-paging": "^1.6.2",
+                "@azure/core-rest-pipeline": "^1.19.1",
+                "tslib": "^2.8.1"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/arm-storage-profile-2020-09-01-hybrid": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage-profile-2020-09-01-hybrid/-/arm-storage-profile-2020-09-01-hybrid-2.0.0.tgz",
-            "integrity": "sha512-qBO9jHugUY7U3dDjokFJ6v3mQdQlFZeY2OHuihHy5Q8d0Fkdv4kO+6nbKXevcOVWlGS1E4Kd1Ah+yqv9YItGWA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-storage-profile-2020-09-01-hybrid/-/arm-storage-profile-2020-09-01-hybrid-2.1.0.tgz",
+            "integrity": "sha512-XZYoBWQP9BkQPde5DA7xIiOJVE+6Eeo755VfRqymN42gRn/X6GOcZ0X5x0qvLVxXZcwpFRKblRpkmxGi0FpIxg==",
+            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.0.0",
+                "@azure/core-client": "^1.6.1",
                 "@azure/core-lro": "^2.2.0",
                 "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.1.0",
+                "@azure/core-rest-pipeline": "^1.8.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
-        "node_modules/@azure/core-asynciterator-polyfill": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.2.tgz",
-            "integrity": "sha512-3rkP4LnnlWawl0LZptJOdXNrT/fHp2eQMadoasa6afspXdpGrtPZuAQc2PD0cpgyuoXtUWyC3tv7xfntjGS5Dw==",
+        "node_modules/@azure/arm-storage/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/core-auth": {
@@ -234,20 +241,21 @@
             }
         },
         "node_modules/@azure/core-client": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.2.tgz",
-            "integrity": "sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+            "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+            "license": "MIT",
             "dependencies": {
-                "@azure/abort-controller": "^2.0.0",
-                "@azure/core-auth": "^1.4.0",
-                "@azure/core-rest-pipeline": "^1.9.1",
-                "@azure/core-tracing": "^1.0.0",
-                "@azure/core-util": "^1.6.1",
-                "@azure/logger": "^1.0.0",
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.10.0",
+                "@azure/core-rest-pipeline": "^1.22.0",
+                "@azure/core-tracing": "^1.3.0",
+                "@azure/core-util": "^1.13.0",
+                "@azure/logger": "^1.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/core-client/node_modules/@azure/abort-controller": {
@@ -287,15 +295,15 @@
             }
         },
         "node_modules/@azure/core-paging": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.2.1.tgz",
-            "integrity": "sha512-UtH5iMlYsvg+nQYIl4UHlvvSrsBjOlRF4fs0j7mxd3rWdAStrKYrh2durOpHs5C9yZbVhsVDaisoyaf/lL1EVA==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+            "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+            "license": "MIT",
             "dependencies": {
-                "@azure/core-asynciterator-polyfill": "^1.0.0",
-                "tslib": "^2.2.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/core-rest-pipeline": {
@@ -1481,25 +1489,26 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureutils": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-4.0.0.tgz",
-            "integrity": "sha512-RXeHsEi9d4ZUhHIbrlI3532TSaL5CRITlOxveR+hWd32RJv25+Rj0lML2A9L3IM0BIdbekbCWMj831Uv0UAxdA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-4.1.0.tgz",
+            "integrity": "sha512-13zJ9VY+BPf7TmcPrqpMLVLE8gtwtN3uJcWOWebgdsNU9RCwxnDDHtdH42CUMEnJ/dc7S8xhP8gmOh+83Pswhg==",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",
                 "@azure/arm-authorization-profile-2020-09-01-hybrid": "^2.1.0",
-                "@azure/arm-msi": "^2.1.0",
+                "@azure/arm-msi": "^2.2.0",
                 "@azure/arm-resources": "^5.0.0",
-                "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
-                "@azure/arm-resources-subscriptions": "^2.0.0",
-                "@azure/arm-storage": "^18.2.0",
-                "@azure/arm-storage-profile-2020-09-01-hybrid": "^2.0.0",
-                "@azure/core-client": "^1.6.0",
-                "@azure/core-rest-pipeline": "^1.9.0",
-                "@azure/logger": "^1.0.4",
-                "@microsoft/vscode-azext-utils": "^4.0.0",
-                "@microsoft/vscode-azureresources-api": "^3.0.0",
-                "semver": "^7.3.7"
+                "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
+                "@azure/arm-resources-subscriptions": "^2.1.0",
+                "@azure/arm-storage": "^18.6.0",
+                "@azure/arm-storage-profile-2020-09-01-hybrid": "^2.1.0",
+                "@azure/core-client": "^1.10.1",
+                "@azure/core-rest-pipeline": "^1.22.2",
+                "@azure/logger": "^1.3.0",
+                "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.6",
+                "@microsoft/vscode-azext-utils": "^4.0.4",
+                "@microsoft/vscode-azureresources-api": "^3.1.0",
+                "semver": "^7.7.4"
             },
             "engines": {
                 "vscode": "^1.105.0"
@@ -1573,9 +1582,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azureresources-api": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.0.0.tgz",
-            "integrity": "sha512-IfivhAfLjUQtIJa3kqfZPJanb9m3XVBgRmYrFQtnRp6GWeKGKhkyMC44MunodtX0k4C7A1LmG3lM4z38sxCcpQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.0.tgz",
+            "integrity": "sha512-jcx5VdDiOftjkjQ+ZXuGQ7xpy7WSKnB7oRLdmGuW3ykaB/PrBSHwStkItSg8l8ycJ0t1kaPOz3eDJP0Ol309jg==",
             "license": "MIT",
             "engines": {
                 "vscode": "^1.105.0"
@@ -6908,9 +6917,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -927,7 +927,7 @@
         "@azure/arm-resources": "^5.2.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
         "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.8",
-        "@microsoft/vscode-azext-azureutils": "^4.0.0",
+        "@microsoft/vscode-azext-azureutils": "^4.1.0",
         "@microsoft/vscode-azext-utils": "^4.0.4",
         "form-data": "^4.0.4",
         "fs-extra": "^11.3.0",


### PR DESCRIPTION
Updates `@microsoft/vscode-azext-azureutils` from `^4.0.0` to `^4.1.0`.

## Bug fixes included in this upgrade

- **Fallback to default name when resource group name is unavailable** ([vscode-azuretools#2219](https://github.com/microsoft/vscode-azuretools/pull/2219)) — Previously, if a resource group name was not available, an error could occur. Now falls back to a default name gracefully.

## Other changes

- **Add in-memory cache for Azure location/provider API calls** ([vscode-azuretools#2239](https://github.com/microsoft/vscode-azuretools/pull/2239)) — Improves performance by caching location and provider responses, reducing redundant API calls.
- **Use BearerChallengePolicy from auth package** ([vscode-azuretools#2232](https://github.com/microsoft/vscode-azuretools/pull/2232)) — Removes a local duplicate of BearerChallengePolicy in favor of the shared implementation from the auth package.
- **npm audit fix** ([vscode-azuretools#2212](https://github.com/microsoft/vscode-azuretools/pull/2212)) — Addresses security vulnerabilities in transitive dependencies.
- **Remove dev package dependency, use new utils** ([vscode-azuretools#2109](https://github.com/microsoft/vscode-azuretools/pull/2109)) — Internal refactor to remove the deprecated dev package and use the new utils package.