### PR TITLE
Add a model selector to the landing page 

### DIFF
--- a/src/commands/copilotOnRails/openChatWithAgent.ts
+++ b/src/commands/copilotOnRails/openChatWithAgent.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { ext } from '../../extensionVariables';
 import { projectSubmissionState } from '../../tree/project/projectSubmissionState';
 import { openLoadingView } from '../../webviews/copilotOnRails/extension/openLoadingView';
-import { recordAgentLaunch } from '../../webviews/copilotOnRails/extension/projectSession';
+import { getSessionModel, recordAgentLaunch } from '../../webviews/copilotOnRails/extension/projectSession';
 import { type LoadingViewConfiguration } from '../../webviews/copilotOnRails/views/utils/viewConfigTypes';
 import { ensureAgentInstructions } from './agentInstructions';
 
@@ -16,6 +16,40 @@ const CUSTOM_AGENT_COMMAND_PREFIX = 'workbench.action.chat.open';
 const CUSTOM_AGENT_LOAD_TIMEOUT_MS = 10_000;
 const CUSTOM_AGENT_LOAD_POLL_INTERVAL_MS = 100;
 let agentLaunchInProgress = false;
+
+/**
+ * Resolves a user-facing model name (e.g. "Claude Opus 4.7 (copilot)") to a
+ * modelSelector object that VS Code's chat commands expect.
+ */
+async function resolveModelSelector(displayName: string): Promise<{ id?: string; vendor?: string } | undefined> {
+    try {
+        const models = await vscode.lm.selectChatModels();
+        // Try matching by "Name (vendor)" format: e.g. "Claude Opus 4.7 (copilot)"
+        const vendorMatch = displayName.match(/^(.+?)\s*\((\w+)\)\s*$/);
+        if (vendorMatch) {
+            const [, name, vendor] = vendorMatch;
+            const match = models.find(
+                (m) => m.name === name.trim() && m.vendor === vendor,
+            );
+            if (match) {
+                return { id: match.id, vendor: match.vendor };
+            }
+        }
+        // Try matching by name alone
+        const byName = models.find((m) => m.name === displayName);
+        if (byName) {
+            return { id: byName.id, vendor: byName.vendor };
+        }
+        // Try matching by id (in case the caller already has the id)
+        const byId = models.find((m) => m.id === displayName);
+        if (byId) {
+            return { id: byId.id, vendor: byId.vendor };
+        }
+    } catch {
+        // If the lm API isn't available, fall through
+    }
+    return undefined;
+}
 
 /**
  * Ensure the GitHub Copilot Chat extension is installed and activated before invoking
@@ -60,7 +94,7 @@ async function waitForCustomAgentCommand(agentName: string): Promise<string | un
     return undefined;
 }
 
-export async function launchAgentChat(agentName: string, query: string): Promise<boolean> {
+export async function launchAgentChat(agentName: string, query: string, model?: string): Promise<boolean> {
     if (agentLaunchInProgress) {
         void vscode.window.showWarningMessage(
             vscode.l10n.t('Another Copilot agent is still starting. Please wait and try again.'),
@@ -82,7 +116,17 @@ export async function launchAgentChat(agentName: string, query: string): Promise
         }
 
         await vscode.commands.executeCommand('workbench.action.chat.newChat');
-        await vscode.commands.executeCommand(commandId, { query });
+        const resolvedModel = model ?? getSessionModel();
+        if (resolvedModel) {
+            const selector = await resolveModelSelector(resolvedModel);
+            await vscode.commands.executeCommand('workbench.action.chat.open', {
+                mode: agentName,
+                query,
+                ...(selector ? { modelSelector: selector } : {}),
+            });
+        } else {
+            await vscode.commands.executeCommand(commandId, { query });
+        }
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         void vscode.window.showErrorMessage(
@@ -119,4 +163,17 @@ export async function openChatWithAgent(agentName: string, prompt: string, loadi
         projectSubmissionState.setPending(loading.stage);
         openLoadingView(loading);
     }
+}
+
+/**
+ * Builds the options object for a direct `workbench.action.chat.open` call,
+ * automatically including the session's model selection when one is stored.
+ */
+export async function buildChatOpenOptions(options: { mode?: string; query: string }): Promise<{ mode?: string; query: string; modelSelector?: { id?: string; vendor?: string } }> {
+    const model = getSessionModel();
+    if (model) {
+        const selector = await resolveModelSelector(model);
+        return selector ? { ...options, modelSelector: selector } : options;
+    }
+    return options;
 }

