### PR TITLE
Allow override of resource type node properties (i.e. name and icon).

### DIFF
--- a/src/tree/azure/grouping/AzureResourceGroupingManager.ts
+++ b/src/tree/azure/grouping/AzureResourceGroupingManager.ts
@@ -11,6 +11,7 @@ import { GroupBySettings } from '../../../commands/explorer/groupBy';
 import { showHiddenTypesSettingKey } from '../../../constants';
 import { ext } from '../../../extensionVariables';
 import { getIconPath, getName } from '../../../utils/azureUtils';
+import { getResourceTypeOverride } from '../../../utils/getResourceTypeOverrides';
 import { localize } from "../../../utils/localize";
 import { settingUtils } from '../../../utils/settingUtils';
 import { treeUtils } from '../../../utils/treeUtils';
@@ -130,13 +131,18 @@ export class AzureResourceGroupingManager extends vscode.Disposable {
             allResources,
             keySelector: resource => resource.resourceType ?? unknownLabel, // TODO: Is resource type ever undefined?
             initialGrouping,
-            groupingItemFactory: (resourceType, resources) => this.groupingItemFactory.createResourceTypeGroupingItem(resourceType as AzExtResourceType, {
-                resources,
-                context,
-                parent,
-                label: getName(resourceType as AzExtResourceType) ?? resourceType,
-                iconPath: getIconPath(resourceType as AzExtResourceType),
-            })
+            groupingItemFactory: (resourceType, resources) => {
+                const override = getResourceTypeOverride(resourceType);
+                return this.groupingItemFactory.createResourceTypeGroupingItem(resourceType as AzExtResourceType, {
+                    resources,
+                    context,
+                    parent,
+                    label: override?.label ?? getName(resourceType as AzExtResourceType) ?? resourceType,
+                    iconPath: override?.iconPath ?? getIconPath(resourceType as AzExtResourceType),
+                    // Keep `id` stable even if the label is overridden by a contribution.
+                    idKey: resourceType,
+                });
+            }
         });
     }
 

--- a/src/tree/azure/grouping/GroupingItem.ts
+++ b/src/tree/azure/grouping/GroupingItem.ts
@@ -58,11 +58,14 @@ export class GroupingItem implements ResourceGroupsItem {
             ...this.context.subscription,
         } : undefined;
 
+        // The id stays stable even if the label is overridden by a contribution,
+        // so VS Code's tree expansion/focus state is preserved.
+        const idKey = options.idKey ?? options.label;
         if (this.context?.subscription) {
-            this.id = `${getAccountAndTenantPrefix(this.context?.subscription)}/subscriptions/${this.context?.subscriptionContext.subscriptionId}/groupings/${this.label}`;
+            this.id = `${getAccountAndTenantPrefix(this.context?.subscription)}/subscriptions/${this.context?.subscriptionContext.subscriptionId}/groupings/${idKey}`;
         } else {
             // favorites groups don't always have a subscription
-            this.id = `/groupings/${this.label}`;
+            this.id = `/groupings/${idKey}`;
         }
     }
 
@@ -171,14 +174,20 @@ export interface GroupingItemOptions {
     iconPath?: TreeItemIconPath,
     parent?: ResourceGroupsItem,
     displayOptions?: GroupingItemDisplayOptions,
+    /**
+     * Optional. Stable key used in the grouping item's `id`. Defaults to
+     * `label`. Set this when the label may be overridden (e.g. by an
+     * extension-contributed display name) so identity remains stable.
+     */
+    idKey?: string,
 }
 
 export type GroupingItemFactory = (options: GroupingItemOptions) => GroupingItem;
 
 export function createGroupingItemFactory(resourceItemFactory: ResourceItemFactory<AzureResource>, branchDataProviderFactory: BranchDataProviderFactory, onDidChangeBranchDataProviders: vscode.Event<AzExtResourceType>, defaultOptions?: GroupingItemDisplayOptions): GroupingItemFactory {
-    return ({ context, contextValues, iconPath, label, resources, parent, displayOptions }) =>
+    return ({ context, contextValues, iconPath, label, resources, parent, displayOptions, idKey }) =>
         new GroupingItem(
-            { context, contextValues, iconPath, label, resources, parent, displayOptions: { ...defaultOptions, ...displayOptions } },
+            { context, contextValues, iconPath, label, resources, parent, idKey, displayOptions: { ...defaultOptions, ...displayOptions } },
             { resourceItemFactory, branchDataProviderFactory, onDidChangeBranchDataProviders, }
         );
 }

