### PR TITLE
Add loading view for Running API tests 

### DIFF
--- a/src/webviews/copilotOnRails/extension/controllers/LocalDevNextStepsViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/LocalDevNextStepsViewController.ts
@@ -11,6 +11,7 @@ import { azureDebugGenerateAgent } from "../../../../constants";
 import { ext } from "../../../../extensionVariables";
 import { type LocalDevNextStepsViewConfiguration } from "../../views/utils/viewConfigTypes";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
+import { openLoadingView } from "../openLoadingView";
 
 type NextStepAction = 'iterate' | 'apiTests' | 'deploy';
 
@@ -54,6 +55,11 @@ export class LocalDevNextStepsViewController extends WebviewController<LocalDevN
                 await vscode.commands.executeCommand('workbench.action.chat.open', {
                     mode: azureDebugGenerateAgent,
                     query: vscode.l10n.t('Run the API tests to verify my endpoints.'),
+                });
+                openLoadingView({
+                    stage: 1,
+                    title: vscode.l10n.t('Running your API tests…'),
+                    message: vscode.l10n.t('Copilot is executing the generated API test collection. For progress please view the Copilot chat.'),
                 });
                 return;
             case 'deploy':


### PR DESCRIPTION
I noticed yesterday after pressing the next steps option to run API tests that there was no loading view that came up after. I am going back and forth on if it is appropriate to have a loading view in this case since users have to interact with the chat a bit to get the tests running. But on the other hand it is nice to have the loading view for congruency 

I added a message in there to look at the chat for progress and let me know if this is something we wouldn't want to have. 