--- a/src/webviews/copilotOnRails/extension/controllers/CreateProjectViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/CreateProjectViewController.ts
@@ -15,6 +15,7 @@ import { recordCreatedAt, recordPrompt } from "../../../../utils/copilotOnRails/
 import { type CreateProjectViewControllerType } from "../../views/utils/viewConfigTypes";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
 import { openLoadingView } from "../openLoadingView";
+import { recordModel } from "../projectSession";
 
 export type { CreateProjectViewControllerType };
 
@@ -23,13 +24,13 @@ export class CreateProjectViewController extends WebviewController<CreateProject
         super(ext.context, viewConfig.title, 'createProjectView', viewConfig, ViewColumn.Active, undefined, getCopilotOnRailsBundleLocation());
 
         this.panel.webview.onDidReceiveMessage(
-            (message: { command: string; prompt?: string }) => {
+            (message: { command: string; prompt?: string; model?: string }) => {
                 switch (message.command) {
                     case 'plan':
                         if (message.prompt) {
                             recordPrompt(message.prompt);
                             recordCreatedAt();
-                            void this.openChatWithQuery(message.prompt);
+                            void this.openChatWithQuery(message.prompt, message.model);
                         } else {
                             this.panel.dispose();
                         }
@@ -39,14 +40,17 @@ export class CreateProjectViewController extends WebviewController<CreateProject
         );
     }
 
-    private async openChatWithQuery(query: string): Promise<void> {
+    private async openChatWithQuery(query: string, model?: string): Promise<void> {
+        if (model) {
+            await recordModel(model);
+        }
         if (!(await ensureCopilotChatReady())) {
             return;
         }
         if (!(await ensureAgentInstructions('azure-project-plan'))) {
             return;
         }
-        if (!(await launchAgentChat(azureProjectPlanAgent, query))) {
+        if (!(await launchAgentChat(azureProjectPlanAgent, query, model))) {
             return;
         }
         this.panel.dispose();

--- a/src/webviews/copilotOnRails/extension/controllers/DeploymentPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/DeploymentPlanViewController.ts
@@ -7,6 +7,7 @@ import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
+import { buildChatOpenOptions } from "../../../../commands/copilotOnRails/openChatWithAgent";
 import { azureDeployAgent } from "../../../../constants";
 import { ext } from "../../../../extensionVariables";
 import { type DeploymentPlanData } from "../../views/utils/deploymentPlanTypes";
@@ -109,10 +110,10 @@ export class DeploymentPlanViewController extends WebviewController<DeploymentPl
         if (!isFeedback) {
             await vscode.commands.executeCommand('workbench.action.chat.newChat');
         }
-        await vscode.commands.executeCommand('workbench.action.chat.open', {
+        await vscode.commands.executeCommand('workbench.action.chat.open', await buildChatOpenOptions({
             mode: azureDeployAgent,
             query,
-        });
+        }));
         if (isFeedback) {
             void this.panel.webview.postMessage({ command: 'revisionInProgress' });
         }

--- a/src/webviews/copilotOnRails/extension/controllers/FrontendPreviewViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/FrontendPreviewViewController.ts
@@ -7,13 +7,14 @@ import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
+import { buildChatOpenOptions } from "../../../../commands/copilotOnRails/openChatWithAgent";
 import { azureProjectScaffoldAgent } from "../../../../constants";
 import { ext } from "../../../../extensionVariables";
 import { PROJECT_PLAN_FILE_GLOB } from "../../../../tree/project/projectPlanFiles";
+import { ProjectPlanStatus } from "../../views/utils/projectPlanStatus";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
 import { type RunningDevServer, startDevServer } from "../utils/devServerManager";
 import { writeProjectPlanStatus } from "../utils/planStatus";
-import { ProjectPlanStatus } from "../../views/utils/projectPlanStatus";
 
 /** State pushed to the webview to drive the preview surface. */
 type PreviewState =
@@ -130,10 +131,10 @@ export class FrontendPreviewViewController extends WebviewController<Record<stri
         }
         // Keep the dev server running so the scaffold agent's edits hot-reload
         // in the iframe while the user watches.
-        void vscode.commands.executeCommand('workbench.action.chat.open', {
+        void buildChatOpenOptions({
             mode: azureProjectScaffoldAgent,
             query,
-        });
+        }).then((options) => vscode.commands.executeCommand('workbench.action.chat.open', options));
         void this.panel.webview.postMessage({ command: 'feedbackSubmitted' });
     }
 

--- a/src/webviews/copilotOnRails/extension/controllers/LocalDevNextStepsViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/LocalDevNextStepsViewController.ts
@@ -6,7 +6,7 @@
 import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
-import { ensureCopilotChatReady } from "../../../../commands/copilotOnRails/openChatWithAgent";
+import { buildChatOpenOptions, ensureCopilotChatReady } from "../../../../commands/copilotOnRails/openChatWithAgent";
 import { azureDebugGenerateAgent } from "../../../../constants";
 import { ext } from "../../../../extensionVariables";
 import { type LocalDevNextStepsViewConfiguration } from "../../views/utils/viewConfigTypes";
@@ -43,19 +43,19 @@ export class LocalDevNextStepsViewController extends WebviewController<LocalDevN
                 }
                 this.panel.dispose();
                 await vscode.commands.executeCommand('workbench.view.debug');
-                await vscode.commands.executeCommand('workbench.action.chat.open', {
+                await vscode.commands.executeCommand('workbench.action.chat.open', await buildChatOpenOptions({
                     query: vscode.l10n.t('I want to keep iterating on my project'),
-                });
+                }));
                 return;
             case 'apiTests':
                 if (!(await ensureCopilotChatReady())) {
                     return;
                 }
                 this.panel.dispose();
-                await vscode.commands.executeCommand('workbench.action.chat.open', {
+                await vscode.commands.executeCommand('workbench.action.chat.open', await buildChatOpenOptions({
                     mode: azureDebugGenerateAgent,
                     query: vscode.l10n.t('Run the API tests to verify my endpoints.'),
-                });
+                }));
                 openLoadingView({
                     stage: 1,
                     title: vscode.l10n.t('Running your API tests…'),

--- a/src/webviews/copilotOnRails/extension/controllers/LocalPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/LocalPlanViewController.ts
@@ -9,6 +9,7 @@ import { getCorProjectId } from "src/utils/copilotOnRails/copilotOnRailsTelemetr
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
+import { buildChatOpenOptions } from "../../../../commands/copilotOnRails/openChatWithAgent";
 import { azureDebugPlanAgent } from "../../../../constants";
 import { ext } from "../../../../extensionVariables";
 import { type LocalPlanData } from "../../views/utils/parseLocalPlanMarkdown";
@@ -78,10 +79,10 @@ export class LocalPlanViewController extends WebviewController<Record<string, ne
             // it iterates on the plan with the existing conversation.
             await vscode.commands.executeCommand('workbench.action.chat.newChat');
         }
-        await vscode.commands.executeCommand('workbench.action.chat.open', {
+        await vscode.commands.executeCommand('workbench.action.chat.open', await buildChatOpenOptions({
             mode: azureDebugPlanAgent,
             query,
-        });
+        }));
         if (isFeedback) {
             void this.panel.webview.postMessage({ command: 'revisionInProgress' });
         }
@@ -110,10 +111,10 @@ export class LocalPlanViewController extends WebviewController<Record<string, ne
             }
             this._isRefreshingPrereqs = true;
             void this.panel.webview.postMessage({ command: 'prerequisitesRefreshing' });
-            await vscode.commands.executeCommand('workbench.action.chat.open', {
+            await vscode.commands.executeCommand('workbench.action.chat.open', await buildChatOpenOptions({
                 mode: azureDebugPlanAgent,
                 query: 'Re-check the prerequisites section only. Re-run the installed/version checks for every tool and extension in the Prerequisites table and update the plan file with the current results.',
-            });
+            }));
             if (this._refreshPrereqsTimer) {
                 clearTimeout(this._refreshPrereqsTimer);
             }

--- a/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
@@ -9,7 +9,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
-import { launchAgentChat } from "../../../../commands/copilotOnRails/openChatWithAgent";
+import { buildChatOpenOptions, launchAgentChat } from "../../../../commands/copilotOnRails/openChatWithAgent";
 import { azureProjectScaffoldAgent } from "../../../../constants";
 import { ext } from "../../../../extensionVariables";
 import { type PlanData, type PreviewPage } from "../../views/utils/parseScaffoldPlanMarkdown";
@@ -63,10 +63,10 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
                     if (!query) {
                         return;
                     }
-                    void vscode.commands.executeCommand('workbench.action.chat.open', {
+                    void buildChatOpenOptions({
                         mode: 'agent',
                         query,
-                    });
+                    }).then((options) => vscode.commands.executeCommand('workbench.action.chat.open', options));
                     void this.panel.webview.postMessage({ command: 'revisionInProgress' });
                     break;
                 }
@@ -265,10 +265,10 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
                 ? 'Re-check the prerequisites section only. Re-run the installed/version checks for every tool and extension in the Prerequisites tables and update the plan file with the current results.'
                 : 'Re-check the prerequisites section only. Re-run the installed/version checks for every tool and extension in the Run Prerequisites table only and update the plan file with the current results.';
 
-            await vscode.commands.executeCommand('workbench.action.chat.open', {
+            await vscode.commands.executeCommand('workbench.action.chat.open', await buildChatOpenOptions({
                 mode: 'azure-project-plan',
                 query,
-            });
+            }));
 
             if (this._refreshPrereqsTimer) {
                 clearTimeout(this._refreshPrereqsTimer);

--- a/src/webviews/copilotOnRails/extension/createProjectWithCopilot.ts
+++ b/src/webviews/copilotOnRails/extension/createProjectWithCopilot.ts
@@ -87,6 +87,12 @@ export async function createProjectWithCopilot(_context: IActionContext): Promis
         promptPlaceholder: vscode.l10n.t('Describe your project...'),
         hint: vscode.l10n.t('Ctrl+Enter to plan'),
         planButtonLabel: vscode.l10n.t('Plan'),
+        modelLabel: vscode.l10n.t('Model'),
+        modelOptions: [
+            'Claude Opus 4.6 (copilot)',
+            'Claude Opus 4.7 (copilot)',
+            'Claude Sonnet 4.6 (copilot)',
+        ],
     });
     controller.revealToForeground();
 }

