### PR TITLE
Write the status for approved project plan

### DIFF
--- a/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
@@ -16,10 +16,12 @@ import { ext } from "../../../../extensionVariables";
 import { CopilotOnRailsContext } from "../../../../utils/copilotOnRails/CopilotOnRailsContext";
 import { callWithDiagnosticsAndTelemetryHandling, corId, setCorProp } from "../../../../utils/copilotOnRails/telemetryUtils";
 import { type PreviewPage, type ScaffoldPlanData } from "../../views/utils/parseScaffoldPlanMarkdown";
+import { ProjectPlanStatus } from "../../views/utils/projectPlanStatus";
 import { AUTOPILOT_QUERY_MARKER, disableAutopilot, enableAutopilot, getEffectiveMaxRequests, raiseWorkspaceMaxRequests } from "../autopilot";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
 import { openLoadingView } from "../openLoadingView";
 import { suppressTrackedViewCloseOnce } from "../projectSession";
+import { writeProjectPlanStatusAtUri } from "../utils/planStatus";
 import { PREVIEW_FOLDER_RELATIVE_PATH, readPreviewPages, type PreviewPagesResult } from "../utils/previewPagesReader";
 import { getScaffoldPlanTelemetry, SCAFFOLD_PLAN_TELEMETRY_PREFIX } from "../utils/scaffoldPlanTelemetryUtils";
 import { openSourceFileOrWarn } from "../utils/singletonViewHost";
@@ -167,9 +169,17 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
         }
         setCorProp(context, ENSURE_AGENT_INSTRUCTIONS_KEY, true);
 
-        const planBeforeAutopilot = confirmedAutopilot
-            ? await this.recordAutopilotMode()
+        const planBeforeApproval = this.sourceFileUri
+            ? await writeProjectPlanStatusAtUri(this.sourceFileUri, ProjectPlanStatus.approved)
             : undefined;
