### PR TITLE
Increase max requests when using copilot on rails flow

### DIFF
--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -17,11 +17,13 @@ export namespace settingUtils {
     }
 
     /**
-     * Uses ext.prefix 'azureResourceGroups' unless otherwise specified
+     * Uses ext.prefix 'azureResourceGroups' unless otherwise specified.
+     * When `target` is omitted, VS Code resolves the scope from the provided resource;
+     * pass an explicit `target` (e.g. `ConfigurationTarget.Workspace`) to force it.
      */
-    export async function updateWorkspaceSetting<T = string>(section: string, value: T, fsPath: string, prefix: string = ext.prefix): Promise<void> {
+    export async function updateWorkspaceSetting<T = string>(section: string, value: T, fsPath: string, prefix: string = ext.prefix, target?: ConfigurationTarget): Promise<void> {
         const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, Uri.file(fsPath));
-        await projectConfiguration.update(section, value);
+        await projectConfiguration.update(section, value, target);
     }
 
     /**

--- a/src/utils/settingUtils.ts
+++ b/src/utils/settingUtils.ts
@@ -18,8 +18,6 @@ export namespace settingUtils {
 
     /**
      * Uses ext.prefix 'azureResourceGroups' unless otherwise specified.
-     * When `target` is omitted, VS Code resolves the scope from the provided resource;
-     * pass an explicit `target` (e.g. `ConfigurationTarget.Workspace`) to force it.
      */
     export async function updateWorkspaceSetting<T = string>(section: string, value: T, fsPath: string, prefix: string = ext.prefix, target?: ConfigurationTarget): Promise<void> {
         const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, Uri.file(fsPath));

--- a/src/webviews/copilotOnRails/extension/autopilot.ts
+++ b/src/webviews/copilotOnRails/extension/autopilot.ts
@@ -8,30 +8,9 @@ import * as vscode from "vscode";
 import { settingUtils } from "../../../utils/settingUtils";
 
 /**
- * Autopilot ("YOLO") mode for the create-project workflow.
- *
- * When the user submits the requirements form with autopilot enabled, the whole
- * plan -> scaffold -> local-debug chain runs end-to-end without approval gates.
- * To make tool actions (file edits, terminal commands) run unattended, we flip
- * VS Code's global `chat.tools.global.autoApprove` setting on for the duration
- * of the run and restore it afterward. We also raise `chat.agent.maxRequests`
- * to a high ceiling so the long scaffold -> integrate -> debug chain doesn't
- * stall on the "Copilot has been working on this problem for a while" continue
- * prompt — but unlike auto-approve, that limit is written at the *Workspace*
- * scope and intentionally left in place (it isn't a security-sensitive global,
- * and a freshly scaffolded workspace benefits from the higher ceiling).
- *
- * Because the auto-approve setting is global and security-sensitive, its
- * restoration is layered:
- *  1. A completion watcher restores it the moment the local debug plan reaches
- *     `Status: Implemented` (the end of the chain).
- *  2. A safety deadline restores it after `MAX_RUN_DURATION_MS` even if the
- *     chain never reaches `Implemented` (failure, stall, or abandoned run), so
- *     auto-approve can never stay on indefinitely.
- *  3. A status-bar item lets the user turn it off manually at any time.
- *  4. On the next activation, a prior active run is either re-armed (if still
- *     within its deadline — covers window reloads mid-run) or restored (if the
- *     deadline has elapsed — covers crashes / abandoned runs).
+ * Autopilot mode for the create-project workflow.
+ * It temporarily enables global chat tool auto-approve and restores it later.
+ * It also raises workspace chat request budget for long unattended runs.
  */
 
 const AUTO_APPROVE_SECTION = 'chat.tools.global';
@@ -40,13 +19,7 @@ const AUTO_APPROVE_KEY = 'autoApprove';
 const MAX_REQUESTS_SECTION = 'chat.agent';
 const MAX_REQUESTS_KEY = 'maxRequests';
 