--- a/src/webviews/copilotOnRails/extension/projectSession.ts
+++ b/src/webviews/copilotOnRails/extension/projectSession.ts
@@ -43,6 +43,8 @@ export interface CopilotSessionState {
     updatedAt: number;
     /** Workspace-relative `.azure/*` artifacts to reference when resuming this phase. */
     contextRefs: string[];
+    /** The language model selected by the user on the landing page, threaded across all phases. */
+    model?: string;
 }
 
 /** The single workspaceState key holding {@link CopilotSessionState}. */
@@ -130,11 +132,29 @@ async function writeSessionState(state: CopilotSessionState | undefined): Promis
  */
 export async function recordPhase(phase: ProjectPhase): Promise<void> {
     sessionActiveInWindow = true;
+    const prev = readSessionState();
     await writeSessionState({
         phase,
         updatedAt: Date.now(),
         contextRefs: PHASE_CONFIG[phase].contextRefs,
+        model: prev?.model,
     });
+}
+
+/** Stores the user's model selection into the session so it persists across phases. */
+export async function recordModel(model: string): Promise<void> {
+    const prev = readSessionState();
+    if (prev) {
+        await writeSessionState({ ...prev, model, updatedAt: Date.now() });
+    } else {
+        // No session yet — store it pre-emptively so the first recordPhase picks it up.
+        await writeSessionState({ phase: 'plan', updatedAt: Date.now(), contextRefs: [], model });
+    }
+}
+
+/** Returns the model the user selected on the landing page, if any. */
+export function getSessionModel(): string | undefined {
+    return readSessionState()?.model;
 }
 
 /** Records a phase launch given the chat agent name. No-op for unknown agents. */

