### PR TITLE
Wait for custom agents before launch

### DIFF
--- a/src/commands/copilotOnRails/openChatWithAgent.ts
+++ b/src/commands/copilotOnRails/openChatWithAgent.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { ext } from '../../extensionVariables';
 import { projectSubmissionState } from '../../tree/project/projectSubmissionState';
 import { openLoadingView } from '../../webviews/copilotOnRails/extension/openLoadingView';
 import { recordAgentLaunch } from '../../webviews/copilotOnRails/extension/projectSession';
@@ -11,6 +12,10 @@ import { type LoadingViewConfiguration } from '../../webviews/copilotOnRails/vie
 import { ensureAgentInstructions } from './agentInstructions';
 
 const COPILOT_CHAT_EXTENSION_ID = 'GitHub.copilot-chat';
+const CUSTOM_AGENT_COMMAND_PREFIX = 'workbench.action.chat.open';
+const CUSTOM_AGENT_LOAD_TIMEOUT_MS = 10_000;
+const CUSTOM_AGENT_LOAD_POLL_INTERVAL_MS = 100;
+let agentLaunchInProgress = false;
 
 /**
  * Ensure the GitHub Copilot Chat extension is installed and activated before invoking
@@ -41,14 +46,61 @@ export async function ensureCopilotChatReady(): Promise<boolean> {
  * keeps each agent's context window focused on its own phase instead of
  * accumulating the entire plan → scaffold → debug conversation.
  */
