### PR TITLE
Update 0.12.4 changelog date to 2026-03-30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.12.4 - 2026-03-25
+## 0.12.4 - 2026-03-30
 
 ### Fixed
 * [[1406]](https://github.com/microsoft/vscode-azureresourcegroups/pull/1406) Filter unselected tenants before hitting maximumTenants limit


### PR DESCRIPTION
Updates the release date for v0.12.4 in CHANGELOG.md from 2026-03-25 to 2026-03-30.