-/**
- * Request budget written to `chat.agent.maxRequests` at the Workspace scope while
- * scaffolding. The unattended chain (scaffold -> integrate -> local debug) makes
- * many tool calls per turn; a high ceiling keeps it from pausing on the "Copilot
- * has been working on this problem for a while" continue prompt that nobody is
- * present to dismiss. Persisted in the workspace and intentionally not restored.
- */
+/** Workspace request budget used for scaffolding runs. */
 export const WORKSPACE_MAX_REQUESTS = 9999;
 
 /**
@@ -86,20 +59,14 @@ async function setAutoApproveValue(value: unknown): Promise<void> {
     await settingUtils.updateGlobalSetting(AUTO_APPROVE_KEY, value, AUTO_APPROVE_SECTION);
 }
 
-/**
- * Reads the effective (merged) `chat.agent.maxRequests` value, or undefined if unset.
- */
+/** Gets the effective `chat.agent.maxRequests` value. */
 export function getEffectiveMaxRequests(): number | undefined {
     return settingUtils.getWorkspaceSetting<number>(MAX_REQUESTS_KEY, undefined, MAX_REQUESTS_SECTION);
 }
 
 /**
- * Raises `chat.agent.maxRequests` to {@link WORKSPACE_MAX_REQUESTS} at the Workspace
- * scope so the unattended scaffold -> integrate -> debug chain doesn't stall on the
- * "Copilot has been working on this problem for a while" continue prompt. The value
- * is persisted in the workspace and intentionally never restored. No-op when no
- * workspace folder is open (a workspace setting can't be written) or when the
- * effective value is already at least the target.
+ * Raises workspace `chat.agent.maxRequests` to {@link WORKSPACE_MAX_REQUESTS}
+ * when possible. The value is intentionally left in workspace settings.
  */
 export async function raiseWorkspaceMaxRequests(): Promise<void> {
     const folder = vscode.workspace.workspaceFolders?.[0];
@@ -113,10 +80,7 @@ export async function raiseWorkspaceMaxRequests(): Promise<void> {
     try {
         await settingUtils.updateWorkspaceSetting(MAX_REQUESTS_KEY, WORKSPACE_MAX_REQUESTS, folder.uri.fsPath, MAX_REQUESTS_SECTION, vscode.ConfigurationTarget.Workspace);
     } catch {
-        // `chat.agent.maxRequests` may not be registered on older VS Code builds,
-        // in which case `update` throws. Bumping the limit is a best-effort
-        // convenience, so swallow the error rather than aborting the autopilot
-        // enable flow (or the guided scaffold launch).
+        // Best effort: this setting may not exist on older VS Code versions.
     }
 }
 
@@ -204,8 +168,6 @@ export async function enableAutopilot(context: vscode.ExtensionContext): Promise
     await context.globalState.update(STATE_DEADLINE, deadline);
 
     await setAutoApproveValue(true);
-    // The request limit is bumped at the Workspace scope and intentionally left
-    // in place (not restored) — see WORKSPACE_MAX_REQUESTS.
     await raiseWorkspaceMaxRequests();
     armAutopilot(deadline);
 }