--- a/src/webviews/copilotOnRails/views/CreateProjectView.tsx
+++ b/src/webviews/copilotOnRails/views/CreateProjectView.tsx
@@ -15,6 +15,9 @@ export const CreateProjectView = (): JSX.Element => {
     const [prompt, setPrompt] = useState('');
     const { vscodeApi } = useContext(WebviewContext);
     const config = useConfiguration<CreateProjectViewControllerType>();
+    const [selectedModel, setSelectedModel] = useState(config.modelOptions[0] ?? '');
+
+    const displayName = (model: string) => model.replace(/\s*\(copilot\)\s*$/i, '');
 
     const planClicked = () => {
         if (!prompt.trim()) {
@@ -23,6 +26,7 @@ export const CreateProjectView = (): JSX.Element => {
         vscodeApi.postMessage({
             command: 'plan',
             prompt: prompt.trim(),
+            model: selectedModel,
         });
     };
 
@@ -56,7 +60,18 @@ export const CreateProjectView = (): JSX.Element => {
                         resize='vertical'
                     />
                     <div className='promptActions'>
-                        <span className='hint'>{config.hint}</span>
+                        <div className='actionsLeft'>
+                            <select
+                                className='modelDropdown'
+                                value={selectedModel}
+                                onChange={(e) => setSelectedModel(e.target.value)}
+                            >
+                                {config.modelOptions.map((model) => (
+                                    <option key={model} value={model}>{displayName(model)}</option>
+                                ))}
+                            </select>
+                            <span className='hint'>{config.hint}</span>
+                        </div>
                         <div className='buttonGroup'>
                             <Button
                                 appearance='primary'

--- a/src/webviews/copilotOnRails/views/styles/createProjectView.scss
+++ b/src/webviews/copilotOnRails/views/styles/createProjectView.scss
@@ -119,10 +119,36 @@
                 border-top: 1px solid var(--vscode-widget-border);
                 background: var(--vscode-editor-background);
 
-                .hint {
-                    font-size: 0.75em;
-                    color: var(--vscode-descriptionForeground);
-                    user-select: none;
+                .actionsLeft {
+                    display: flex;
+                    align-items: center;
+                    gap: 10px;
+
+                    .modelDropdown {
+                        font-size: 0.9em;
+                        color: var(--vscode-foreground);
+                        background: transparent;
+                        border: none;
+                        border-bottom: 1px solid var(--vscode-widget-border);
+                        padding: 2px 4px;
+                        cursor: pointer;
+                        outline: none;
+
+                        &:focus {
+                            border-bottom-color: var(--vscode-focusBorder);
+                        }
+
+                        option {
+                            background: var(--vscode-dropdown-background);
+                            color: var(--vscode-dropdown-foreground);
+                        }
+                    }
+
+                    .hint {
+                        font-size: 0.75em;
+                        color: var(--vscode-descriptionForeground);
+                        user-select: none;
+                    }
                 }
 
                 .buttonGroup {

--- a/src/webviews/copilotOnRails/views/utils/viewConfigTypes.ts
+++ b/src/webviews/copilotOnRails/views/utils/viewConfigTypes.ts
@@ -10,6 +10,8 @@ export type CreateProjectViewControllerType = {
     promptPlaceholder: string;
     hint: string;
     planButtonLabel: string;
+    modelLabel: string;
+    modelOptions: string[];
 }
 
 export type DeploymentPlanViewStrings = {


### PR DESCRIPTION
Here is how it looks: 
<img width="897" height="588" alt="image" src="https://github.com/user-attachments/assets/98bf238a-9304-42e9-ac90-b7c9764c765e" />

I tested this and it carries over between agent changes. Currently Claude Opus 4.6 is the default model in the dropdown. 