--- a/src/utils/getResourceContributions.ts
+++ b/src/utils/getResourceContributions.ts
@@ -6,9 +6,34 @@
 import * as vscode from 'vscode';
 import { contributesKey } from '../constants';
 
+/**
+ * A path to an icon file contributed by an extension. Either a single path used
+ * for both light and dark themes, or distinct paths per theme. Paths are
+ * resolved relative to the contributing extension's root.
+ *
+ * Theme icons (`$(id)` references) are intentionally not supported here:
+ * resource-type group nodes are expected to use branded Azure service icons.
+ */
+export type ContributedIconPath = string | { readonly light: string; readonly dark: string };
+
+export interface AzureBranchContribution {
+    readonly type: string;
+    /**
+     * Optional. Overrides the default localized label of the resource-type
+     * group node when the tree is grouped by resource type. Supports `%key%`
+     * NLS substitution against the contributing extension's `package.nls.json`.
+     */
+    readonly displayName?: string;
+    /**
+     * Optional. Overrides the default icon of the resource-type group node
+     * when the tree is grouped by resource type.
+     */
+    readonly icon?: ContributedIconPath;
+}
+
 interface ResourceGroupsContribution {
     readonly azure: {
-        readonly branches?: { type: string }[];
+        readonly branches?: AzureBranchContribution[];
         readonly resources?: boolean;
     }
     readonly workspace: {

--- a/src/utils/getResourceTypeOverrides.ts
+++ b/src/utils/getResourceTypeOverrides.ts
@@ -31,6 +31,30 @@ function ensureSubscribed(): void {
     }
 }
 
+const themeIconPattern = /^\$\(.+\)$/;
+
+/**
+ * Returns true if `value` is a structurally valid contributed icon path: a
+ * non-empty string or an object with non-empty string `light` and `dark`
+ * properties. Invalid values (numbers, arrays, nested objects, empty strings,
+ * etc.) are rejected so that a misconfigured partner extension cannot crash
+ * tree construction.
+ *
+ * Note: theme-icon strings (`$(id)`) pass this check intentionally — callers
+ * are expected to test for theme icons separately before calling this function.
+ */
+function isValidIconPath(value: unknown): value is ContributedIconPath {
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+        const obj = value as Record<string, unknown>;
+        return typeof obj['light'] === 'string' && obj['light'].length > 0
+            && typeof obj['dark'] === 'string' && obj['dark'].length > 0;
+    }
+    return false;
+}
+
 function resolveIconPath(extensionUri: vscode.Uri, icon: ContributedIconPath): TreeItemIconPath {
     if (typeof icon === 'string') {
         return Utils.joinPath(extensionUri, icon);
@@ -54,19 +78,35 @@ function buildCache(): Map<string, ResourceTypeOverride> {
         }
 
         for (const branch of branches) {
-            if (!branch.type || (branch.displayName === undefined && branch.icon === undefined)) {
-                continue;
-            }
+            try {
+                if (!branch.type || (branch.displayName === undefined && branch.icon === undefined)) {
+                    continue;
+                }
 
-            if (map.has(branch.type)) {
-                ext.outputChannel.warn(`Multiple extensions declare a display override for resource type "${branch.type}". Using the first by extension id; ignoring "${extension.id}".`);
-                continue;
-            }
+                if (map.has(branch.type)) {
+                    ext.outputChannel.warn(`Multiple extensions declare a display override for resource type "${branch.type}". Using the first by extension id; ignoring "${extension.id}".`);
+                    continue;
+                }
 
-            map.set(branch.type, {
-                label: branch.displayName,
-                iconPath: branch.icon !== undefined ? resolveIconPath(extension.extensionUri, branch.icon) : undefined,
-            });
+                let iconPath: TreeItemIconPath | undefined;
+                if (branch.icon !== undefined) {
+                    const rawIcon: unknown = branch.icon;
+                    if (typeof rawIcon === 'string' && themeIconPattern.test(rawIcon)) {
+                        ext.outputChannel.warn(`Extension "${extension.id}" contributed a theme icon ("${rawIcon}") for resource type "${branch.type}". Theme icons are not supported for resource-type group nodes; the icon will be ignored.`);
+                    } else if (!isValidIconPath(rawIcon)) {
+                        ext.outputChannel.warn(`Extension "${extension.id}" contributed an invalid icon for resource type "${branch.type}"; the icon will be ignored.`);
+                    } else {
+                        iconPath = resolveIconPath(extension.extensionUri, rawIcon);
+                    }
+                }
+
+                map.set(branch.type, {
+                    label: branch.displayName,
+                    iconPath,
+                });
+            } catch (e) {
+                ext.outputChannel.warn(`Failed to process display override from extension "${extension.id}" for resource type "${branch.type ?? '(unknown)'}": ${String(e)}`);
+            }
         }
     }
 

--- a/src/utils/getResourceTypeOverrides.ts
+++ b/src/utils/getResourceTypeOverrides.ts
@@ -10,6 +10,15 @@ import { AzExtResourceType } from '../../api/src/AzExtResourceType';
 import { ext } from '../extensionVariables';
 import { ContributedIconPath, getResourceContributions } from './getResourceContributions';
 
+function warn(message: string): void {
+    // `ext.outputChannel` is not initialized in unit tests; fall back to console.
+    if (ext?.outputChannel?.warn) {
+        ext.outputChannel.warn(message);
+    } else {
+        console.warn(message);
+    }
+}
+
 /**
  * Static, contribution-driven overrides for the display of a resource-type
  * group node. Resolved from contributing extensions' `package.json` without
@@ -88,7 +97,7 @@ export function buildOverrideMapFromExtensions(extensions: readonly vscode.Exten
                 }
 
                 if (map.has(branch.type)) {
-                    ext.outputChannel.warn(`Multiple extensions declare a display override for resource type "${branch.type}". Using the first by extension id; ignoring "${extension.id}".`);
+                    warn(`Multiple extensions declare a display override for resource type "${branch.type}". Using the first by extension id; ignoring "${extension.id}".`);
                     continue;
                 }
 
@@ -96,9 +105,9 @@ export function buildOverrideMapFromExtensions(extensions: readonly vscode.Exten
                 if (branch.icon !== undefined) {
                     const rawIcon: unknown = branch.icon;
                     if (typeof rawIcon === 'string' && themeIconPattern.test(rawIcon)) {
-                        ext.outputChannel.warn(`Extension "${extension.id}" contributed a theme icon ("${rawIcon}") for resource type "${branch.type}". Theme icons are not supported for resource-type group nodes; the icon will be ignored.`);
+                        warn(`Extension "${extension.id}" contributed a theme icon ("${rawIcon}") for resource type "${branch.type}". Theme icons are not supported for resource-type group nodes; the icon will be ignored.`);
                     } else if (!isValidIconPath(rawIcon)) {
-                        ext.outputChannel.warn(`Extension "${extension.id}" contributed an invalid icon for resource type "${branch.type}"; the icon will be ignored.`);
+                        warn(`Extension "${extension.id}" contributed an invalid icon for resource type "${branch.type}"; the icon will be ignored.`);
                     } else {
                         iconPath = resolveIconPath(extension.extensionUri, rawIcon);
                     }
@@ -109,7 +118,7 @@ export function buildOverrideMapFromExtensions(extensions: readonly vscode.Exten
                     iconPath,
                 });
             } catch (e) {
-                ext.outputChannel.warn(`Failed to process display override from extension "${extension.id}" for resource type "${branch.type ?? '(unknown)'}": ${String(e)}`);
+                warn(`Failed to process display override from extension "${extension.id}" for resource type "${branch.type ?? '(unknown)'}": ${String(e)}`);
             }
         }
     }

--- a/src/utils/getResourceTypeOverrides.ts
+++ b/src/utils/getResourceTypeOverrides.ts
@@ -65,13 +65,17 @@ function resolveIconPath(extensionUri: vscode.Uri, icon: ContributedIconPath): T
     };
 }
 
-function buildCache(): Map<string, ResourceTypeOverride> {
+/**
+ * @internal Exported for testing only. Builds a resource-type → override map
+ * from the supplied extension list without touching `vscode.extensions.all`.
+ */
+export function buildOverrideMapFromExtensions(extensions: readonly vscode.Extension<unknown>[]): Map<string, ResourceTypeOverride> {
     const map = new Map<string, ResourceTypeOverride>();
 
     // Sort by extension id to make conflict resolution deterministic.
-    const extensions = [...vscode.extensions.all].sort((a, b) => a.id.localeCompare(b.id));
+    const sorted = [...extensions].sort((a, b) => a.id.localeCompare(b.id));
 
-    for (const extension of extensions) {
+    for (const extension of sorted) {
         const branches = getResourceContributions(extension)?.azure?.branches;
         if (!branches) {
             continue;
@@ -121,7 +125,7 @@ function buildCache(): Map<string, ResourceTypeOverride> {
 export function getResourceTypeOverride(resourceType: AzExtResourceType | string): ResourceTypeOverride | undefined {
     ensureSubscribed();
     if (!cache) {
-        cache = buildCache();
+        cache = buildOverrideMapFromExtensions(vscode.extensions.all);
     }
     return cache.get(resourceType);
 }

--- a/src/utils/getResourceTypeOverrides.ts
+++ b/src/utils/getResourceTypeOverrides.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TreeItemIconPath } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+import { Utils } from 'vscode-uri';
+import { AzExtResourceType } from '../../api/src/AzExtResourceType';
+import { ext } from '../extensionVariables';
+import { ContributedIconPath, getResourceContributions } from './getResourceContributions';
+
+/**
+ * Static, contribution-driven overrides for the display of a resource-type
+ * group node. Resolved from contributing extensions' `package.json` without
+ * activating them.
+ */
+export interface ResourceTypeOverride {
+    readonly label?: string;
+    readonly iconPath?: TreeItemIconPath;
+}
+
+let cache: Map<string, ResourceTypeOverride> | undefined;
+let changeSubscription: vscode.Disposable | undefined;
+
+function ensureSubscribed(): void {
+    if (!changeSubscription) {
+        changeSubscription = vscode.extensions.onDidChange(() => {
+            cache = undefined;
+        });
+    }
+}
+
+function resolveIconPath(extensionUri: vscode.Uri, icon: ContributedIconPath): TreeItemIconPath {
+    if (typeof icon === 'string') {
+        return Utils.joinPath(extensionUri, icon);
+    }
+    return {
+        light: Utils.joinPath(extensionUri, icon.light),
+        dark: Utils.joinPath(extensionUri, icon.dark),
+    };
+}
+
+function buildCache(): Map<string, ResourceTypeOverride> {
+    const map = new Map<string, ResourceTypeOverride>();
+
+    // Sort by extension id to make conflict resolution deterministic.
+    const extensions = [...vscode.extensions.all].sort((a, b) => a.id.localeCompare(b.id));
+
+    for (const extension of extensions) {
+        const branches = getResourceContributions(extension)?.azure?.branches;
+        if (!branches) {
+            continue;
+        }
+
+        for (const branch of branches) {
+            if (!branch.type || (branch.displayName === undefined && branch.icon === undefined)) {
+                continue;
+            }
+
+            if (map.has(branch.type)) {
+                ext.outputChannel.warn(`Multiple extensions declare a display override for resource type "${branch.type}". Using the first by extension id; ignoring "${extension.id}".`);
+                continue;
+            }
+
+            map.set(branch.type, {
+                label: branch.displayName,
+                iconPath: branch.icon !== undefined ? resolveIconPath(extension.extensionUri, branch.icon) : undefined,
+            });
+        }
+    }
+
+    return map;
+}
+
+/**
+ * Returns the contribution-declared display override for the given resource
+ * type, or `undefined` if no contributing extension declares one. Reading does
+ * not activate any extension.
+ */
+export function getResourceTypeOverride(resourceType: AzExtResourceType | string): ResourceTypeOverride | undefined {
+    ensureSubscribed();
+    if (!cache) {
+        cache = buildCache();
+    }
+    return cache.get(resourceType);
+}

--- a/test/getResourceTypeOverrides.test.ts
+++ b/test/getResourceTypeOverrides.test.ts
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import * as vscode from 'vscode';
+import { AzExtResourceType } from '../api/src/AzExtResourceType';
+import { buildOverrideMapFromExtensions } from '../src/utils/getResourceTypeOverrides';
+
+function mockExtension(id: string, packageJson: object): vscode.Extension<unknown> {
+    return {
+        id,
+        extensionUri: vscode.Uri.file(`/mock-ext/${id}`),
+        extensionPath: `/mock-ext/${id}`,
+        isActive: false,
+        packageJSON: packageJson,
+        extensionKind: vscode.ExtensionKind.UI,
+        exports: undefined,
+        activate: () => Promise.resolve(undefined),
+    };
+}
+
+function contributingExt(id: string, type: string, overrides: { displayName?: string; icon?: unknown }): vscode.Extension<unknown> {
+    return mockExtension(id, {
+        contributes: {
+            'x-azResources': {
+                azure: {
+                    branches: [{ type, ...overrides }]
+                }
+            }
+        }
+    });
+}
+
+suite('getResourceTypeOverrides', () => {
+
+    test('returns undefined when extension contributes type without displayName or icon', () => {
+        // Extension contributes the type but provides neither displayName nor icon
+        const map = buildOverrideMapFromExtensions([
+            contributingExt('ext.a', AzExtResourceType.FunctionApp, {})
+        ]);
+        assert.strictEqual(map.get(AzExtResourceType.FunctionApp), undefined);
+    });
+
+    test('returns label override when displayName is contributed', () => {
+        const map = buildOverrideMapFromExtensions([
+            contributingExt('ext.a', AzExtResourceType.FunctionApp, { displayName: 'My Functions' })
+        ]);
+        const override = map.get(AzExtResourceType.FunctionApp);
+        assert.ok(override, 'Expected an override entry');
+        assert.strictEqual(override.label, 'My Functions');
+    });
+
+    test('returns iconPath (Uri) when a single-string icon is contributed', () => {
+        const map = buildOverrideMapFromExtensions([
+            contributingExt('ext.a', AzExtResourceType.FunctionApp, { icon: 'resources/icon.svg' })
+        ]);
+        const override = map.get(AzExtResourceType.FunctionApp);
+        assert.ok(override, 'Expected an override entry');
+        assert.ok(override.iconPath instanceof vscode.Uri, 'Expected iconPath to be a Uri for a string icon');
+        assert.ok((override.iconPath as vscode.Uri).path.endsWith('resources/icon.svg'));
+    });
+
+    test('returns iconPath (light/dark) when a light/dark icon is contributed', () => {
+        const map = buildOverrideMapFromExtensions([
+            contributingExt('ext.a', AzExtResourceType.FunctionApp, {
+                icon: { light: 'light/icon.svg', dark: 'dark/icon.svg' }
+            })
+        ]);
+        const override = map.get(AzExtResourceType.FunctionApp);
+        assert.ok(override, 'Expected an override entry');
+        assert.ok(override.iconPath && typeof override.iconPath === 'object' && 'light' in override.iconPath,
+            'Expected iconPath to be a light/dark object');
+        const ip = override.iconPath as { light: vscode.Uri; dark: vscode.Uri };
+        assert.ok(ip.light.path.endsWith('light/icon.svg'));
+        assert.ok(ip.dark.path.endsWith('dark/icon.svg'));
+    });
+
+    test('returns no iconPath when a theme icon is contributed', () => {
+        const map = buildOverrideMapFromExtensions([
+            contributingExt('ext.a', AzExtResourceType.FunctionApp, { icon: '$(rocket)', displayName: 'Keep This' })
+        ]);
+        const override = map.get(AzExtResourceType.FunctionApp);
+        assert.ok(override, 'Expected an override entry (displayName should still be set)');
+        assert.strictEqual(override.label, 'Keep This');
+        assert.strictEqual(override.iconPath, undefined, 'Theme icon should be ignored');
+    });
+
+    test('returns no iconPath when an invalid icon value is contributed', () => {
+        // icon: 123 is not a valid path — should be silently ignored
+        const map = buildOverrideMapFromExtensions([
+            contributingExt('ext.a', AzExtResourceType.FunctionApp, { icon: 123, displayName: 'Keep This' })
+        ]);
+        const override = map.get(AzExtResourceType.FunctionApp);
+        assert.ok(override, 'Expected an override entry (displayName should still be set)');
+        assert.strictEqual(override.label, 'Keep This');
+        assert.strictEqual(override.iconPath, undefined, 'Invalid icon should be ignored');
+    });
+
+    test('conflict resolution: first extension by id wins', () => {
+        // 'aaa.ext' sorts before 'zzz.ext', so its contribution should win
+        const map = buildOverrideMapFromExtensions([
+            contributingExt('zzz.ext', AzExtResourceType.FunctionApp, { displayName: 'ZZZ Label' }),
+            contributingExt('aaa.ext', AzExtResourceType.FunctionApp, { displayName: 'AAA Label' }),
+        ]);
+        const override = map.get(AzExtResourceType.FunctionApp);
+        assert.ok(override, 'Expected an override entry');
+        assert.strictEqual(override.label, 'AAA Label', 'First by id should win');
+    });
+
+    test('returns undefined for a type not claimed by any extension', () => {
+        const map = buildOverrideMapFromExtensions([
+            contributingExt('ext.a', AzExtResourceType.AppServices, { displayName: 'App Services Override' })
+        ]);
+        assert.strictEqual(map.get(AzExtResourceType.FunctionApp), undefined);
+    });
+
+    test('extensions with no x-azResources contribution are ignored', () => {
+        const map = buildOverrideMapFromExtensions([
+            mockExtension('ext.no-contrib', { contributes: {} })
+        ]);
+        assert.strictEqual(map.size, 0);
+    });
+});

--- a/test/grouping.test.ts
+++ b/test/grouping.test.ts
@@ -32,6 +32,31 @@ suite('Azure resource grouping tests', async () => {
         assert.ok(functionGroup);
     });
 
+    test('Resource type group id is stable (uses raw type key, not display label)', async () => {
+        createMockSubscriptionWithFunctions();
+
+        await commands.executeCommand('azureResourceGroups.groupBy.resourceType');
+
+        const tdp = api().azureResourceTreeDataProvider;
+        const subscriptions = await tdp.getChildren();
+
+        const groups = await tdp.getChildren(subscriptions![0]) as GroupingItem[];
+        const functionGroup = groups.find(group => (group as ResourceTypeGroupingItem).resourceType === AzExtResourceType.FunctionApp) as ResourceTypeGroupingItem;
+        assert.ok(functionGroup, 'FunctionApp grouping item should exist');
+
+        // The id must contain the raw AzExtResourceType enum value ('FunctionApp'),
+        // not the localized display label ('Function App'). This ensures VS Code's
+        // tree expansion/focus state survives a label change via a contributed override.
+        assert.ok(
+            functionGroup.id.includes(AzExtResourceType.FunctionApp),
+            `Expected id to contain '${AzExtResourceType.FunctionApp}', got: ${functionGroup.id}`
+        );
+        assert.ok(
+            !functionGroup.id.includes('Function App'),
+            `Expected id to use the raw type key, not the display label. Got: ${functionGroup.id}`
+        );
+    });
+
     test('Group by resource group', async () => {
         const mocks = createMockSubscriptionWithFunctions();
 


### PR DESCRIPTION
## Summary

Adds a `package.json`-only extension point that lets a contributing extension override the **label** and/or **icon** of its root resource-type group node (the node shown when the Azure resources tree is grouped by Resource Type). Previously these were determined entirely inside this extension by `getName` / `getIconPath` in `src/utils/azureUtils.ts` with no override path, forcing partner extensions to PR this repo to change a display name or ship a new branded SVG.

Resolves #1432

## Design

Override is declared statically in the contributing extension's `package.json`, so the host can read it **without activating the extension** — preserving the lazy-activation invariant enforced by `ResourceGroupsExtensionManager.activateApplicationResourceBranchDataProvider`. A programmatic API on `AzureResourceBranchDataProvider` was considered and rejected for v1 because it would require activating every contributing extension to ask whether it wants to customize the root node.

### Contribution shape

```jsonc
"contributes": {
    "x-azResources": {
        "azure": {
            "branches": [
                {
                    "type": "FunctionApp",
                    "displayName": "%functionApp.displayName%",
                    "icon": {
                        "light": "resources/light/functionApp.svg",
                        "dark": "resources/dark/functionApp.svg"
                    }
                }
            ]
        }
    }
}
```

- `displayName` *(string, optional)* — replaces the label produced by `getName`. Supports `%key%` NLS substitution against the contributing extension's `package.nls.json` (resolved by VS Code at extension load time).
- `icon` *(string | { light, dark }, optional)* — replaces the icon produced by `getIconPath`. Paths resolve relative to the contributing extension's `extensionUri`. **Theme icons (`$(id)`) are intentionally not supported** — root resource-type nodes are expected to use branded Azure service icons.

Both fields are optional and independent. If absent, current behavior is unchanged.

### Resolution

For each `ResourceTypeGroupingItem` of type `T`:

1. Scan `vscode.extensions.all` (no activation) for any extension declaring `azure.branches[].type === T` with a `displayName` or `icon`.
2. If found, use that; otherwise fall back to `getName(T)` / `getIconPath(T)`.
3. Multiple extensions claiming the same type → sort deterministically by extension id, take the first, log a warning. In practice each `AzExtResourceType` has a single owning extension.

Result is cached and invalidated on `vscode.extensions.onDidChange`.

### Identity stability

`GroupingItem.id` was previously derived from `label`. Since labels can now be overridden by a contribution, `ResourceTypeGroupingItem` now passes a stable `idKey` (the raw `AzExtResourceType` enum value) so VS Code's tree expansion/focus state is preserved when a label changes.

# Compatibility

- Purely additive to both the contribution schema and runtime behavior.
- No change to the public `api/src/` surface — this is a `package.json` contribution point only. No host API version bump required.
- The built-in `azExtDisplayInfo` map and `resources/azureIcons/` directory remain authoritative defaults; partner extensions can choose to override.
- Existing extensions with no override behave exactly as before.
- `id` derivation for non-resource-type groups (resource-group, location, generic) is unchanged.

## Testing

Manually verified with the sibling `vscode-azurecontainerapps` extension by adding a `displayName` (NLS key) and `icon` to its `ContainerAppsEnvironment` branch contribution. With the override:

- Group node renders the contributed branded SVG and custom label.
- Tree expansion state survives a label change (id is stable).
- Removing the override fields restores the default behavior with no change in identity.

Automated tests are not included in this PR; suggested follow-ups:
- Unit tests for `getResourceTypeOverride` (NLS-resolved label, single-string vs themed `icon`, duplicate-extension warning, cache invalidation on `onDidChange`).
- Integration test in `test/grouping.test.ts` asserting overridden label/icon and stable `id` for the `FunctionApp` group node.

## Open questions

- Conflict policy when two extensions declare an override for the same `AzExtResourceType` is currently *warn-and-pick-first-by-extension-id*. Open to alternatives (e.g. ignore-both) if reviewers prefer.