### PR TITLE
Add a warning for when the GHC4A extension/skills are not installed when trying to deploy

### DIFF
--- a/src/chat/chatStandIn.ts
+++ b/src/chat/chatStandIn.ts
@@ -5,13 +5,12 @@
 
 import { callWithTelemetryAndErrorHandling, IActionContext, registerCommand } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
+import { gitHubCopilotForAzureExtensionId } from '../constants';
 import { settingUtils } from '../utils/settingUtils';
 import { askAgentAboutResourcePrompt } from './askAgentAboutResource';
 
-const GitHubCopilotForAzureExtensionId = 'ms-azuretools.vscode-azure-github-copilot';
-
 export function registerChatStandInParticipantIfNeeded(context: vscode.ExtensionContext): void {
-    const ghcp4aInstalled = vscode.extensions.getExtension(GitHubCopilotForAzureExtensionId) !== undefined;
+    const ghcp4aInstalled = vscode.extensions.getExtension(gitHubCopilotForAzureExtensionId) !== undefined;
     const enableChatStandIn = vscode.workspace.getConfiguration('azureResourceGroups').get<boolean | undefined>('enableChatStandIn');
 
     if (ghcp4aInstalled || // If the GitHub Copilot for Azure extension is already installed, don't register the chat participant
@@ -55,7 +54,7 @@ async function chatStandIn(
 
 async function installGitHubCopilotForAzureFromChat(context: IActionContext): Promise<void> {
     try {
-        await vscode.commands.executeCommand('workbench.extensions.installExtension', GitHubCopilotForAzureExtensionId);
+        await vscode.commands.executeCommand('workbench.extensions.installExtension', gitHubCopilotForAzureExtensionId);
     } catch {
         // Almost certainly the user cancelled the installation
         context.telemetry.properties.result = 'Canceled';

--- a/src/commands/copilotOnRails/deploymentPrerequisites.ts
+++ b/src/commands/copilotOnRails/deploymentPrerequisites.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { homedir } from 'node:os';
+import * as vscode from 'vscode';
 import { gitHubCopilotForAzureExtensionId } from '../../constants';
 
 const azurePrepareSkillName = 'azure-prepare';

--- a/src/commands/copilotOnRails/deploymentPrerequisites.ts
+++ b/src/commands/copilotOnRails/deploymentPrerequisites.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { homedir } from 'node:os';
+import { gitHubCopilotForAzureExtensionId } from '../../constants';
+
+const azurePrepareSkillName = 'azure-prepare';
+const skillFileName = 'SKILL.md';
+const installAzureSkillsLocallyCommandId = '@azure.installAzureSkillsLocally';
+
+async function fileExists(uri: vscode.Uri): Promise<boolean> {
+    try {
+        const stat = await vscode.workspace.fs.stat(uri);
+        return (stat.type & vscode.FileType.File) !== 0;
+    } catch {
+        return false;
+    }
+}
+
+async function hasAzurePrepareSkill(): Promise<boolean> {
+    const roots = [
+        vscode.Uri.joinPath(vscode.Uri.file(homedir()), '.agents'),
+        ...(vscode.workspace.workspaceFolders?.map(folder => vscode.Uri.joinPath(folder.uri, '.agents')) ?? []),
+    ];
+    for (const root of roots) {
+        if (await fileExists(vscode.Uri.joinPath(root, 'skills', azurePrepareSkillName, skillFileName))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export async function ensureAzureDeploymentPrerequisites(): Promise<boolean> {
+    let copilotForAzure = vscode.extensions.getExtension(gitHubCopilotForAzureExtensionId);
+    const hasSkill = await hasAzurePrepareSkill();
+    if (copilotForAzure && hasSkill) {
+        return true;
+    }
+
+    const install = copilotForAzure ? vscode.l10n.t('Install Skill') : vscode.l10n.t('Install');
+    const message = copilotForAzure
+        ? vscode.l10n.t('Deployment requires the "{0}" skill from GitHub Copilot for Azure. Install the skill to continue?', azurePrepareSkillName)
+        : vscode.l10n.t('Deployment requires the GitHub Copilot for Azure extension and its "{0}" skill. Install the extension to continue?', azurePrepareSkillName);
+    const choice = await vscode.window.showWarningMessage(message, { modal: true }, install);
+    if (choice !== install) {
+        return false;
+    }
+
+    try {
+        if (!copilotForAzure) {
+            await vscode.commands.executeCommand('workbench.extensions.installExtension', gitHubCopilotForAzureExtensionId);
+            copilotForAzure = vscode.extensions.getExtension(gitHubCopilotForAzureExtensionId);
+        }
+        if (!copilotForAzure) {
+            throw new Error('GitHub Copilot for Azure was not installed.');
+        }
+
+        await copilotForAzure.activate();
+        if (!(await hasAzurePrepareSkill())) {
+            await vscode.commands.executeCommand(installAzureSkillsLocallyCommandId);
+        }
+        if (await hasAzurePrepareSkill()) {
+            return true;
+        }
+    } catch {
+        // The install command rejects when installation is canceled or fails.
+    }
+
+    void vscode.window.showErrorMessage(
+        vscode.l10n.t('GitHub Copilot for Azure with the "{0}" skill is required to start deployment.', azurePrepareSkillName),
+    );
+    return false;
+}

--- a/src/commands/copilotOnRails/openChatWithAgent.ts
+++ b/src/commands/copilotOnRails/openChatWithAgent.ts
@@ -145,14 +145,16 @@ export async function launchAgentChat(agentName: string, query: string, model?: 
 }
 
 export async function openChatWithAgent(agentName: string, prompt: string, loading?: LoadingViewConfiguration): Promise<void> {
-    if (agentName === azureDeployAgent && !(await ensureAzureDeploymentPrerequisites())) {
-        return;
+    if (agentName === azureDeployAgent) {
+        if (!(await ensureAzureDeploymentPrerequisites())) {
+            return;
+        }
+    } else {
+        if (!(await ensureAgentInstructions(agentName))) {
+            return;
+        }
     }
     if (!(await ensureCopilotChatReady())) {
-        return;
-    }
-    // Deployment uses the azure-prepare skill instead of the workspace scaffold/debug instructions.
-    if (agentName !== azureDeployAgent && !(await ensureAgentInstructions(agentName))) {
         return;
     }
     if (!(await launchAgentChat(agentName, prompt))) {

--- a/src/commands/copilotOnRails/openChatWithAgent.ts
+++ b/src/commands/copilotOnRails/openChatWithAgent.ts
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { azureDeployAgent } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { projectSubmissionState } from '../../tree/project/projectSubmissionState';
 import { openLoadingView } from '../../webviews/copilotOnRails/extension/openLoadingView';
 import { getSessionModel, recordAgentLaunch } from '../../webviews/copilotOnRails/extension/projectSession';
 import { type LoadingViewConfiguration } from '../../webviews/copilotOnRails/views/utils/viewConfigTypes';
 import { ensureAgentInstructions } from './agentInstructions';
+import { ensureAzureDeploymentPrerequisites } from './deploymentPrerequisites';
 
 const COPILOT_CHAT_EXTENSION_ID = 'GitHub.copilot-chat';
 const CUSTOM_AGENT_COMMAND_PREFIX = 'workbench.action.chat.open';
@@ -117,16 +119,11 @@ export async function launchAgentChat(agentName: string, query: string, model?: 
 
         await vscode.commands.executeCommand('workbench.action.chat.newChat');
         const resolvedModel = model ?? getSessionModel();
-        if (resolvedModel) {
-            const selector = await resolveModelSelector(resolvedModel);
-            await vscode.commands.executeCommand('workbench.action.chat.open', {
-                mode: agentName,
-                query,
-                ...(selector ? { modelSelector: selector } : {}),
-            });
-        } else {
-            await vscode.commands.executeCommand(commandId, { query });
-        }
+        const selector = resolvedModel ? await resolveModelSelector(resolvedModel) : undefined;
+        await vscode.commands.executeCommand(commandId, {
+            query,
+            ...(selector ? { modelSelector: selector } : {}),
+        });
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         void vscode.window.showErrorMessage(
@@ -148,6 +145,9 @@ export async function launchAgentChat(agentName: string, query: string, model?: 
 }
 
 export async function openChatWithAgent(agentName: string, prompt: string, loading?: LoadingViewConfiguration): Promise<void> {
+    if (agentName === azureDeployAgent && !(await ensureAzureDeploymentPrerequisites())) {
+        return;
+    }
     if (!(await ensureCopilotChatReady())) {
         return;
     }

--- a/src/commands/copilotOnRails/openChatWithAgent.ts
+++ b/src/commands/copilotOnRails/openChatWithAgent.ts
@@ -151,8 +151,8 @@ export async function openChatWithAgent(agentName: string, prompt: string, loadi
     if (!(await ensureCopilotChatReady())) {
         return;
     }
-    // Make sure the agent's instruction files are present in the workspace before invoking it.
-    if (!(await ensureAgentInstructions(agentName))) {
+    // Deployment uses the azure-prepare skill instead of the workspace scaffold/debug instructions.
+    if (agentName !== azureDeployAgent && !(await ensureAgentInstructions(agentName))) {
         return;
     }
     if (!(await launchAgentChat(agentName, prompt))) {

--- a/src/commands/copilotOnRails/registerCopilotOnRailsCommands.ts
+++ b/src/commands/copilotOnRails/registerCopilotOnRailsCommands.ts
@@ -104,8 +104,8 @@ export function startAzureDebugGenerateCommand(_context: CopilotOnRailsContext, 
     });
 }
 
-export function startDeploymentCommand(_context: CopilotOnRailsContext, prompt?: string): Promise<void> {
-    return openChatWithAgent(copilotOnRailsCustomAgents.azureDeployCustomAgent, prompt ?? 'Prepare the project for deployment to Azure — generate `.azure/deployment-plan.md`, then the infrastructure (Bicep or Terraform), `azure.yaml`, and any Dockerfiles needed for `azd up`.', {
+export async function startDeploymentCommand(_context: CopilotOnRailsContext, prompt?: string): Promise<void> {
+    await openChatWithAgent(copilotOnRailsCustomAgents.azureDeployCustomAgent, prompt ?? 'Prepare the project for deployment to Azure — generate `.azure/deployment-plan.md`, then the infrastructure (Bicep or Terraform), `azure.yaml`, and any Dockerfiles needed for `azd up`.', {
         stage: 2,
         title: l10n.t('Preparing deployment…'),
         message: l10n.t('Copilot is preparing your deployment plan.'),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@
 import { l10n } from 'vscode';
 
 export const resourcesExtensionId: string = 'ms-azuretools.vscode-azureresourcegroups';
+export const gitHubCopilotForAzureExtensionId = 'ms-azuretools.vscode-azure-github-copilot';
 export const azureResourceProviderId: string = 'vscode-azureresourcegroups.azureResourceProvider';
 export const contributesKey = 'x-azResources';
 // every group id has a groupBySetting/value format, so just following it

--- a/src/webviews/copilotOnRails/extension/controllers/DeploymentPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/DeploymentPlanViewController.ts
@@ -7,7 +7,6 @@ import { callWithTelemetryAndErrorHandling, type IActionContext } from "@microso
 import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
-import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
 import { buildChatOpenOptions } from "../../../../commands/copilotOnRails/openChatWithAgent";
 import { azureDeployAgent } from "../../../../constants";
 import { ext } from "../../../../extensionVariables";
@@ -20,9 +19,6 @@ import { DEPLOYMENT_PLAN_TELEMETRY_PREFIX, getDeploymentPlanTelemetry } from "..
 import { openSourceFileOrWarn } from "../utils/singletonViewHost";
 
 export type { DeploymentPlanViewConfiguration, DeploymentPlanViewStrings };
-
-/** Telemetry property key recording whether agent instructions were successfully ensured. */
-const ENSURE_AGENT_INSTRUCTIONS_KEY = 'ensureAgentInstructions';
 
 /** Localized strings rendered by the deployment plan webview. */
 function getDeploymentPlanViewStrings(): DeploymentPlanViewStrings {
@@ -129,13 +125,6 @@ export class DeploymentPlanViewController extends WebviewController<DeploymentPl
     }
 
     private async trySubmitPlanApproval(context: CopilotOnRailsContext): Promise<boolean> {
-        if (!(await ensureAgentInstructions(azureDeployAgent))) {
-            setCorProp(context, ENSURE_AGENT_INSTRUCTIONS_KEY, false);
-            setCorProp(context, 'approvalOutcome', 'agentInstructionsMissing');
-            return false;
-        }
-        setCorProp(context, ENSURE_AGENT_INSTRUCTIONS_KEY, true);
-
         // Fresh chat session for the approval hand-off so the next phase starts with a clean context window.
         await vscode.commands.executeCommand('workbench.action.chat.newChat');
         await vscode.commands.executeCommand('workbench.action.chat.open', await buildChatOpenOptions({
@@ -150,13 +139,6 @@ export class DeploymentPlanViewController extends WebviewController<DeploymentPl
     private async trySubmitPlanFeedback(query: string): Promise<boolean> {
         return await callWithTelemetryAndErrorHandling('copilotOnRails.submitDeploymentPlanFeedback', async (actionContext: IActionContext) => {
             return await callWithDiagnosticsAndTelemetryHandling(actionContext, { type: 'webviewAction', name: 'submitDeploymentPlanFeedback' }, async (context: CopilotOnRailsContext) => {
-                if (!(await ensureAgentInstructions(azureDeployAgent))) {
-                    setCorProp(context, ENSURE_AGENT_INSTRUCTIONS_KEY, false);
-                    setCorProp(context, 'feedbackOutcome', 'agentInstructionsMissing');
-                    return false;
-                }
-                setCorProp(context, ENSURE_AGENT_INSTRUCTIONS_KEY, true);
-
                 // Reuse the current session so the agent iterates on the plan with the existing conversation.
                 await vscode.commands.executeCommand('workbench.action.chat.open', await buildChatOpenOptions({
                     mode: azureDeployAgent,


### PR DESCRIPTION
Once a user goes from the local deb to deploy phase we check to see if the GHC4A extension is installed and if the azure prepare skill is installed. If not it will warn the user to install to continue. If the user clicks install the extension and the skills will be installed into the folder that is being used utilizing the `@azure: Install Azure Skills Locally` command