+        setCorProp(context, 'statusWriteSucceeded', planBeforeApproval !== undefined);
+        if (planBeforeApproval !== undefined) {
+            this.onSelfWrite?.(planBeforeApproval.replace(/^(\*\*Status\*\*:[ \t]*)([^\r\n]*)/m, `$1${ProjectPlanStatus.approved}`));
+        }
+
+        if (confirmedAutopilot) {
+            await this.recordAutopilotMode();
+        }
         if (confirmedAutopilot) {
             await enableAutopilot(ext.context);
         } else {
@@ -180,9 +190,10 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
         if (!(await launchAgentChat(azureProjectScaffoldAgent, confirmedAutopilot ? `${AUTOPILOT_QUERY_MARKER} ${baseQuery}` : baseQuery))) {
             if (confirmedAutopilot) {
                 await disableAutopilot();
-                if (planBeforeAutopilot !== undefined && this.sourceFileUri) {
-                    await vscode.workspace.fs.writeFile(this.sourceFileUri, Buffer.from(planBeforeAutopilot, 'utf-8'));
-                }
+            }
+            if (planBeforeApproval !== undefined && this.sourceFileUri) {
+                await vscode.workspace.fs.writeFile(this.sourceFileUri, Buffer.from(planBeforeApproval, 'utf-8'));
+                this.onSelfWrite?.(planBeforeApproval);
             }
             setCorProp(context, 'approvalOutcome', 'launchFailed');
             return false;

--- a/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
@@ -21,7 +21,7 @@ import { AUTOPILOT_QUERY_MARKER, disableAutopilot, enableAutopilot, getEffective
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
 import { openLoadingView } from "../openLoadingView";
 import { suppressTrackedViewCloseOnce } from "../projectSession";
-import { writeProjectPlanStatusAtUri } from "../utils/planStatus";
+import { replaceProjectPlanStatus, writeProjectPlanStatusAtUri } from "../utils/planStatus";
 import { PREVIEW_FOLDER_RELATIVE_PATH, readPreviewPages, type PreviewPagesResult } from "../utils/previewPagesReader";
 import { getScaffoldPlanTelemetry, SCAFFOLD_PLAN_TELEMETRY_PREFIX } from "../utils/scaffoldPlanTelemetryUtils";
 import { openSourceFileOrWarn } from "../utils/singletonViewHost";
@@ -174,7 +174,10 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
             : undefined;
         setCorProp(context, 'statusWriteSucceeded', planBeforeApproval !== undefined);
         if (planBeforeApproval !== undefined) {
-            this.onSelfWrite?.(planBeforeApproval.replace(/^(\*\*Status\*\*:[ \t]*)([^\r\n]*)/m, `$1${ProjectPlanStatus.approved}`));
+            const approvedPlan = replaceProjectPlanStatus(planBeforeApproval, ProjectPlanStatus.approved);
+            if (approvedPlan !== undefined) {
+                this.onSelfWrite?.(approvedPlan);
+            }
         }
 
         if (confirmedAutopilot) {

--- a/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
@@ -194,6 +194,7 @@ export class ScaffoldPlanViewController extends WebviewController<Record<string,
             if (confirmedAutopilot) {
                 await disableAutopilot();
             }
+            // Undo the approval because scaffolding did not start, leaving the plan ready to retry.
             if (planBeforeApproval !== undefined && this.sourceFileUri) {
                 await vscode.workspace.fs.writeFile(this.sourceFileUri, Buffer.from(planBeforeApproval, 'utf-8'));
                 this.onSelfWrite?.(planBeforeApproval);

--- a/src/webviews/copilotOnRails/extension/utils/planStatus.ts
+++ b/src/webviews/copilotOnRails/extension/utils/planStatus.ts
@@ -13,6 +13,46 @@ import * as vscode from 'vscode';
  */
 const STATUS_LINE_REGEX = /^(\*\*Status\*\*:[ \t]*)([^\r\n]*)/m;
 
+/** Replaces only the canonical status metadata value in plan markdown. */
+export function replaceProjectPlanStatus(content: string, newStatus: string): string | undefined {
+    if (!STATUS_LINE_REGEX.test(content)) {
+        return undefined;
+    }
+    return content.replace(STATUS_LINE_REGEX, (_full, prefix: string) => `${prefix}${newStatus}`);
+}
+
+/**
+ * Overwrites the status metadata row in one specific plan file. Returns the
+ * original content when the status changed so callers can roll the write back.
+ */
+export async function writeProjectPlanStatusAtUri(uri: vscode.Uri, newStatus: string): Promise<string | undefined> {
+    let content: string;
+    try {
+        content = Buffer.from(await vscode.workspace.fs.readFile(uri)).toString('utf-8');
+    } catch {
+        return undefined;
+    }
+
+    const updated = replaceProjectPlanStatus(content, newStatus);
+    if (updated === undefined) {
+        return undefined;
+    }
+    if (updated === content) {
+        return content;
+    }
+
+    try {
+        await vscode.workspace.fs.writeFile(uri, Buffer.from(updated, 'utf-8'));
+        const persisted = Buffer.from(await vscode.workspace.fs.readFile(uri)).toString('utf-8');
+        if (STATUS_LINE_REGEX.exec(persisted)?.[2]?.trim() !== newStatus) {
+            return undefined;
+        }
+    } catch {
+        return undefined;
+    }
+    return content;
+}
+
 /**
  * Overwrites the value of the `**Status**:` metadata row of the plan file matched
  * by `glob`, preserving the label. Used to make plan-state transitions that must
@@ -25,25 +65,8 @@ export async function writeProjectPlanStatus(glob: string, newStatus: string): P
     if (!uri) {
         return false;
     }
-
-    let content: string;
-    try {
-        content = Buffer.from(await vscode.workspace.fs.readFile(uri)).toString('utf-8');
-    } catch {
-        return false;
-    }
-
-    if (!STATUS_LINE_REGEX.test(content)) {
-        return false;
-    }
-    // Replace only the value on the `**Status**:` line, keeping the label exactly.
-    const updated = content.replace(STATUS_LINE_REGEX, (_full, prefix: string) => `${prefix}${newStatus}`);
-    if (updated === content) {
-        return false;
-    }
-
-    await vscode.workspace.fs.writeFile(uri, Buffer.from(updated, 'utf-8'));
-    return true;
+    const previous = await writeProjectPlanStatusAtUri(uri, newStatus);
+    return previous !== undefined && STATUS_LINE_REGEX.exec(previous)?.[2]?.trim() !== newStatus;
 }
 
 /**

--- a/src/webviews/copilotOnRails/views/utils/projectPlanStatus.ts
+++ b/src/webviews/copilotOnRails/views/utils/projectPlanStatus.ts
@@ -11,6 +11,8 @@
  * status string literals.
  */
 export const ProjectPlanStatus = {
+    /** User approved the generated project plan. */
+    approved: 'Approved',
     /** Scaffold finished; awaiting the user's UI approval before integration. */
     awaitingIntegration: 'Awaiting Integration',
     /** User approved the UI; the integrate phase is in progress. */

--- a/test/copilotOnRails/planStatus.test.ts
+++ b/test/copilotOnRails/planStatus.test.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test } from 'mocha';
+import { replaceProjectPlanStatus } from '../../src/webviews/copilotOnRails/extension/utils/planStatus';
+
+suite('planStatus', () => {
+    test('replaces only the canonical status metadata row', () => {
+        const plan = [
+            '# Project Plan',
+            '**Status**: Planning',
+            '',
+            'A section mentioning Status: Planning must remain unchanged.',
+        ].join('\n');
+
+        assert.strictEqual(
+            replaceProjectPlanStatus(plan, 'Approved'),
+            plan.replace('**Status**: Planning', '**Status**: Approved'),
+        );
+    });
+
+    test('preserves CRLF line endings and status spacing', () => {
+        const plan = '# Project Plan\r\n**Status**:\tPlanning\r\n**Mode**: NEW\r\n';
+
+        assert.strictEqual(
+            replaceProjectPlanStatus(plan, 'Approved'),
+            '# Project Plan\r\n**Status**:\tApproved\r\n**Mode**: NEW\r\n',
+        );
+    });
+
+    test('rejects a plan without the canonical status row', () => {
+        assert.strictEqual(replaceProjectPlanStatus('# Project Plan\nStatus: Planning', 'Approved'), undefined);
+    });
+});


### PR DESCRIPTION
This is an attempt to help mitigate this issue: https://github.com/microsoft/vscode-azureresourcegroups/issues/1578.

After approval we will attempt to write the `Status: Approved` ourseleved instead of relying on the agent to do it. In the case we fail to do this it will fall back to the default behavior we have in there at the moment. 