### PR TITLE
Add command to download agent instruction files to workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,11 @@
                 "category": "Azure"
             },
             {
+                "command": "azureResourceGroups.downloadAgentInstructions",
+                "title": "Download Azure Agent Instructions",
+                "category": "Azure"
+            },
+            {
                 "command": "azureResourceGroups.uploadFileCloudConsole",
                 "title": "%azureResourceGroups.uploadToCloudShell%",
                 "category": "Azure"

--- a/resources/agents/azure-debug-generate/.metadata.json
+++ b/resources/agents/azure-debug-generate/.metadata.json
@@ -1,0 +1,4 @@
+{
+    "name": "azure-debug-generate",
+    "version": "0.0.1"
+}

--- a/resources/agents/azure-debug-plan/.metadata.json
+++ b/resources/agents/azure-debug-plan/.metadata.json
@@ -1,0 +1,4 @@
+{
+    "name": "azure-debug-plan",
+    "version": "0.0.1"
+}

--- a/resources/agents/azure-project-plan/.metadata.json
+++ b/resources/agents/azure-project-plan/.metadata.json
@@ -1,0 +1,4 @@
+{
+    "name": "azure-project-plan",
+    "version": "0.0.1"
+}

--- a/resources/agents/azure-project-scaffold/.metadata.json
+++ b/resources/agents/azure-project-scaffold/.metadata.json
@@ -1,0 +1,4 @@
+{
+    "name": "azure-project-scaffold",
+    "version": "0.0.1"
+}

--- a/resources/agents/azure-project-test/.metadata.json
+++ b/resources/agents/azure-project-test/.metadata.json
@@ -1,0 +1,4 @@
+{
+    "name": "azure-project-test",
+    "version": "0.0.1"
+}

--- a/resources/agents/shared-references/.metadata.json
+++ b/resources/agents/shared-references/.metadata.json
@@ -1,0 +1,4 @@
+{
+    "name": "shared-references",
+    "version": "0.0.1"
+}

--- a/src/commands/copilotOnRails/agentInstructions.ts
+++ b/src/commands/copilotOnRails/agentInstructions.ts
@@ -1,0 +1,178 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
+import * as vscode from 'vscode';
+import { ext } from '../../extensionVariables';
+
+/** Name of the metadata file bundled alongside each instruction folder. */
+const METADATA_FILE = '.metadata.json';
+
+/** Folder (relative to the workspace root) where instruction folders are downloaded. */
+const WORKSPACE_AGENTS_RELATIVE_PATH = ['.github', 'agents'];
+
+interface AgentInstructionMetadata {
+    name: string;
+    version: string;
+}
+
+/**
+ * Maps each contributed chat agent to the instruction folders (under
+ * `resources/agents`) it relies on at runtime. Agents that don't ship bundled
+ * instruction folders (e.g. `azure-deploy`, which reads an external skill) are
+ * intentionally omitted.
+ */
+const agentInstructionFolders: Record<string, string[]> = {
+    'azure-project-plan': ['azure-project-plan', 'shared-references'],
+    'azure-project-scaffold': ['azure-project-scaffold', 'shared-references'],
+    'azure-debug-plan': ['azure-debug-plan'],
+    'azure-debug-generate': ['azure-debug-generate'],
+};
+
+/** Every distinct instruction folder across all agents. */
+const allInstructionFolders: string[] = [...new Set(Object.values(agentInstructionFolders).flat())];
+
+/** Root of the instruction folders bundled with the extension. */
+function getBundledAgentsRoot(): vscode.Uri {
+    return vscode.Uri.joinPath(ext.context.extensionUri, 'resources', 'agents');
+}
+
+/** Root of the instruction folders inside the user's workspace (`.github/agents`), or `undefined` when no workspace is open. */
+function getWorkspaceAgentsRoot(): vscode.Uri | undefined {
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    if (!folder) {
+        return undefined;
+    }
+    return vscode.Uri.joinPath(folder.uri, ...WORKSPACE_AGENTS_RELATIVE_PATH);
+}
+
+/** Reads the `version` field from a `.metadata.json` file, or `undefined` if it's missing/unreadable. */
+async function readInstructionVersion(metadataUri: vscode.Uri): Promise<string | undefined> {
+    try {
+        const bytes = await vscode.workspace.fs.readFile(metadataUri);
+        const parsed = JSON.parse(Buffer.from(bytes).toString('utf-8')) as Partial<AgentInstructionMetadata>;
+        return typeof parsed.version === 'string' ? parsed.version : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/** Copies the given instruction folders from the extension bundle into the workspace, replacing any existing copies. */
+async function copyInstructionFolders(folders: string[], agentsRoot: vscode.Uri): Promise<void> {
+    const bundledRoot = getBundledAgentsRoot();
+    for (const folder of folders) {
+        const source = vscode.Uri.joinPath(bundledRoot, folder);
+        const dest = vscode.Uri.joinPath(agentsRoot, folder);
+        try {
+            await vscode.workspace.fs.delete(dest, { recursive: true, useTrash: false });
+        } catch {
+            // Nothing to remove yet — this is the first download.
+        }
+        await vscode.workspace.fs.copy(source, dest, { overwrite: true });
+    }
+}
+
+interface InstructionState {
+    anyMissing: boolean;
+    anyOutdated: boolean;
+}
+
+/** Compares the bundled instruction versions against what's installed in the workspace. */
+async function getInstructionState(folders: string[], agentsRoot: vscode.Uri): Promise<InstructionState> {
+    const bundledRoot = getBundledAgentsRoot();
+    let anyMissing = false;
+    let anyOutdated = false;
+    for (const folder of folders) {
+        const bundledVersion = await readInstructionVersion(vscode.Uri.joinPath(bundledRoot, folder, METADATA_FILE));
+        const installedVersion = await readInstructionVersion(vscode.Uri.joinPath(agentsRoot, folder, METADATA_FILE));
+        if (installedVersion === undefined) {
+            anyMissing = true;
+        } else if (bundledVersion !== undefined && installedVersion !== bundledVersion) {
+            anyOutdated = true;
+        }
+    }
+    return { anyMissing, anyOutdated };
+}
+
+/**
+ * Ensures the bundled instruction files for `agentName` are present (and up to date)
+ * in the workspace before the agent is invoked.
+ *
+ * - When the files are missing, the user is asked whether to download them. Declining
+ *   throws a {@link UserCancelledError} so the caller aborts the agent invocation.
+ * - When the files are present but a newer version is bundled, the user is asked
+ *   whether to upgrade. Declining keeps the existing files and continues.
+ *
+ * No-ops for agents that don't ship bundled instructions and when no workspace is open.
+ */
+export async function ensureAgentInstructions(agentName: string): Promise<void> {
+    const folders = agentInstructionFolders[agentName];
+    if (!folders || folders.length === 0) {
+        return;
+    }
+
+    const agentsRoot = getWorkspaceAgentsRoot();
+    if (!agentsRoot) {
+        return;
+    }
+
+    const { anyMissing, anyOutdated } = await getInstructionState(folders, agentsRoot);
+    if (!anyMissing && !anyOutdated) {
+        return;
+    }
+
+    if (anyMissing) {
+        const download = vscode.l10n.t('Download');
+        const choice = await vscode.window.showInformationMessage(
+            vscode.l10n.t('The "{0}" agent needs its instruction files in your workspace to run correctly.', agentName),
+            {
+                modal: true,
+                detail: vscode.l10n.t('These files contain the step-by-step instructions the agent follows. They will be downloaded to ".github/agents". Without them, the agent cannot complete its workflow.'),
+            },
+            download,
+        );
+        if (choice !== download) {
+            throw new UserCancelledError('downloadAgentInstructions');
+        }
+    } else {
+        const upgrade = vscode.l10n.t('Upgrade');
+        const choice = await vscode.window.showInformationMessage(
+            vscode.l10n.t('A newer version of the "{0}" agent instruction files is available.', agentName),
+            {
+                modal: true,
+                detail: vscode.l10n.t('Your workspace has an older version of these instructions in ".github/agents". Upgrade to the latest version?'),
+            },
+            upgrade,
+        );
+        if (choice !== upgrade) {
+            return;
+        }
+    }
+
+    await copyInstructionFolders(folders, agentsRoot);
+}
+
+/**
+ * Command handler that downloads agent instruction folders into the workspace.
+ *
+ * When invoked directly (e.g. from the Command Palette) the user is not prompted —
+ * running the command is treated as explicit consent to write into `.github/agents`.
+ * An optional `agentName` limits the download to a single agent's folders; otherwise
+ * every agent's instructions are downloaded.
+ */
+export async function downloadAgentInstructions(_context: IActionContext, agentName?: string): Promise<void> {
+    const agentsRoot = getWorkspaceAgentsRoot();
+    if (!agentsRoot) {
+        throw new Error(vscode.l10n.t('Open a folder or workspace before downloading Azure agent instructions.'));
+    }
+
+    const folders = agentName ? (agentInstructionFolders[agentName] ?? []) : allInstructionFolders;
+    if (folders.length === 0) {
+        throw new Error(vscode.l10n.t('No instruction files are available for the "{0}" agent.', agentName ?? ''));
+    }
+
+    await copyInstructionFolders(folders, agentsRoot);
+    void vscode.window.showInformationMessage(vscode.l10n.t('Azure agent instructions downloaded to ".github/agents".'));
+}

--- a/src/commands/copilotOnRails/agentInstructions.ts
+++ b/src/commands/copilotOnRails/agentInstructions.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext } from '@microsoft/vscode-azext-utils';
+import { AzExtFsExtra, IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
 
@@ -34,23 +34,13 @@ function getWorkspaceAgentsRoot(): vscode.Uri | undefined {
     return vscode.Uri.joinPath(folder.uri, ...WORKSPACE_AGENTS_RELATIVE_PATH);
 }
 
-/** Returns `true` if the given URI exists in the workspace filesystem. */
-async function uriExists(uri: vscode.Uri): Promise<boolean> {
-    try {
-        await vscode.workspace.fs.stat(uri);
-        return true;
-    } catch {
-        return false;
-    }
-}
-
 /** Copies each of the given instruction folders from the extension bundle into the workspace, replacing any existing copies. */
 async function copyInstructionFolders(folders: string[], agentsRoot: vscode.Uri): Promise<void> {
     const bundledRoot = getBundledAgentsRoot();
     for (const folder of folders) {
         const source = vscode.Uri.joinPath(bundledRoot, folder);
         const dest = vscode.Uri.joinPath(agentsRoot, folder);
-        await vscode.workspace.fs.copy(source, dest, { overwrite: true });
+        await AzExtFsExtra.copy(source, dest, { overwrite: true });
     }
 }
 
@@ -71,7 +61,7 @@ export async function ensureAgentInstructions(agentName: string): Promise<boolea
 
     const missingFolders: string[] = [];
     for (const folder of agentInstructionFolders) {
-        if (!(await uriExists(vscode.Uri.joinPath(agentsRoot, folder)))) {
+        if (!(await AzExtFsExtra.pathExists(vscode.Uri.joinPath(agentsRoot, folder)))) {
             missingFolders.push(folder);
         }
     }

--- a/src/commands/copilotOnRails/agentInstructions.ts
+++ b/src/commands/copilotOnRails/agentInstructions.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
+import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
 
@@ -91,25 +91,27 @@ async function getInstructionState(folders: string[], agentsRoot: vscode.Uri): P
 }
 
 /**
- * Ensures the bundled instruction files for `agentName` are present (and up to date)
- * in the workspace before the agent is invoked.
+ * Ensures the bundled instruction files are present (and up to date) in the workspace
+ * before an agent is invoked.
  *
  * - When the files are missing, the user is asked whether to download them. Declining
- *   throws a {@link UserCancelledError} so the caller aborts the agent invocation.
+ *   returns `false` so the caller can abort the agent invocation.
  * - When the files are present but a newer version is bundled, the user is asked
- *   whether to upgrade. Declining keeps the existing files and continues.
+ *   whether to upgrade. Declining keeps the existing files and returns `true` —
+ *   having any version of the files is sufficient to proceed.
  *
- * No-ops for agents that don't ship bundled instructions and when no workspace is open.
+ * Returns `true` (proceed) in all cases except: files missing **and** user declined download.
+ * No-ops (returns `true`) when no workspace is open.
  */
-export async function ensureAgentInstructions(agentName: string): Promise<void> {
+export async function ensureAgentInstructions(agentName: string): Promise<boolean> {
     const agentsRoot = getWorkspaceAgentsRoot();
     if (!agentsRoot) {
-        return;
+        return true;
     }
 
     const { anyMissing, anyOutdated } = await getInstructionState(agentInstructionFolders, agentsRoot);
     if (!anyMissing && !anyOutdated) {
-        return;
+        return true;
     }
 
     if (anyMissing) {
@@ -123,7 +125,7 @@ export async function ensureAgentInstructions(agentName: string): Promise<void> 
             download,
         );
         if (choice !== download) {
-            throw new UserCancelledError('downloadAgentInstructions');
+            return false;
         }
     } else {
         const upgrade = vscode.l10n.t('Upgrade');
@@ -136,11 +138,12 @@ export async function ensureAgentInstructions(agentName: string): Promise<void> 
             upgrade,
         );
         if (choice !== upgrade) {
-            return;
+            return true;
         }
     }
 
     await copyInstructionFolders(agentInstructionFolders, agentsRoot);
+    return true;
 }
 
 /**

--- a/src/commands/copilotOnRails/agentInstructions.ts
+++ b/src/commands/copilotOnRails/agentInstructions.ts
@@ -7,16 +7,8 @@ import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
 
-/** Name of the metadata file bundled alongside each instruction folder. */
-const METADATA_FILE = '.metadata.json';
-
 /** Folder (relative to the workspace root) where instruction folders are downloaded. */
 const WORKSPACE_AGENTS_RELATIVE_PATH = ['.github', 'agents'];
-
-interface AgentInstructionMetadata {
-    name: string;
-    version: string;
-}
 
 /** Every instruction folder bundled with the extension (under `resources/agents`). */
 const agentInstructionFolders: string[] = [
@@ -42,65 +34,33 @@ function getWorkspaceAgentsRoot(): vscode.Uri | undefined {
     return vscode.Uri.joinPath(folder.uri, ...WORKSPACE_AGENTS_RELATIVE_PATH);
 }
 
-/** Reads the `version` field from a `.metadata.json` file, or `undefined` if it's missing/unreadable. */
-async function readInstructionVersion(metadataUri: vscode.Uri): Promise<string | undefined> {
+/** Returns `true` if the given URI exists in the workspace filesystem. */
+async function uriExists(uri: vscode.Uri): Promise<boolean> {
     try {
-        const bytes = await vscode.workspace.fs.readFile(metadataUri);
-        const parsed = JSON.parse(Buffer.from(bytes).toString('utf-8')) as Partial<AgentInstructionMetadata>;
-        return typeof parsed.version === 'string' ? parsed.version : undefined;
+        await vscode.workspace.fs.stat(uri);
+        return true;
     } catch {
-        return undefined;
+        return false;
     }
 }
 
-/** Copies the given instruction folders from the extension bundle into the workspace, replacing any existing copies. */
+/** Copies each of the given instruction folders from the extension bundle into the workspace, replacing any existing copies. */
 async function copyInstructionFolders(folders: string[], agentsRoot: vscode.Uri): Promise<void> {
     const bundledRoot = getBundledAgentsRoot();
     for (const folder of folders) {
         const source = vscode.Uri.joinPath(bundledRoot, folder);
         const dest = vscode.Uri.joinPath(agentsRoot, folder);
-        try {
-            await vscode.workspace.fs.delete(dest, { recursive: true, useTrash: false });
-        } catch {
-            // Nothing to remove yet — this is the first download.
-        }
         await vscode.workspace.fs.copy(source, dest, { overwrite: true });
     }
 }
 
-interface InstructionState {
-    anyMissing: boolean;
-    anyOutdated: boolean;
-}
-
-/** Compares the bundled instruction versions against what's installed in the workspace. */
-async function getInstructionState(folders: string[], agentsRoot: vscode.Uri): Promise<InstructionState> {
-    const bundledRoot = getBundledAgentsRoot();
-    let anyMissing = false;
-    let anyOutdated = false;
-    for (const folder of folders) {
-        const bundledVersion = await readInstructionVersion(vscode.Uri.joinPath(bundledRoot, folder, METADATA_FILE));
-        const installedVersion = await readInstructionVersion(vscode.Uri.joinPath(agentsRoot, folder, METADATA_FILE));
-        if (installedVersion === undefined) {
-            anyMissing = true;
-        } else if (bundledVersion !== undefined && installedVersion !== bundledVersion) {
-            anyOutdated = true;
-        }
-    }
-    return { anyMissing, anyOutdated };
-}
-
 /**
- * Ensures the bundled instruction files are present (and up to date) in the workspace
- * before an agent is invoked.
+ * Ensures the bundled instruction files are present in the workspace before an agent is invoked.
  *
- * - When the files are missing, the user is asked whether to download them. Declining
+ * - When any folder is missing, the user is asked whether to download them. Declining
  *   returns `false` so the caller can abort the agent invocation.
- * - When the files are present but a newer version is bundled, the user is asked
- *   whether to upgrade. Declining keeps the existing files and returns `true` —
- *   having any version of the files is sufficient to proceed.
+ * - When all folders are already present, returns `true` immediately without any prompts.
  *
- * Returns `true` (proceed) in all cases except: files missing **and** user declined download.
  * No-ops (returns `true`) when no workspace is open.
  */
 export async function ensureAgentInstructions(agentName: string): Promise<boolean> {
@@ -109,40 +69,31 @@ export async function ensureAgentInstructions(agentName: string): Promise<boolea
         return true;
     }
 
-    const { anyMissing, anyOutdated } = await getInstructionState(agentInstructionFolders, agentsRoot);
-    if (!anyMissing && !anyOutdated) {
+    const missingFolders: string[] = [];
+    for (const folder of agentInstructionFolders) {
+        if (!(await uriExists(vscode.Uri.joinPath(agentsRoot, folder)))) {
+            missingFolders.push(folder);
+        }
+    }
+
+    if (missingFolders.length === 0) {
         return true;
     }
 
-    if (anyMissing) {
-        const download = vscode.l10n.t('Download');
-        const choice = await vscode.window.showInformationMessage(
-            vscode.l10n.t('The "{0}" agent needs its instruction files in your workspace to run correctly.', agentName),
-            {
-                modal: true,
-                detail: vscode.l10n.t('These files contain the step-by-step instructions the agent follows. They will be downloaded to ".github/agents". Without them, the agent cannot complete its workflow.'),
-            },
-            download,
-        );
-        if (choice !== download) {
-            return false;
-        }
-    } else {
-        const upgrade = vscode.l10n.t('Upgrade');
-        const choice = await vscode.window.showInformationMessage(
-            vscode.l10n.t('A newer version of the "{0}" agent instruction files is available.', agentName),
-            {
-                modal: true,
-                detail: vscode.l10n.t('Your workspace has an older version of these instructions in ".github/agents". Upgrade to the latest version?'),
-            },
-            upgrade,
-        );
-        if (choice !== upgrade) {
-            return true;
-        }
+    const download = vscode.l10n.t('Download');
+    const choice = await vscode.window.showInformationMessage(
+        vscode.l10n.t('The "{0}" agent needs its instruction files in your workspace to run correctly.', agentName),
+        {
+            modal: true,
+            detail: vscode.l10n.t('These files contain the step-by-step instructions the agent follows. They will be downloaded to ".github/agents". Without them, the agent cannot complete its workflow.'),
+        },
+        download,
+    );
+    if (choice !== download) {
+        return false;
     }
 
-    await copyInstructionFolders(agentInstructionFolders, agentsRoot);
+    await copyInstructionFolders(missingFolders, agentsRoot);
     return true;
 }
 

--- a/src/commands/copilotOnRails/agentInstructions.ts
+++ b/src/commands/copilotOnRails/agentInstructions.ts
@@ -18,21 +18,15 @@ interface AgentInstructionMetadata {
     version: string;
 }
 
-/**
- * Maps each contributed chat agent to the instruction folders (under
- * `resources/agents`) it relies on at runtime. Agents that don't ship bundled
- * instruction folders (e.g. `azure-deploy`, which reads an external skill) are
- * intentionally omitted.
- */
-const agentInstructionFolders: Record<string, string[]> = {
-    'azure-project-plan': ['azure-project-plan', 'shared-references'],
-    'azure-project-scaffold': ['azure-project-scaffold', 'shared-references'],
-    'azure-debug-plan': ['azure-debug-plan'],
-    'azure-debug-generate': ['azure-debug-generate'],
-};
-
-/** Every distinct instruction folder across all agents. */
-const allInstructionFolders: string[] = [...new Set(Object.values(agentInstructionFolders).flat())];
+/** Every instruction folder bundled with the extension (under `resources/agents`). */
+const agentInstructionFolders: string[] = [
+    'azure-debug-generate',
+    'azure-debug-plan',
+    'azure-project-plan',
+    'azure-project-scaffold',
+    'azure-project-test',
+    'shared-references',
+];
 
 /** Root of the instruction folders bundled with the extension. */
 function getBundledAgentsRoot(): vscode.Uri {
@@ -108,17 +102,12 @@ async function getInstructionState(folders: string[], agentsRoot: vscode.Uri): P
  * No-ops for agents that don't ship bundled instructions and when no workspace is open.
  */
 export async function ensureAgentInstructions(agentName: string): Promise<void> {
-    const folders = agentInstructionFolders[agentName];
-    if (!folders || folders.length === 0) {
-        return;
-    }
-
     const agentsRoot = getWorkspaceAgentsRoot();
     if (!agentsRoot) {
         return;
     }
 
-    const { anyMissing, anyOutdated } = await getInstructionState(folders, agentsRoot);
+    const { anyMissing, anyOutdated } = await getInstructionState(agentInstructionFolders, agentsRoot);
     if (!anyMissing && !anyOutdated) {
         return;
     }
@@ -151,28 +140,21 @@ export async function ensureAgentInstructions(agentName: string): Promise<void> 
         }
     }
 
-    await copyInstructionFolders(folders, agentsRoot);
+    await copyInstructionFolders(agentInstructionFolders, agentsRoot);
 }
 
 /**
- * Command handler that downloads agent instruction folders into the workspace.
+ * Command handler that downloads all agent instruction folders into the workspace.
  *
- * When invoked directly (e.g. from the Command Palette) the user is not prompted —
+ * When invoked (e.g. from the Command Palette) the user is not prompted —
  * running the command is treated as explicit consent to write into `.github/agents`.
- * An optional `agentName` limits the download to a single agent's folders; otherwise
- * every agent's instructions are downloaded.
  */
-export async function downloadAgentInstructions(_context: IActionContext, agentName?: string): Promise<void> {
+export async function downloadAgentInstructions(_context: IActionContext): Promise<void> {
     const agentsRoot = getWorkspaceAgentsRoot();
     if (!agentsRoot) {
         throw new Error(vscode.l10n.t('Open a folder or workspace before downloading Azure agent instructions.'));
     }
 
-    const folders = agentName ? (agentInstructionFolders[agentName] ?? []) : allInstructionFolders;
-    if (folders.length === 0) {
-        throw new Error(vscode.l10n.t('No instruction files are available for the "{0}" agent.', agentName ?? ''));
-    }
-
-    await copyInstructionFolders(folders, agentsRoot);
+    await copyInstructionFolders(agentInstructionFolders, agentsRoot);
     void vscode.window.showInformationMessage(vscode.l10n.t('Azure agent instructions downloaded to ".github/agents".'));
 }

--- a/src/commands/copilotOnRails/openChatWithAgent.ts
+++ b/src/commands/copilotOnRails/openChatWithAgent.ts
@@ -36,8 +36,9 @@ export async function openChatWithAgent(agentName: string, prompt: string): Prom
         return;
     }
     // Make sure the agent's instruction files are present in the workspace before invoking it.
-    // Throws UserCancelledError if the user declines to download required instructions.
-    await ensureAgentInstructions(agentName);
+    if (!(await ensureAgentInstructions(agentName))) {
+        return;
+    }
     await vscode.commands.executeCommand('workbench.action.chat.open', {
         mode: agentName,
         query: prompt,

--- a/src/commands/copilotOnRails/openChatWithAgent.ts
+++ b/src/commands/copilotOnRails/openChatWithAgent.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { ensureAgentInstructions } from './agentInstructions';
 
 const COPILOT_CHAT_EXTENSION_ID = 'GitHub.copilot-chat';
 
@@ -34,6 +35,9 @@ export async function openChatWithAgent(agentName: string, prompt: string): Prom
     if (!(await ensureCopilotChatReady())) {
         return;
     }
+    // Make sure the agent's instruction files are present in the workspace before invoking it.
+    // Throws UserCancelledError if the user declines to download required instructions.
+    await ensureAgentInstructions(agentName);
     await vscode.commands.executeCommand('workbench.action.chat.open', {
         mode: agentName,
         query: prompt,

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -172,8 +172,8 @@ export function registerCommands(): void {
     registerCommand('azureResourceGroups.openRequirementsView', openRequirementsViewFromWorkspace);
 
     // Hand-off commands
-    registerCommand('azureResourceGroups.downloadAgentInstructions', (context: IActionContext, agentName?: string) =>
-        downloadAgentInstructions(context, agentName));
+    registerCommand('azureResourceGroups.downloadAgentInstructions', (context: IActionContext) =>
+        downloadAgentInstructions(context));
     registerCommand('azureResourceGroups.startProjectScaffold', (_context: IActionContext, prompt?: string) =>
         openChatWithAgent('azure-project-scaffold', prompt ?? 'Plan and scaffold a new Azure project: gather requirements, produce `.azure/project-plan.md`, require explicit user approval, then scaffold the frontend preview, backend services, database, and API routes.'));
     registerCommand('azureResourceGroups.startLocalDevelopment', (_context: IActionContext, prompt?: string) =>

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -25,6 +25,7 @@ import { openPlanViewFromWorkspace } from '../webviews/copilotOnRails/extension/
 import { logIn } from './accounts/logIn';
 import { SelectSubscriptionOptions, selectSubscriptions } from './accounts/selectSubscriptions';
 import { clearActivities } from './activities/clearActivities';
+import { downloadAgentInstructions } from './copilotOnRails/agentInstructions';
 import { openChatWithAgent } from './copilotOnRails/openChatWithAgent';
 import { createResource } from './createResource';
 import { createResourceGroup } from './createResourceGroup';
@@ -170,6 +171,8 @@ export function registerCommands(): void {
     registerCommand('azureResourceGroups.openRequirementsView', openRequirementsViewFromWorkspace);
 
     // Hand-off commands
+    registerCommand('azureResourceGroups.downloadAgentInstructions', (context: IActionContext, agentName?: string) =>
+        downloadAgentInstructions(context, agentName));
     registerCommand('azureResourceGroups.startProjectScaffold', (_context: IActionContext, prompt?: string) =>
         openChatWithAgent('azure-project-scaffold', prompt ?? 'Plan and scaffold a new Azure project: gather requirements, produce `.azure/project-plan.md`, require explicit user approval, then scaffold the frontend preview, backend services, database, and API routes.'));
     registerCommand('azureResourceGroups.startLocalDevelopment', (_context: IActionContext, prompt?: string) =>

--- a/src/webviews/copilotOnRails/extension/controllers/CreateProjectViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/CreateProjectViewController.ts
@@ -6,6 +6,7 @@
 import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
+import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
 import { ensureCopilotChatReady } from "../../../../commands/copilotOnRails/openChatWithAgent";
 import { ext } from "../../../../extensionVariables";
 import { type CreateProjectViewControllerType } from "../../views/utils/viewConfigTypes";
@@ -34,6 +35,12 @@ export class CreateProjectViewController extends WebviewController<CreateProject
 
     private async openChatWithQuery(query: string): Promise<void> {
         if (!(await ensureCopilotChatReady())) {
+            return;
+        }
+        try {
+            await ensureAgentInstructions('azure-project-plan');
+        } catch {
+            // User declined to download required instructions — abort the hand-off.
             return;
         }
         this.panel.dispose();

--- a/src/webviews/copilotOnRails/extension/controllers/CreateProjectViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/CreateProjectViewController.ts
@@ -37,10 +37,7 @@ export class CreateProjectViewController extends WebviewController<CreateProject
         if (!(await ensureCopilotChatReady())) {
             return;
         }
-        try {
-            await ensureAgentInstructions('azure-project-plan');
-        } catch {
-            // User declined to download required instructions — abort the hand-off.
+        if (!(await ensureAgentInstructions('azure-project-plan'))) {
             return;
         }
         this.panel.dispose();

--- a/src/webviews/copilotOnRails/extension/controllers/LocalPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/LocalPlanViewController.ts
@@ -6,6 +6,7 @@
 import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
+import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
 import { azureDebugPlanAgent } from "../../../../constants";
 import { ext } from "../../../../extensionVariables";
 import { type LocalPlanData } from "../../views/utils/parseLocalPlanMarkdown";
@@ -26,22 +27,14 @@ export class LocalPlanViewController extends WebviewController<Record<string, ne
                     void this.panel.webview.postMessage({ command: 'setLocalPlanData', data: planData });
                     break;
                 case 'approvePlan':
-                    void vscode.commands.executeCommand('workbench.action.chat.open', {
-                        mode: azureDebugPlanAgent,
-                        query: 'I approve the debug setup plan.',
-                    });
-                    this.panel.dispose();
+                    void this.approveAndOpenDebugPlanChat();
                     break;
                 case 'submitPlanFeedback': {
                     const query = message.prompt?.trim();
                     if (!query) {
                         return;
                     }
-                    void vscode.commands.executeCommand('workbench.action.chat.open', {
-                        mode: azureDebugPlanAgent,
-                        query,
-                    });
-                    void this.panel.webview.postMessage({ command: 'revisionInProgress' });
+                    void this.openDebugPlanChat(query, true);
                     break;
                 }
                 case 'openSourceFile':
@@ -49,6 +42,30 @@ export class LocalPlanViewController extends WebviewController<Record<string, ne
                     break;
             }
         });
+    }
+
+    private async approveAndOpenDebugPlanChat(): Promise<void> {
+        if (!(await this.openDebugPlanChat('I approve the debug setup plan.', false))) {
+            return;
+        }
+        this.panel.dispose();
+    }
+
+    private async openDebugPlanChat(query: string, isFeedback: boolean): Promise<boolean> {
+        try {
+            await ensureAgentInstructions(azureDebugPlanAgent);
+        } catch {
+            // User declined to download required instructions — abort the hand-off.
+            return false;
+        }
+        await vscode.commands.executeCommand('workbench.action.chat.open', {
+            mode: azureDebugPlanAgent,
+            query,
+        });
+        if (isFeedback) {
+            void this.panel.webview.postMessage({ command: 'revisionInProgress' });
+        }
+        return true;
     }
 
     updatePlanData(planData: LocalPlanData, sourceFileUri?: vscode.Uri): void {

--- a/src/webviews/copilotOnRails/extension/controllers/LocalPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/LocalPlanViewController.ts
@@ -52,10 +52,7 @@ export class LocalPlanViewController extends WebviewController<Record<string, ne
     }
 
     private async openDebugPlanChat(query: string, isFeedback: boolean): Promise<boolean> {
-        try {
-            await ensureAgentInstructions(azureDebugPlanAgent);
-        } catch {
-            // User declined to download required instructions — abort the hand-off.
+        if (!(await ensureAgentInstructions(azureDebugPlanAgent))) {
             return false;
         }
         await vscode.commands.executeCommand('workbench.action.chat.open', {

--- a/src/webviews/copilotOnRails/extension/controllers/RequirementsViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/RequirementsViewController.ts
@@ -6,6 +6,7 @@
 import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
+import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
 import { ext } from "../../../../extensionVariables";
 import { type RequirementsData } from "../../views/utils/parseRequirements";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
@@ -72,12 +73,13 @@ export class RequirementsViewController extends WebviewController<Record<string,
 
         const relativePath = vscode.workspace.asRelativePath(this.sourceFileUri);
         try {
+            await ensureAgentInstructions('azure-project-plan');
             await vscode.commands.executeCommand('workbench.action.chat.open', {
                 mode: 'azure-project-plan',
                 query: vscode.l10n.t('Requirements submitted at {0} — read the file and continue generating .azure/project-plan.md.', relativePath),
             });
         } catch {
-            // Chat may not be available; saving still succeeded.
+            // Chat may not be available, or the user declined to download required instructions; saving still succeeded.
         }
 
         this.panel.dispose();

--- a/src/webviews/copilotOnRails/extension/controllers/RequirementsViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/RequirementsViewController.ts
@@ -72,14 +72,15 @@ export class RequirementsViewController extends WebviewController<Record<string,
         void this.panel.webview.postMessage({ command: 'submitComplete' });
 
         const relativePath = vscode.workspace.asRelativePath(this.sourceFileUri);
-        try {
-            await ensureAgentInstructions('azure-project-plan');
-            await vscode.commands.executeCommand('workbench.action.chat.open', {
-                mode: 'azure-project-plan',
-                query: vscode.l10n.t('Requirements submitted at {0} — read the file and continue generating .azure/project-plan.md.', relativePath),
-            });
-        } catch {
-            // Chat may not be available, or the user declined to download required instructions; saving still succeeded.
+        if (await ensureAgentInstructions('azure-project-plan')) {
+            try {
+                await vscode.commands.executeCommand('workbench.action.chat.open', {
+                    mode: 'azure-project-plan',
+                    query: vscode.l10n.t('Requirements submitted at {0} — read the file and continue generating .azure/project-plan.md.', relativePath),
+                });
+            } catch {
+                // Chat may not be available; saving still succeeded.
+            }
         }
 
         this.panel.dispose();

--- a/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
@@ -48,10 +48,7 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
     }
 
     private async approveAndOpenScaffoldChat(): Promise<void> {
-        try {
-            await ensureAgentInstructions('azure-project-scaffold');
-        } catch {
-            // User declined to download required instructions — abort the hand-off.
+        if (!(await ensureAgentInstructions('azure-project-scaffold'))) {
             return;
         }
         await vscode.commands.executeCommand('workbench.action.chat.open', {

--- a/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
@@ -6,6 +6,7 @@
 import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
+import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
 import { ext } from "../../../../extensionVariables";
 import { type PlanData } from "../../views/utils/parseScaffoldPlanMarkdown";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
@@ -25,11 +26,7 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
                     void this.panel.webview.postMessage({ command: 'setPlanData', data: planData });
                     break;
                 case 'approvePlan':
-                    void vscode.commands.executeCommand('workbench.action.chat.open', {
-                        mode: 'azure-project-scaffold',
-                        query: 'I approve the plan.',
-                    });
-                    this.panel.dispose();
+                    void this.approveAndOpenScaffoldChat();
                     break;
                 case 'submitPlanFeedback': {
                     const query = message.prompt?.trim();
@@ -48,6 +45,20 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
                     break;
             }
         });
+    }
+
+    private async approveAndOpenScaffoldChat(): Promise<void> {
+        try {
+            await ensureAgentInstructions('azure-project-scaffold');
+        } catch {
+            // User declined to download required instructions — abort the hand-off.
+            return;
+        }
+        await vscode.commands.executeCommand('workbench.action.chat.open', {
+            mode: 'azure-project-scaffold',
+            query: 'I approve the plan.',
+        });
+        this.panel.dispose();
     }
 
     updatePlanData(planData: PlanData, sourceFileUri?: vscode.Uri): void {


### PR DESCRIPTION
## Summary

The custom agents are contributed via `package.json`, but they rely on instruction folders under `resources/agents/` that must be present in the user's workspace to function. This PR downloads those instruction folders into the workspace and gates agent invocation on their presence.

## Changes

- **New command** `azureResourceGroups.downloadAgentInstructions` ("Azure: Download Azure Agent Instructions") copies all bundled instruction folders into `.github/agents/`.
  - Downloads all 6 instruction folders: `azure-debug-generate`, `azure-debug-plan`, `azure-project-plan`, `azure-project-scaffold`, `azure-project-test`, and `shared-references`.
  - When invoked directly from the Command Palette, it downloads **without prompting** (running the command is treated as consent).
- **Verification gate** (`ensureAgentInstructions`) runs before every custom-agent invocation:
  - **Missing** → modal prompt explaining why the files are needed; **Download** copies only the missing folders, declining returns `false` to abort the hand-off.
  - **Present** → returns `true` immediately with no prompts or version checks.
  - No workspace open → no-op (returns `true`).
- Wired the gate into `openChatWithAgent` (hand-off commands) and the `ScaffoldPlanView`, `CreateProject`, `LocalPlan`, and `Requirements` webview controllers.