### PR TITLE
api: add optional createIfNone to AzureAuthentication.getSessionWithScopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Added
+* Add an optional `options` parameter to `AzureAuthentication.getSessionWithScopes`. Passing `{ createIfNone: true }` allows an interactive consent prompt when a session for the requested scopes has not yet been granted. See [microsoft/vscode-azurefunctions#5073](https://github.com/microsoft/vscode-azurefunctions/issues/5073)
+
 ## 0.12.5 - 2026-05-28
 
 ### Changed

--- a/api/docs/vscode-azureresources-api.d.ts
+++ b/api/docs/vscode-azureresources-api.d.ts
@@ -126,10 +126,13 @@ export declare interface AzureAuthentication {
      *
      * @param scopeListOrRequest - The scopes for which the authentication is needed. Use AuthenticationWwwAuthenticateRequest for supporting challenge requests.
      * Note: use of AuthenticationWwwAuthenticateRequest requires VS Code v1.105.0
+     * @param options - (Optional) Options controlling how the session is acquired. By default a plain
+     * scope list is acquired silently; set `createIfNone` to allow an interactive consent prompt when
+     * no session for the requested scopes has been granted yet. Challenge requests always allow prompting.
      *
      * @returns A VS Code authentication session or undefined, if none could be obtained.
      */
-    getSessionWithScopes(scopeListOrRequest: string[] | vscode.AuthenticationWwwAuthenticateRequest): vscode.ProviderResult<vscode.AuthenticationSession>;
+    getSessionWithScopes(scopeListOrRequest: string[] | vscode.AuthenticationWwwAuthenticateRequest, options?: GetSessionWithScopesOptions): vscode.ProviderResult<vscode.AuthenticationSession>;
 }
 
 export declare interface AzureExtensionApi {
@@ -395,6 +398,17 @@ export declare function getAzExtResourceType(resource: {
  * See: https://github.com/microsoft/vscode-azureresourcegroups/blob/main/api/src/auth/README.md
  * */
 export declare function getAzureResourcesExtensionApi(extensionContext: vscode.ExtensionContext, apiVersionRange: '2.0.0', options?: GetApiOptions): Promise<AzureResourcesExtensionApi>;
+
+/**
+ * Options for {@link AzureAuthentication.getSessionWithScopes}.
+ */
+export declare interface GetSessionWithScopesOptions {
+    /**
+     * Whether to allow an interactive prompt (sign in / consent) if no session for the requested
+     * scopes is already available. Defaults to `false`, in which case the session is acquired silently.
+     */
+    createIfNone?: boolean;
+}
 
 export declare function isWrapper(maybeWrapper: unknown): maybeWrapper is Wrapper;
 

--- a/api/src/resources/azure.ts
+++ b/api/src/resources/azure.ts
@@ -24,10 +24,24 @@ export interface AzureAuthentication {
      *
      * @param scopeListOrRequest - The scopes for which the authentication is needed. Use AuthenticationWwwAuthenticateRequest for supporting challenge requests.
      * Note: use of AuthenticationWwwAuthenticateRequest requires VS Code v1.105.0
+     * @param options - (Optional) Options controlling how the session is acquired. By default a plain
+     * scope list is acquired silently; set `createIfNone` to allow an interactive consent prompt when
+     * no session for the requested scopes has been granted yet. Challenge requests always allow prompting.
      *
      * @returns A VS Code authentication session or undefined, if none could be obtained.
      */
-    getSessionWithScopes(scopeListOrRequest: string[] | vscode.AuthenticationWwwAuthenticateRequest): vscode.ProviderResult<vscode.AuthenticationSession>;
+    getSessionWithScopes(scopeListOrRequest: string[] | vscode.AuthenticationWwwAuthenticateRequest, options?: GetSessionWithScopesOptions): vscode.ProviderResult<vscode.AuthenticationSession>;
+}
+
+/**
+ * Options for {@link AzureAuthentication.getSessionWithScopes}.
+ */
+export interface GetSessionWithScopesOptions {
+    /**
+     * Whether to allow an interactive prompt (sign in / consent) if no session for the requested
+     * scopes is already available. Defaults to `false`, in which case the session is acquired silently.
+     */
+    createIfNone?: boolean;
 }
 
 /**


### PR DESCRIPTION
> **Draft** — contract-parity change for the resources API. Off the critical path for fixing microsoft/vscode-azurefunctions#5073; the runtime fix ships via the auth + appservice packages. Opened as a draft so the public API typing can be kept in sync when the auth change is consumed.

## Summary

Mirrors the new optional `options` parameter (with `createIfNone`) added to `@microsoft/vscode-azext-azureauth`'s `getSessionWithScopes` onto the **public resources API** `AzureAuthentication.getSessionWithScopes`, keeping the published contract in parity with the auth implementation.

## Context

Part of microsoft/vscode-azurefunctions#5073. The functional fix lives in:
- `@microsoft/vscode-azext-azureauth` — adds the `createIfNone` option (microsoft/vscode-azuretools#2314)
- `@microsoft/vscode-azext-azureappservice` — eagerly consents to the App Service audience using it (microsoft/vscode-azuretools#2315)

This PR is **type-only** and not required for the runtime fix (the appservice side accesses `authentication` structurally), but it keeps the documented public API accurate for consumers who want to pass `options` through the resources API typings.

## Changes

- `getSessionWithScopes` gains `options?: GetSessionWithScopesOptions` in `api/src/resources/azure.ts`.
- New exported `GetSessionWithScopesOptions` interface.
- Regenerated `api/docs/vscode-azureresources-api.d.ts` via `api-extractor` (verified in sync with `dist/`).
- CHANGELOG `Unreleased / Added` entry.

Refs microsoft/vscode-azurefunctions#5073