@@ -226,8 +188,6 @@ export async function disableAutopilot(): Promise<void> {
         const prior = context.globalState.get<unknown>(STATE_PRIOR_VALUE);
         // `null` means there was no explicit global value, so clear it.
         await setAutoApproveValue(prior === null ? undefined : prior);
-        // Note: `chat.agent.maxRequests` is deliberately NOT restored — it was
-        // written at the Workspace scope and is left in place.
         await context.globalState.update(STATE_ACTIVE, false);
         await context.globalState.update(STATE_PRIOR_VALUE, undefined);
         await context.globalState.update(STATE_DEADLINE, undefined);

--- a/src/webviews/copilotOnRails/extension/autopilot.ts
+++ b/src/webviews/copilotOnRails/extension/autopilot.ts
@@ -13,7 +13,10 @@ import * as vscode from "vscode";
  * plan -> scaffold -> local-debug chain runs end-to-end without approval gates.
  * To make tool actions (file edits, terminal commands) run unattended, we flip
  * VS Code's global `chat.tools.global.autoApprove` setting on for the duration
- * of the run and restore it afterward.
+ * of the run and restore it afterward. We also raise `chat.agent.maxRequests`
+ * so the long scaffold -> integrate -> debug chain doesn't stall on the
+ * "Copilot has been working on this problem for a while" continue prompt, then
+ * restore the user's prior value when the run ends.
  *
  * Because that setting is global and security-sensitive, restoration is layered:
  *  1. A completion watcher restores it the moment the local debug plan reaches
@@ -29,6 +32,18 @@ import * as vscode from "vscode";
 
 const AUTO_APPROVE_SECTION = 'chat.tools.global';
 const AUTO_APPROVE_KEY = 'autoApprove';
+
+const MAX_REQUESTS_SECTION = 'chat.agent';
+const MAX_REQUESTS_KEY = 'maxRequests';
+
+/**
+ * Request budget granted to a single agent turn while autopilot is active. The
+ * unattended chain (scaffold -> integrate -> local debug) makes many tool calls
+ * per turn; a high ceiling keeps it from pausing on the "Copilot has been
+ * working on this problem for a while" continue prompt that nobody is present
+ * to dismiss. Restored to the user's prior value when the run ends.
+ */
+const AUTOPILOT_MAX_REQUESTS = 9999;
 
 /**
  * Maximum wall-clock duration an autopilot run may keep global auto-approve on.
@@ -46,6 +61,7 @@ export const DEBUG_PLAN_GLOB = '.azure/vscode-debug-plan.md';
 /** globalState keys used to survive window reloads mid-run. */
 const STATE_ACTIVE = 'azureResourceGroups.autopilot.active';
 const STATE_PRIOR_VALUE = 'azureResourceGroups.autopilot.priorAutoApprove';
+const STATE_PRIOR_MAX_REQUESTS = 'azureResourceGroups.autopilot.priorMaxRequests';
 /** Epoch ms after which an active run is considered stale and auto-restored. */
 const STATE_DEADLINE = 'azureResourceGroups.autopilot.deadline';
 
@@ -68,6 +84,18 @@ function getAutoApproveValue(): unknown {
 async function setAutoApproveValue(value: unknown): Promise<void> {
     const config = vscode.workspace.getConfiguration(AUTO_APPROVE_SECTION);
     await config.update(AUTO_APPROVE_KEY, value, vscode.ConfigurationTarget.Global);
+}
+
+function getMaxRequestsValue(): unknown {
+    const config = vscode.workspace.getConfiguration(MAX_REQUESTS_SECTION);
+    // We only ever write at the Global target, so the global value is what we
+    // need to preserve and restore.
+    return config.inspect(MAX_REQUESTS_KEY)?.globalValue;
+}
+
+async function setMaxRequestsValue(value: unknown): Promise<void> {
+    const config = vscode.workspace.getConfiguration(MAX_REQUESTS_SECTION);
+    await config.update(MAX_REQUESTS_KEY, value, vscode.ConfigurationTarget.Global);
 }
 
 function showStatusBarItem(): void {
@@ -147,12 +175,14 @@ export async function enableAutopilot(context: vscode.ExtensionContext): Promise
     // Don't clobber a previously-saved prior value if autopilot is already on.
     if (context.globalState.get<boolean>(STATE_ACTIVE) !== true) {
         await context.globalState.update(STATE_PRIOR_VALUE, getAutoApproveValue() ?? null);
+        await context.globalState.update(STATE_PRIOR_MAX_REQUESTS, getMaxRequestsValue() ?? null);
     }
     const deadline = Date.now() + MAX_RUN_DURATION_MS;
     await context.globalState.update(STATE_ACTIVE, true);
     await context.globalState.update(STATE_DEADLINE, deadline);
 
     await setAutoApproveValue(true);
+    await setMaxRequestsValue(AUTOPILOT_MAX_REQUESTS);
     armAutopilot(deadline);
 }
 
@@ -172,8 +202,11 @@ export async function disableAutopilot(): Promise<void> {
         const prior = context.globalState.get<unknown>(STATE_PRIOR_VALUE);
         // `null` means there was no explicit global value, so clear it.
         await setAutoApproveValue(prior === null ? undefined : prior);
+        const priorMaxRequests = context.globalState.get<unknown>(STATE_PRIOR_MAX_REQUESTS);
+        await setMaxRequestsValue(priorMaxRequests === null ? undefined : priorMaxRequests);
         await context.globalState.update(STATE_ACTIVE, false);
         await context.globalState.update(STATE_PRIOR_VALUE, undefined);
+        await context.globalState.update(STATE_PRIOR_MAX_REQUESTS, undefined);
         await context.globalState.update(STATE_DEADLINE, undefined);
     }
 

--- a/src/webviews/copilotOnRails/extension/autopilot.ts
+++ b/src/webviews/copilotOnRails/extension/autopilot.ts
@@ -14,11 +14,14 @@ import * as vscode from "vscode";
  * To make tool actions (file edits, terminal commands) run unattended, we flip
  * VS Code's global `chat.tools.global.autoApprove` setting on for the duration
  * of the run and restore it afterward. We also raise `chat.agent.maxRequests`
- * so the long scaffold -> integrate -> debug chain doesn't stall on the
- * "Copilot has been working on this problem for a while" continue prompt, then
- * restore the user's prior value when the run ends.
+ * to a high ceiling so the long scaffold -> integrate -> debug chain doesn't
+ * stall on the "Copilot has been working on this problem for a while" continue
+ * prompt — but unlike auto-approve, that limit is written at the *Workspace*
+ * scope and intentionally left in place (it isn't a security-sensitive global,
+ * and a freshly scaffolded workspace benefits from the higher ceiling).
  *
- * Because that setting is global and security-sensitive, restoration is layered:
+ * Because the auto-approve setting is global and security-sensitive, its
+ * restoration is layered:
  *  1. A completion watcher restores it the moment the local debug plan reaches
  *     `Status: Implemented` (the end of the chain).
  *  2. A safety deadline restores it after `MAX_RUN_DURATION_MS` even if the
@@ -37,13 +40,13 @@ const MAX_REQUESTS_SECTION = 'chat.agent';
 const MAX_REQUESTS_KEY = 'maxRequests';
 
 /**
- * Request budget granted to a single agent turn while autopilot is active. The
- * unattended chain (scaffold -> integrate -> local debug) makes many tool calls
- * per turn; a high ceiling keeps it from pausing on the "Copilot has been
- * working on this problem for a while" continue prompt that nobody is present
- * to dismiss. Restored to the user's prior value when the run ends.
+ * Request budget written to `chat.agent.maxRequests` at the Workspace scope while
+ * scaffolding. The unattended chain (scaffold -> integrate -> local debug) makes
+ * many tool calls per turn; a high ceiling keeps it from pausing on the "Copilot
+ * has been working on this problem for a while" continue prompt that nobody is
+ * present to dismiss. Persisted in the workspace and intentionally not restored.
  */
-const AUTOPILOT_MAX_REQUESTS = 9999;
+export const WORKSPACE_MAX_REQUESTS = 9999;
 
 /**
  * Maximum wall-clock duration an autopilot run may keep global auto-approve on.
@@ -61,7 +64,6 @@ export const DEBUG_PLAN_GLOB = '.azure/vscode-debug-plan.md';
 /** globalState keys used to survive window reloads mid-run. */
 const STATE_ACTIVE = 'azureResourceGroups.autopilot.active';
 const STATE_PRIOR_VALUE = 'azureResourceGroups.autopilot.priorAutoApprove';
-const STATE_PRIOR_MAX_REQUESTS = 'azureResourceGroups.autopilot.priorMaxRequests';
 /** Epoch ms after which an active run is considered stale and auto-restored. */
 const STATE_DEADLINE = 'azureResourceGroups.autopilot.deadline';
 
@@ -86,16 +88,31 @@ async function setAutoApproveValue(value: unknown): Promise<void> {
     await config.update(AUTO_APPROVE_KEY, value, vscode.ConfigurationTarget.Global);
 }
 
-function getMaxRequestsValue(): unknown {
-    const config = vscode.workspace.getConfiguration(MAX_REQUESTS_SECTION);
-    // We only ever write at the Global target, so the global value is what we
-    // need to preserve and restore.
-    return config.inspect(MAX_REQUESTS_KEY)?.globalValue;
+/**
+ * Reads the effective (merged) `chat.agent.maxRequests` value, or undefined if unset.
+ */
+export function getEffectiveMaxRequests(): number | undefined {
+    return vscode.workspace.getConfiguration(MAX_REQUESTS_SECTION).get<number>(MAX_REQUESTS_KEY);
 }
 
-async function setMaxRequestsValue(value: unknown): Promise<void> {
+/**
+ * Raises `chat.agent.maxRequests` to {@link WORKSPACE_MAX_REQUESTS} at the Workspace
+ * scope so the unattended scaffold -> integrate -> debug chain doesn't stall on the
+ * "Copilot has been working on this problem for a while" continue prompt. The value
+ * is persisted in the workspace and intentionally never restored. No-op when no
+ * workspace folder is open (a workspace setting can't be written) or when the
+ * effective value is already at least the target.
+ */
+export async function raiseWorkspaceMaxRequests(): Promise<void> {
+    if (!vscode.workspace.workspaceFolders?.length) {
+        return;
+    }
+    const current = getEffectiveMaxRequests();
+    if (typeof current === 'number' && current >= WORKSPACE_MAX_REQUESTS) {
+        return;
+    }
     const config = vscode.workspace.getConfiguration(MAX_REQUESTS_SECTION);
-    await config.update(MAX_REQUESTS_KEY, value, vscode.ConfigurationTarget.Global);
+    await config.update(MAX_REQUESTS_KEY, WORKSPACE_MAX_REQUESTS, vscode.ConfigurationTarget.Workspace);
 }
 
 function showStatusBarItem(): void {
@@ -167,7 +184,8 @@ function registerCompletionWatcher(): void {
 
 /**
  * Enables autopilot: records the user's current global auto-approve value, turns
- * the setting on globally, and arms the status-bar item and completion watcher.
+ * the setting on globally, raises the workspace request limit, and arms the
+ * status-bar item and completion watcher.
  */
 export async function enableAutopilot(context: vscode.ExtensionContext): Promise<void> {
     extensionContext = context;
@@ -175,14 +193,15 @@ export async function enableAutopilot(context: vscode.ExtensionContext): Promise
     // Don't clobber a previously-saved prior value if autopilot is already on.
     if (context.globalState.get<boolean>(STATE_ACTIVE) !== true) {
         await context.globalState.update(STATE_PRIOR_VALUE, getAutoApproveValue() ?? null);
-        await context.globalState.update(STATE_PRIOR_MAX_REQUESTS, getMaxRequestsValue() ?? null);
     }
     const deadline = Date.now() + MAX_RUN_DURATION_MS;
     await context.globalState.update(STATE_ACTIVE, true);
     await context.globalState.update(STATE_DEADLINE, deadline);
 
     await setAutoApproveValue(true);
-    await setMaxRequestsValue(AUTOPILOT_MAX_REQUESTS);
+    // The request limit is bumped at the Workspace scope and intentionally left
+    // in place (not restored) — see WORKSPACE_MAX_REQUESTS.
+    await raiseWorkspaceMaxRequests();
     armAutopilot(deadline);
 }
 
@@ -202,11 +221,10 @@ export async function disableAutopilot(): Promise<void> {
         const prior = context.globalState.get<unknown>(STATE_PRIOR_VALUE);
         // `null` means there was no explicit global value, so clear it.
         await setAutoApproveValue(prior === null ? undefined : prior);
-        const priorMaxRequests = context.globalState.get<unknown>(STATE_PRIOR_MAX_REQUESTS);
-        await setMaxRequestsValue(priorMaxRequests === null ? undefined : priorMaxRequests);
+        // Note: `chat.agent.maxRequests` is deliberately NOT restored — it was
+        // written at the Workspace scope and is left in place.
         await context.globalState.update(STATE_ACTIVE, false);
         await context.globalState.update(STATE_PRIOR_VALUE, undefined);
-        await context.globalState.update(STATE_PRIOR_MAX_REQUESTS, undefined);
         await context.globalState.update(STATE_DEADLINE, undefined);
     }
 

--- a/src/webviews/copilotOnRails/extension/autopilot.ts
+++ b/src/webviews/copilotOnRails/extension/autopilot.ts
@@ -5,6 +5,7 @@
 
 import { AzExtFsExtra } from "@microsoft/vscode-azext-utils";
 import * as vscode from "vscode";
+import { settingUtils } from "../../../utils/settingUtils";
 
 /**
  * Autopilot ("YOLO") mode for the create-project workflow.
@@ -76,23 +77,20 @@ let safetyTimer: ReturnType<typeof setTimeout> | undefined;
 let extensionContext: vscode.ExtensionContext | undefined;
 
 function getAutoApproveValue(): unknown {
-    const config = vscode.workspace.getConfiguration(AUTO_APPROVE_SECTION);
-    const inspected = config.inspect(AUTO_APPROVE_KEY);
     // We only ever write at the Global target, so the global value is what we
     // need to preserve and restore.
-    return inspected?.globalValue;
+    return settingUtils.getGlobalSetting<unknown>(AUTO_APPROVE_KEY, AUTO_APPROVE_SECTION);
 }
 
 async function setAutoApproveValue(value: unknown): Promise<void> {
-    const config = vscode.workspace.getConfiguration(AUTO_APPROVE_SECTION);
-    await config.update(AUTO_APPROVE_KEY, value, vscode.ConfigurationTarget.Global);
+    await settingUtils.updateGlobalSetting(AUTO_APPROVE_KEY, value, AUTO_APPROVE_SECTION);
 }
 
 /**
  * Reads the effective (merged) `chat.agent.maxRequests` value, or undefined if unset.
  */
 export function getEffectiveMaxRequests(): number | undefined {
-    return vscode.workspace.getConfiguration(MAX_REQUESTS_SECTION).get<number>(MAX_REQUESTS_KEY);
+    return settingUtils.getWorkspaceSetting<number>(MAX_REQUESTS_KEY, undefined, MAX_REQUESTS_SECTION);
 }
 
 /**
@@ -104,15 +102,22 @@ export function getEffectiveMaxRequests(): number | undefined {
  * effective value is already at least the target.
  */
 export async function raiseWorkspaceMaxRequests(): Promise<void> {
-    if (!vscode.workspace.workspaceFolders?.length) {
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    if (!folder) {
         return;
     }
     const current = getEffectiveMaxRequests();
     if (typeof current === 'number' && current >= WORKSPACE_MAX_REQUESTS) {
         return;
     }
-    const config = vscode.workspace.getConfiguration(MAX_REQUESTS_SECTION);
-    await config.update(MAX_REQUESTS_KEY, WORKSPACE_MAX_REQUESTS, vscode.ConfigurationTarget.Workspace);
+    try {
+        await settingUtils.updateWorkspaceSetting(MAX_REQUESTS_KEY, WORKSPACE_MAX_REQUESTS, folder.uri.fsPath, MAX_REQUESTS_SECTION);
+    } catch {
+        // `chat.agent.maxRequests` may not be registered on older VS Code builds,
+        // in which case `update` throws. Bumping the limit is a best-effort
+        // convenience, so swallow the error rather than aborting the autopilot
+        // enable flow (or the guided scaffold launch).
+    }
 }
 
 function showStatusBarItem(): void {

--- a/src/webviews/copilotOnRails/extension/autopilot.ts
+++ b/src/webviews/copilotOnRails/extension/autopilot.ts
@@ -111,7 +111,7 @@ export async function raiseWorkspaceMaxRequests(): Promise<void> {
         return;
     }
     try {
-        await settingUtils.updateWorkspaceSetting(MAX_REQUESTS_KEY, WORKSPACE_MAX_REQUESTS, folder.uri.fsPath, MAX_REQUESTS_SECTION);
+        await settingUtils.updateWorkspaceSetting(MAX_REQUESTS_KEY, WORKSPACE_MAX_REQUESTS, folder.uri.fsPath, MAX_REQUESTS_SECTION, vscode.ConfigurationTarget.Workspace);
     } catch {
         // `chat.agent.maxRequests` may not be registered on older VS Code builds,
         // in which case `update` throws. Bumping the limit is a best-effort

--- a/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
@@ -11,11 +11,18 @@ import { ViewColumn } from "vscode";
 import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
 import { ext } from "../../../../extensionVariables";
 import { type PlanData, type PreviewPage } from "../../views/utils/parseScaffoldPlanMarkdown";
-import { AUTOPILOT_QUERY_MARKER, enableAutopilot } from "../autopilot";
+import { AUTOPILOT_QUERY_MARKER, enableAutopilot, getEffectiveMaxRequests, raiseWorkspaceMaxRequests } from "../autopilot";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
 import { openLoadingView } from "../openLoadingView";
 import { PREVIEW_FOLDER_RELATIVE_PATH, readPreviewPages, type PreviewPagesResult } from "../utils/previewPagesReader";
 import { openSourceFileOrWarn } from "../utils/singletonViewHost";
+
+/**
+ * Below this `chat.agent.maxRequests` ceiling, a guided (non-autopilot) scaffold
+ * run risks pausing partway through on the "Copilot has been working on this
+ * problem for a while" continue prompt. We offer to raise the limit once.
+ */
+const MIN_RECOMMENDED_MAX_REQUESTS = 1000;
 
 export class ScaffoldPlanViewController extends WebviewController<Record<string, never>> {
     private sourceFileUri: vscode.Uri | undefined;
@@ -103,6 +110,10 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
         if (confirmedAutopilot) {
             await this.recordAutopilotMode();
             await enableAutopilot(ext.context);
+        } else {
+            // Autopilot already raises the request limit; for guided runs, warn the
+            // user if their limit is low enough that scaffolding could stall.
+            await this.ensureRequestBudget();
         }
 
         const baseQuery = vscode.l10n.t('I approve the plan.');
@@ -116,6 +127,43 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
             stage: 0,
             title: vscode.l10n.t('Scaffolding your project…'),
             message: vscode.l10n.t('Copilot is creating your project files. For progress please view the Copilot chat.'),
+        });
+    }
+
+    /**
+     * For guided runs, warns the user when `chat.agent.maxRequests` is low enough
+     * that scaffolding could stall on the continue prompt, and offers to raise it
+     * once at the Workspace scope. Non-blocking: declining proceeds as-is.
+     */
+    private async ensureRequestBudget(): Promise<void> {
+        const current = getEffectiveMaxRequests();
+        if (typeof current === 'number' && current >= MIN_RECOMMENDED_MAX_REQUESTS) {
+            return;
+        }
+        // A workspace setting can't be written without an open folder, so there's
+        // nothing to offer.
+        if (!vscode.workspace.workspaceFolders?.length) {
+            return;
+        }
+        await callWithTelemetryAndErrorHandling('azureResourceGroups.scaffold.requestBudgetWarning', async (context: IActionContext) => {
+            context.errorHandling.suppressDisplay = true;
+            const yes: vscode.MessageItem = { title: vscode.l10n.t('Yes') };
+            // `isCloseAffordance` relabels the modal's default Cancel button to
+            // "No" (Esc/X still dismisses), and makes that choice resolve
+            // normally instead of throwing UserCancelledError.
+            const no: vscode.MessageItem = { title: vscode.l10n.t('No'), isCloseAffordance: true };
+            const result = await context.ui.showWarningMessage(
+                vscode.l10n.t('Raise the chat request limit for this workspace?'),
+                {
+                    modal: true,
+                    detail: vscode.l10n.t('Your chat request limit (chat.agent.maxRequests) is low, so Copilot may pause partway through scaffolding and ask you to continue. Raise the limit for this workspace so scaffolding can run without interruption?'),
+                },
+                yes,
+                no,
+            );
+            if (result === yes) {
+                await raiseWorkspaceMaxRequests();
+            }
         });
     }
 

--- a/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
@@ -83,7 +83,7 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
                     vscode.l10n.t('Approve this plan and run the rest in Autopilot mode?'),
                     {
                         modal: true,
-                        detail: vscode.l10n.t('Autopilot scaffolds and sets up local debugging without stopping for further approvals. While it runs, all chat tool actions (including file edits and terminal commands) are auto-approved globally. You can turn this off any time from the status bar.'),
+                        detail: vscode.l10n.t('Autopilot scaffolds and sets up local debugging without stopping for further approvals. While it runs, all chat tool actions (including file edits and terminal commands) are auto-approved globally, and the chat request limit is raised so the run doesn\'t pause partway through. You can turn this off any time from the status bar.'),
                     },
                     { title: vscode.l10n.t('Enable Autopilot') },
                 );

--- a/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
@@ -17,11 +17,7 @@ import { openLoadingView } from "../openLoadingView";
 import { PREVIEW_FOLDER_RELATIVE_PATH, readPreviewPages, type PreviewPagesResult } from "../utils/previewPagesReader";
 import { openSourceFileOrWarn } from "../utils/singletonViewHost";
 
-/**
- * Below this `chat.agent.maxRequests` ceiling, a guided (non-autopilot) scaffold
- * run risks pausing partway through on the "Copilot has been working on this
- * problem for a while" continue prompt. We offer to raise the limit once.
- */
+/** Prompt to raise max requests for guided runs below this threshold. */
 const MIN_RECOMMENDED_MAX_REQUESTS = 1000;
 
 export class ScaffoldPlanViewController extends WebviewController<Record<string, never>> {
@@ -79,9 +75,6 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
     }
 
     private async approveAndOpenScaffoldChat(autopilot: boolean): Promise<void> {
-        // Autopilot is chosen on the plan page. Approving with it on requires an
-        // explicit modal confirmation because it enables global auto-approval of
-        // chat tool actions for the rest of the run.
         let confirmedAutopilot = false;
         if (autopilot) {
             confirmedAutopilot = await callWithTelemetryAndErrorHandling('azureResourceGroups.autopilot.confirm', async (context: IActionContext) => {
@@ -96,8 +89,6 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
                 );
                 return true;
             }) ?? false;
-            // Cancelling the modal aborts approval entirely so the user can decide
-            // again (rather than silently falling back to a guided approval).
             if (!confirmedAutopilot) {
                 return;
             }
@@ -111,8 +102,6 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
             await this.recordAutopilotMode();
             await enableAutopilot(ext.context);
         } else {
-            // Autopilot already raises the request limit; for guided runs, warn the
-            // user if their limit is low enough that scaffolding could stall.
             await this.ensureRequestBudget();
         }
 
@@ -130,27 +119,18 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
         });
     }
 
-    /**
-     * For guided runs, warns the user when `chat.agent.maxRequests` is low enough
-     * that scaffolding could stall on the continue prompt, and offers to raise it
-     * once at the Workspace scope. Non-blocking: declining proceeds as-is.
-     */
+    /** For guided runs, optionally raises `chat.agent.maxRequests`. */
     private async ensureRequestBudget(): Promise<void> {
         const current = getEffectiveMaxRequests();
         if (typeof current === 'number' && current >= MIN_RECOMMENDED_MAX_REQUESTS) {
             return;
         }
-        // A workspace setting can't be written without an open folder, so there's
-        // nothing to offer.
         if (!vscode.workspace.workspaceFolders?.length) {
             return;
         }
         await callWithTelemetryAndErrorHandling('azureResourceGroups.scaffold.requestBudgetWarning', async (context: IActionContext) => {
             context.errorHandling.suppressDisplay = true;
             const yes: vscode.MessageItem = { title: vscode.l10n.t('Yes') };
-            // `isCloseAffordance` relabels the modal's default Cancel button to
-            // "No" (Esc/X still dismisses), and makes that choice resolve
-            // normally instead of throwing UserCancelledError.
             const no: vscode.MessageItem = { title: vscode.l10n.t('No'), isCloseAffordance: true };
             const result = await context.ui.showWarningMessage(
                 vscode.l10n.t('Raise the chat request limit for this workspace?'),


### PR DESCRIPTION
<img width="432" height="161" alt="image" src="https://github.com/user-attachments/assets/632f72e8-3ae7-4250-8dd4-4a83b905e289" />

When running the Copilot on Rails scaffold flow, a low chat.agent.maxRequests limit causes Copilot to pause partway through with a "continue to iterate?" prompt. This PR raises that limit to a high ceiling at the Workspace scope so scaffolding can run uninterrupted — for both autopilot and guided runs.

**Changes**
Autopilot (autopilot.ts): replaced the temporary global maxRequests override (saved/restored) with a persistent Workspace bump (WORKSPACE_MAX_REQUESTS = 9999) that is intentionally not restored. Added getEffectiveMaxRequests() and raiseWorkspaceMaxRequests() helpers (no-op when no workspace folder is open or the limit is already high enough). The global chat.tools.global.autoApprove toggle is still saved and restored as before.
Guided scaffold (ScaffoldPlanViewController.ts): when the effective limit is below 1000, shows a Yes/No modal asking whether to raise the request limit for the workspace before launching the scaffold chat. "Yes" raises it; "No" (the modal's close affordance) proceeds unchanged. Skipped for autopilot (which already bumps it) and for the debug plan.
**Notes**
The workspace setting is written to settings.json and left in place by design.
chat.tools.global.autoApprove remains global and is always restored after an autopilot run.