### PR TITLE
CoR: Add browser detection as part of identifying prerequisites and align generated tasks against that

### DIFF
--- a/resources/agents/azure-debug-generate.agent.md
+++ b/resources/agents/azure-debug-generate.agent.md
@@ -86,7 +86,7 @@ Preface the options with the following statement:
 
 Adjust the prefacing statement to omit the "run API tests or" portion if API tests were not generated.
 
-Then ask the user what they would like to do next. Check `.azure/vscode-debug-plan.md` to determine whether API test collections were generated (i.e., the plan's Services table includes API test entries marked for generation). Present options conditionally:
+Then ask the user what they would like to do next. Ask this as a plain open chat question (regular chat text) — do **NOT** call `vscode_askQuestions` or any other interactive question API for it. Keep calling the Next Steps view as described above; only the follow-up question itself must stay in chat. Check `.azure/vscode-debug-plan.md` to determine whether API test collections were generated (i.e., the plan's Services table includes API test entries marked for generation). Present options conditionally:
 
 - **Always offer:** "Keep iterating" and "Deploy to Azure"
 - **Only offer "Run API tests"** if the plan included API test collection generation.

--- a/resources/agents/azure-debug-generate/references/project-types/frontend-spa/debug-adapters/chromium.md
+++ b/resources/agents/azure-debug-generate/references/project-types/frontend-spa/debug-adapters/chromium.md
@@ -6,8 +6,10 @@
 
 | Browser | VS Code Debugger Type | Required Extension |
 |---------|----------------------|-------------------|
-| Chrome | `chrome` — default | None — built-in |
+| Chrome | `chrome` | None — built-in |
 | Edge | `msedge` | None — built-in |
+
+Use the browser recorded in the plan's Prerequisites section (see [prerequisites.md](../../../../../shared-references/prerequisites.md) § Browser detection) to pick the `type`.
 
 ---
 
@@ -26,7 +28,7 @@
 
 | Field | Source |
 |-------|--------|
-| `type` | Browser Debugger Type from table above — default to `chrome` |
+| `type` | Browser Debugger Type from table above — matches the browser recorded in the plan's Prerequisites (`chrome` for Chrome, `msedge` for Edge) |
 | `url` | Default Port from [frontend-spa.md § Framework Lookup Table](../frontend-spa.md) |
 | `webRoot` | **Framework root** — see `webRoot` Resolution below |
 | `preLaunchTask` | `{id} dev` — the dev server task from [frontend-spa.md § VS Code Task Configuration](../frontend-spa.md) |

--- a/resources/agents/azure-debug-generate/references/project-types/frontend-spa/frontend-spa.md
+++ b/resources/agents/azure-debug-generate/references/project-types/frontend-spa/frontend-spa.md
@@ -22,7 +22,7 @@ Match against these signals to classify a workspace root as a frontend SPA. If t
 
 ## Prerequisites
 
-No project-type-specific tools required. Browser debugging uses VS Code's built-in capabilities. Runtime prerequisites (e.g., Node.js) are listed in `runtimes/{rt}.md § Prerequisites`.
+No VS Code extension is required — browser debugging uses VS Code's built-in adapter. A Chromium-based browser (Chrome or Edge) must be installed, though; that is captured as a Debug prerequisite via [prerequisites.md](../../../../shared-references/prerequisites.md) § Browser detection. Runtime prerequisites (e.g., Node.js) are listed in `runtimes/{rt}.md § Prerequisites`.
 
 ---
 
@@ -88,7 +88,7 @@ Use this table to resolve per-framework values when generating the VS Code confi
 
 ### VS Code Debug Configuration
 
-The request mode is always `launch` (VS Code opens the browser). Default to `chrome` — the user can change the browser in the plan before approval.
+The request mode is always `launch` (VS Code opens the browser). The browser (Chrome or Edge) is the one recorded in the plan's Prerequisites section during the browser detection pass (see [prerequisites.md](../../../../shared-references/prerequisites.md) § Browser detection) — use its debug adapter `type` (`chrome` for Chrome, `msedge` for Edge). The user can change the browser in the plan before approval.
 
 Look up the launch configuration template from the corresponding adapter file in [`debug-adapters/`](debug-adapters/):
 
@@ -171,7 +171,7 @@ Use the `Ready Pattern (begins)` and `Ready Pattern (ends)` columns from the **F
 After generating `launch.json` and `tasks.json`, verify the following were produced correctly:
 
 1. ✅ Dev server task exists in `tasks.json` with a custom `background` problem matcher using the correct begin/end patterns from the Framework Lookup Table
-2. ✅ `launch.json` uses the correct browser debug adapter (e.g., `chrome`) with `"request": "launch"`
+2. ✅ `launch.json` uses the browser debug adapter matching the browser recorded in the plan's Prerequisites (`chrome` or `msedge`) with `"request": "launch"`
 3. ✅ `launch.json` `url` matches the framework's default port from the Framework Lookup Table
 4. ✅ `launch.json` `preLaunchTask` points to the dev server task
 

--- a/resources/agents/shared-references/prerequisites.md
+++ b/resources/agents/shared-references/prerequisites.md
@@ -36,7 +36,7 @@ Dependencies that are required to run the project locally. If a run tool is miss
 
 ### Debug Tools
 
-Tooling needed to debug the project locally, not just to run it through the terminal. Two independent kinds of entries belong here and both must be evaluated every time: container tooling (Docker, Docker Compose) for any Azure-dependency emulators, and the VS Code debug-integration extension for each detected project type that has a matching row in the table below. The extensions are required for the debug experience — task types, problem matchers, launch integration — even when the project has no Azure emulator dependencies and even when the matching CLI or runtime tool already appears in the Run group.
+Tooling needed to debug the project locally, not just to run it through the terminal. Three independent kinds of entries belong here and all must be evaluated every time: container tooling (Docker, Docker Compose) for any Azure-dependency emulators; a Chromium-based browser (Chrome or Edge) for any frontend project type that debugs in a browser; and the VS Code debug-integration extension for each detected project type that has a matching row in the table below. The extensions are required for the debug experience — task types, problem matchers, launch integration — even when the project has no Azure emulator dependencies and even when the matching CLI or runtime tool already appears in the Run group.
 
 This table is the **authoritative list** — include every row whose trigger matches the project, and maintainers must add any new debug tool or extension here so it is considered. Some project types require a specific VS Code extension for the debug experience (e.g. Azure Functions needs the Functions extension for its `func` task type and problem matchers), so do not infer these from memory — take them from this table.
 
@@ -46,7 +46,10 @@ Prefer to use the debug tools listed here. Also, never list VS Code itself — t
 |------------------|----------|----------------------|-------------|
 | Docker | Container runtime | Project has Azure dependencies that run as local emulators | `docker --version` |
 | Docker Compose | Orchestrator | Orchestrating emulators | Do not detect — always record as unknown (`❓`), version `—` (see Docker Compose detection in Phase 2) |
+| Chrome or Edge | Browser | Project has a frontend/SPA project type that debugs in a browser | See Browser detection in Phase 2 — detect Chrome/Edge; if neither is found, fall back by OS |
 | `ms-azuretools.vscode-azurefunctions` | VS Code extension | Has an Azure Functions service | extensions filesystem check (Phase 2); installed (`✅`) if found, otherwise unknown (`❓`) — never not-installed |
+
+For a frontend project that debugs in a browser, always include a single browser row (Chrome or Edge). Unlike the Docker Compose and VS Code extension rows, the browser resolves to installed (`✅`) or not-installed (`❌`) from a real scan — see Browser detection in Phase 2. Record the **specific browser chosen** (Chrome or Edge) in the row name; the generate phase reads it to pick the frontend debug adapter `type` (`chrome` for Chrome, `msedge` for Edge).
 
 Always emit a Debug row for every VS Code extension whose project type is present. Run the Phase 2 filesystem check: if the extension folder is found, record it installed (`✅`); if it is not found, record it as unknown (`❓`), never as not-installed (`❌`) — the folder scan can come up empty in restricted shells even when the extension is installed. Never drop the row just because the extension wasn't found, and never treat it as already covered by a Run tool. For example, an Azure Functions project must include a `ms-azuretools.vscode-azurefunctions` row even though Azure Functions Core Tools already appears under Run — the Core Tools CLI and the extension are separate prerequisites.
 
@@ -116,3 +119,39 @@ Get-ChildItem "$env:USERPROFILE\.vscode\extensions", "$env:USERPROFILE\.vscode-i
 ```
 
 The extensions to check come from the **VS Code debug-integration extensions** table in Phase 1 — that table is the authoritative list. Detect each one with the extensions filesystem check above. If the check finds the extension folder, record it installed (`✅`); if it finds nothing, record it as unknown (`❓`), never as not-installed (`❌`) — the scan can come up empty in restricted shells even when the extension is installed. An unknown status is not counted as a missing tool.
+
+---
+
+### Browser detection
+
+Only when the project has a frontend/SPA project type that debugs in a browser. Frontend debugging launches a Chromium-based browser — Chrome or Edge — so detect which one is already installed and record **that** browser. The chosen browser drives the generated debug config `type`: Chrome → `chrome`, Edge → `msedge`.
+
+Detect both, then choose in this order:
+
+1. If **Chrome** is installed, choose Chrome and record it installed (`✅`) with its version if available.
+2. Otherwise if **Edge** is installed, choose Edge and record it installed (`✅`) with its version if available.
+3. If **neither** is installed, fall back by operating system and record the fallback as not-installed (`❌`) with its download URL in the Install column:
+   - **Windows** → Edge (`msedge`). Edge ships with Windows and is normally detected as installed in step 2, so this fallback rarely triggers.
+   - **macOS / Linux** → Chrome (`chrome`).
+
+Unlike Docker Compose and VS Code extensions, the browser is a normal detection — it resolves to installed (`✅`) or not-installed (`❌`); never record it as unknown (`❓`).
+
+```bash
+# macOS — installed if the app bundle exists
+ls -d "/Applications/Google Chrome.app" 2>/dev/null   # Chrome
+ls -d "/Applications/Microsoft Edge.app" 2>/dev/null  # Edge
+```
+
+```bash
+# Linux — installed if any binary resolves
+which google-chrome google-chrome-stable chromium chromium-browser 2>/dev/null   # Chrome / Chromium
+which microsoft-edge microsoft-edge-stable 2>/dev/null                            # Edge
+```
+
+```powershell
+# Windows — installed if any path exists
+Test-Path "$env:ProgramFiles\Google\Chrome\Application\chrome.exe", "${env:ProgramFiles(x86)}\Google\Chrome\Application\chrome.exe"  # Chrome
+Test-Path "$env:ProgramFiles\Microsoft\Edge\Application\msedge.exe", "${env:ProgramFiles(x86)}\Microsoft\Edge\Application\msedge.exe"  # Edge
+```
+
+Download URLs for the Install column: Chrome `https://www.google.com/chrome/`, Edge `https://www.microsoft.com/edge`.


### PR DESCRIPTION
Also includes a small change to next steps where I tell it to avoid running the VS Code ask questions API.

Example:
<img width="1922" height="932" alt="image" src="https://github.com/user-attachments/assets/4298e520-c079-481d-8a7f-8980ecc0da8f" />
