### PR TITLE
Add "Create with Copilot" button when no folder is opened 

### DIFF
--- a/package.json
+++ b/package.json
@@ -521,6 +521,10 @@
                 "view": "azureResourceGroups",
                 "contents": "Please sign in to a specific tenant (directory) to continue. \n [Sign in to Tenant (Directory)...](command:azureResourceGroups.signInToTenant)\n[View Accounts & Tenants](command:azureTenantsView.focus)",
                 "when": "azureResourceGroups.needsTenantAuth == true"
+            },
+            {
+                "view": "workbench.explorer.emptyView",
+                "contents": "%azureProject.emptyExplorerWelcomeContent%"
             }
         ],
         "menus": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -72,5 +72,6 @@
     "azureResourceGroups.openLocalNextStepsView": "Open Local Next Steps View",
     "azureResourceGroups.openScaffoldNextStepsView": "Open Scaffold Next Steps View",
     "azureProject.viewName": "Azure Project",
-    "azureProject.welcomeContent": "Use Copilot to plan and create a complete application that's configured for Azure services and setup for local development.\n[Create New Project With Copilot](command:azureResourceGroups.createProjectWithCopilot)"
+    "azureProject.welcomeContent": "Use Copilot to plan and create a complete application that's configured for Azure services and setup for local development.\n[Create New Project With Copilot](command:azureResourceGroups.createProjectWithCopilot)",
+    "azureProject.emptyExplorerWelcomeContent": "Use Copilot to plan and create a complete application that's configured for Azure services and setup for local development.\n[Create New Project With Copilot](command:azureResourceGroups.createProjectWithCopilot)"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,7 @@ import { WorkspaceResourceBranchDataProviderManager } from './tree/workspace/Wor
 import { registerWorkspaceTree } from './tree/workspace/registerWorkspaceTree';
 import { createResourceClient } from './utils/azureClients';
 import { disableAutopilot, registerAutopilot } from './webviews/copilotOnRails/extension/autopilot';
+import { resumePendingCreateWithCopilot } from './webviews/copilotOnRails/extension/createProjectWithCopilot';
 import { registerRequirementsAutoOpen } from './webviews/copilotOnRails/extension/openRequirementsView';
 
 export async function activate(context: vscode.ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }): Promise<apiUtils.AzureExtensionApiProvider> {
@@ -126,6 +127,7 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
         }));
 
         registerCommands();
+        void resumePendingCreateWithCopilot(context);
         survey(context);
 
         registerChatStandInParticipantIfNeeded(context);

--- a/src/webviews/copilotOnRails/extension/createProjectWithCopilot.ts
+++ b/src/webviews/copilotOnRails/extension/createProjectWithCopilot.ts
@@ -5,13 +5,48 @@
 
 import { type IActionContext } from "@microsoft/vscode-azext-utils";
 import * as vscode from 'vscode';
+import { ext } from "../../../extensionVariables";
 import { CreateProjectViewController } from "./controllers/CreateProjectViewController";
 import { copilotOnRailsCommandIds } from "./copilotOnRailsCommands";
 
 const localDev = vscode.l10n.t('Local Development');
 const deploy = vscode.l10n.t('Deploy');
 
+/**
+ * globalState key holding the epoch-ms deadline until which a pending "Create
+ * with Copilot" request should auto-resume after a folder is opened.
+ */
+const PENDING_CREATE_DEADLINE_KEY = 'azureResourceGroups.createProjectWithCopilot.pendingDeadline';
+/** How long a pending create request stays valid across a window reload. */
+const PENDING_CREATE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * If the user previously pressed "Create with Copilot" without an open folder
+ * and chose to open one, re-runs the command once the folder is open. Call this
+ * during activation. No-ops when there's no pending request or it has expired.
+ */
+export async function resumePendingCreateWithCopilot(context: vscode.ExtensionContext): Promise<void> {
+    const deadline = context.globalState.get<number>(PENDING_CREATE_DEADLINE_KEY);
+    if (deadline === undefined) {
+        return;
+    }
+
+    // Consume the flag regardless of outcome so it only ever fires once.
+    await context.globalState.update(PENDING_CREATE_DEADLINE_KEY, undefined);
+
+    const folders = vscode.workspace.workspaceFolders;
+    if (Date.now() > deadline || !folders || folders.length === 0) {
+        return;
+    }
+
+    await vscode.commands.executeCommand(copilotOnRailsCommandIds.createProjectWithCopilot);
+}
+
 export async function createProjectWithCopilot(_context: IActionContext): Promise<void> {
+    if (!(await ensureWorkspaceOpen())) {
+        return;
+    }
+
     // Local Development => Deploy
     if (await hasCompletedPhase('.azure/vscode-debug-plan.md', 'implemented')) {
         const choice = await vscode.window.showInformationMessage(
@@ -53,6 +88,37 @@ export async function createProjectWithCopilot(_context: IActionContext): Promis
         planButtonLabel: vscode.l10n.t('Plan'),
     });
     controller.revealToForeground();
+}
+
+/**
+ * Ensures there is an open folder/workspace to create the project in. If none is
+ * open, prompts the user to open or create one. Returns true when a workspace is
+ * (already) open and the flow can continue, false otherwise.
+ */
+async function ensureWorkspaceOpen(): Promise<boolean> {
+    const folders = vscode.workspace.workspaceFolders;
+    if (folders && folders.length > 0) {
+        return true;
+    }
+
+    const openFolder = vscode.l10n.t('Open Folder...');
+    const newWindow = vscode.l10n.t('New Empty Window');
+
+    const choice = await vscode.window.showInformationMessage(
+        vscode.l10n.t('Creating a project with Copilot requires an open folder. Open or create an empty folder to continue.'),
+        { modal: true },
+        openFolder,
+        newWindow,
+    );
+
+    if (choice === openFolder) {
+        await ext.context.globalState.update(PENDING_CREATE_DEADLINE_KEY, Date.now() + PENDING_CREATE_TIMEOUT_MS);
+        await vscode.commands.executeCommand('workbench.action.files.openFolder');
+    } else if (choice === newWindow) {
+        await vscode.commands.executeCommand('workbench.action.newWindow');
+    }
+
+    return false;
 }
 
 async function hasCompletedPhase(filePath: string, expectedStatus: string): Promise<boolean> {


### PR DESCRIPTION
Here is how it looks: 
<img width="712" height="1392" alt="image" src="https://github.com/user-attachments/assets/e294791b-ef91-414f-b4ee-14b3477901e1" />

After the button is pressed it asks if you want to create or open a folder. After the folder is opened it will auto open the landing page so the user doesn't have to go back and press the button again.