-export async function launchAgentChat(agentName: string, query: string): Promise<void> {
-    await vscode.commands.executeCommand('workbench.action.chat.newChat');
-    await vscode.commands.executeCommand('workbench.action.chat.open', {
-        mode: agentName,
-        query,
-    });
+async function waitForCustomAgentCommand(agentName: string): Promise<string | undefined> {
+    const commandId = `${CUSTOM_AGENT_COMMAND_PREFIX}${agentName}`;
+    const deadline = Date.now() + CUSTOM_AGENT_LOAD_TIMEOUT_MS;
+
+    do {
+        if ((await vscode.commands.getCommands()).includes(commandId)) {
+            return commandId;
+        }
+        await new Promise(resolve => setTimeout(resolve, CUSTOM_AGENT_LOAD_POLL_INTERVAL_MS));
+    } while (Date.now() < deadline);
+
+    return undefined;
+}
+
+export async function launchAgentChat(agentName: string, query: string): Promise<boolean> {
+    if (agentLaunchInProgress) {
+        void vscode.window.showWarningMessage(
+            vscode.l10n.t('Another Copilot agent is still starting. Please wait and try again.'),
+        );
+        return false;
+    }
+
+    agentLaunchInProgress = true;
+    try {
+        // Revealing chat initializes its custom-mode registry. The agent-specific
+        // command appears only after VS Code has finished loading that registry.
+        await vscode.commands.executeCommand('workbench.action.chat.open');
+        const commandId = await waitForCustomAgentCommand(agentName);
+        if (!commandId) {
+            void vscode.window.showErrorMessage(
+                vscode.l10n.t('The "{0}" Copilot agent did not finish loading. Please try again.', agentName),
+            );
+            return false;
+        }
+
+        await vscode.commands.executeCommand('workbench.action.chat.newChat');
+        await vscode.commands.executeCommand(commandId, { query });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        void vscode.window.showErrorMessage(
+            vscode.l10n.t('The "{0}" Copilot agent could not be started: {1}', agentName, message),
+        );
+        return false;
+    } finally {
+        agentLaunchInProgress = false;
+    }
+
     // Record the phase we just launched so an interrupted run can be resumed.
-    await recordAgentLaunch(agentName);
+    try {
+        await recordAgentLaunch(agentName);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        ext.outputChannel.warn(vscode.l10n.t('Could not record the "{0}" Copilot agent launch: {1}', agentName, message));
+    }
+    return true;
 }
 
 export async function openChatWithAgent(agentName: string, prompt: string, loading?: LoadingViewConfiguration): Promise<void> {
@@ -59,7 +111,9 @@ export async function openChatWithAgent(agentName: string, prompt: string, loadi
     if (!(await ensureAgentInstructions(agentName))) {
         return;
     }
-    await launchAgentChat(agentName, prompt);
+    if (!(await launchAgentChat(agentName, prompt))) {
+        return;
+    }
 
     if (loading) {
         projectSubmissionState.setPending(loading.stage);

--- a/src/webviews/copilotOnRails/extension/controllers/CreateProjectViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/CreateProjectViewController.ts
@@ -46,8 +46,10 @@ export class CreateProjectViewController extends WebviewController<CreateProject
         if (!(await ensureAgentInstructions('azure-project-plan'))) {
             return;
         }
+        if (!(await launchAgentChat(azureProjectPlanAgent, query))) {
+            return;
+        }
         this.panel.dispose();
-        await launchAgentChat(azureProjectPlanAgent, query);
         projectSubmissionState.setPending();
         openLoadingView({
             stage: 0,

--- a/src/webviews/copilotOnRails/extension/controllers/RequirementsViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/RequirementsViewController.ts
@@ -80,6 +80,10 @@ export class RequirementsViewController extends WebviewController<Record<string,
 
         const relativePath = vscode.workspace.asRelativePath(this.sourceFileUri);
         if (await ensureAgentInstructions('azure-project-plan')) {
+            const query = vscode.l10n.t('Requirements submitted at {0} — read the file and continue generating .azure/project-plan.md.', relativePath);
+            if (!(await launchAgentChat(azureProjectPlanAgent, query))) {
+                return;
+            }
             // Programmatic hand-off to the plan phase — don't treat this close as the user abandoning the flow.
             suppressTrackedViewCloseOnce();
             this.panel.dispose();
@@ -88,12 +92,6 @@ export class RequirementsViewController extends WebviewController<Record<string,
                 title: vscode.l10n.t('Generating your project plan…'),
                 message: vscode.l10n.t('Copilot is using your answers to build .azure/project-plan.md. The plan view will open automatically when it’s ready.'), showNeedHelp: true,
             });
-            const query = vscode.l10n.t('Requirements submitted at {0} — read the file and continue generating .azure/project-plan.md.', relativePath);
-            try {
-                await launchAgentChat(azureProjectPlanAgent, query);
-            } catch {
-                // Chat may not be available; saving still succeeded.
-            }
         }
     }
 }

--- a/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
@@ -13,7 +13,7 @@ import { launchAgentChat } from "../../../../commands/copilotOnRails/openChatWit
 import { azureProjectScaffoldAgent } from "../../../../constants";
 import { ext } from "../../../../extensionVariables";
 import { type PlanData, type PreviewPage } from "../../views/utils/parseScaffoldPlanMarkdown";
-import { AUTOPILOT_QUERY_MARKER, enableAutopilot, getEffectiveMaxRequests, raiseWorkspaceMaxRequests } from "../autopilot";
+import { AUTOPILOT_QUERY_MARKER, disableAutopilot, enableAutopilot, getEffectiveMaxRequests, raiseWorkspaceMaxRequests } from "../autopilot";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
 import { openLoadingView } from "../openLoadingView";
 import { suppressTrackedViewCloseOnce } from "../projectSession";
@@ -133,15 +133,25 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
             return;
         }
 
+        const planBeforeAutopilot = confirmedAutopilot
+            ? await this.recordAutopilotMode()
+            : undefined;
         if (confirmedAutopilot) {
-            await this.recordAutopilotMode();
             await enableAutopilot(ext.context);
         } else {
             await this.ensureRequestBudget();
         }
 
         const baseQuery = vscode.l10n.t('I approve the plan.');
-        await launchAgentChat(azureProjectScaffoldAgent, confirmedAutopilot ? `${AUTOPILOT_QUERY_MARKER} ${baseQuery}` : baseQuery);
+        if (!(await launchAgentChat(azureProjectScaffoldAgent, confirmedAutopilot ? `${AUTOPILOT_QUERY_MARKER} ${baseQuery}` : baseQuery))) {
+            if (confirmedAutopilot) {
+                await disableAutopilot();
+                if (planBeforeAutopilot !== undefined && this.sourceFileUri) {
+                    await vscode.workspace.fs.writeFile(this.sourceFileUri, Buffer.from(planBeforeAutopilot, 'utf-8'));
+                }
+            }
+            return;
+        }
         // Programmatic hand-off to the scaffold phase — don't treat this close as the user abandoning the flow.
         suppressTrackedViewCloseOnce();
         this.panel.dispose();
@@ -183,9 +193,10 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
 
     /**
      * Records autopilot mode in the plan file for downstream agents to reference.
-     * No-op if the source file is unknown or autopilot is already recorded.
+     * Returns the previous content when the file changed so a failed launch can
+     * restore it. No-ops if the source file is unknown or autopilot is already recorded.
      */
-    private async recordAutopilotMode(): Promise<void> {
+    private async recordAutopilotMode(): Promise<string | undefined> {
         if (!this.sourceFileUri) {
             return;
         }
@@ -202,7 +213,7 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
             if (existingAt >= 0) {
                 lines[existingAt] = row;
                 await vscode.workspace.fs.writeFile(this.sourceFileUri, Buffer.from(lines.join('\n'), 'utf-8'));
-                return;
+                return raw;
             }
             // Insert the metadata row next to the existing **Mode**/**Status**
             // header lines; otherwise after the first heading; otherwise at the top.
@@ -219,9 +230,11 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
                 lines.splice(insertAt + 1, 0, row);
             }
             await vscode.workspace.fs.writeFile(this.sourceFileUri, Buffer.from(lines.join('\n'), 'utf-8'));
+            return raw;
         } catch {
             // Best-effort: if we can't persist the marker, the chat query marker
             // still carries autopilot into the scaffold agent.
+            return undefined;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a race in the Copilot-on-Rails custom-agent selection/launch flow. When handing off between workflow phases (plan → scaffold → debug), we previously invoked the generic `workbench.action.chat.open` with the agent name as `mode` before VS Code had finished registering the agent-specific chat command. Depending on timing, the launch could land in the wrong agent/mode or silently no-op.

## Changes

- **Reveal chat, then wait for the agent-specific command.** `launchAgentChat` now first reveals chat (which initializes the custom-mode registry), then polls `vscode.commands.getCommands()` for the dynamically registered `workbench.action.chat.open<agentName>` command (10s timeout, 100ms interval) before invoking it.
- **Prevent concurrent launches.** A module-level `agentLaunchInProgress` guard rejects overlapping launches and warns the user instead of stacking chat commands.
- **Surface failures.** Timeouts and thrown errors now show an error message; `launchAgentChat` returns a `boolean` success signal.
- **Don't advance workflow panels on failure.** Callers (`CreateProjectViewController`, `RequirementsViewController`, `ScaffoldPlanViewController`) now launch the agent *before* disposing their panel / opening the loading view and bail out early if the launch fails.
- **Roll back Autopilot on scaffold-launch failure.** `ScaffoldPlanViewController` captures the pre-Autopilot plan content, and if the scaffold launch fails it calls `disableAutopilot()` and restores the plan file's previous metadata.
- Recording the agent launch is now best-effort (logged, non-fatal).

## Validation

- `npm run build` (esbuild + webviews + `tsc --noEmit`) — passes
- `npm run lint` (eslint, `--max-warnings 0`) — passes
- Manually confirmed the fix in an Extension Development Host.