### PR TITLE
CoR: Remove `onStartupActivation` by making `Azure Project` view always visible but collapsed

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "preview": true,
     "activationEvents": [
         "onFileSystem:azureResourceGroups",
-        "onStartupFinished",
+        "workspaceContains:**/.azure/.pending-create",
         "workspaceContains:**/.azure/project-plan.md",
         "workspaceContains:**/.azure/requirements.json",
         "workspaceContains:**/.azure/vscode-debug-plan.md"
@@ -486,8 +486,7 @@
                 {
                     "id": "azureProject",
                     "name": "%azureProject.viewName%",
-                    "visibility": "visible",
-                    "when": "ms-azuretools.vscode-azureresourcegroups.hasProjectPlanFiles == true || ms-azuretools.vscode-azureresourcegroups.hasPendingProjectSubmission == true || ms-azuretools.vscode-azureresourcegroups.isEmptyWorkspace == true"
+                    "visibility": "collapsed"
                 }
             ]
         },

--- a/src/commands/copilotOnRails/registerCopilotOnRailsCommands.ts
+++ b/src/commands/copilotOnRails/registerCopilotOnRailsCommands.ts
@@ -5,7 +5,7 @@
 
 import { IActionContext, registerCommand } from '@microsoft/vscode-azext-utils';
 import { l10n } from 'vscode';
-import { azureDebugPlanAgent } from '../../constants';
+import { azureDebugPlanAgent, azureProjectId } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { CopilotOnRailsContext } from '../../utils/copilotOnRails/CopilotOnRailsContext';
 import { callWithDiagnosticsAndTelemetryHandling, corId } from '../../utils/copilotOnRails/telemetryUtils';
@@ -44,7 +44,7 @@ export const copilotOnRailsCommandIds = {
     openDeploymentPlanView: corId('openDeploymentPlanView'),
 
     resumeProjectWithCopilot: corId('resumeProjectWithCopilot'),
-    refreshProjectTree: 'azureProject.refresh',
+    refreshProjectTree: `${azureProjectId}.refresh`,
     inspectDiagnostics: corId('inspectDiagnostics'),
     reportIssue: corId('reportIssue'),
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,10 +13,10 @@ export const contributesKey = 'x-azResources';
 export const ungroupedId = 'group/ungrouped';
 export const showHiddenTypesSettingKey = 'showHiddenTypes';
 export const hasFocusedGroupContextKey = 'ms-azuretools.vscode-azureresourcegroups.hasFocusedGroup';
-export const hasProjectPlanFilesContextKey = 'ms-azuretools.vscode-azureresourcegroups.hasProjectPlanFiles';
-export const isEmptyWorkspaceContextKey = 'ms-azuretools.vscode-azureresourcegroups.isEmptyWorkspace';
-export const hasPendingProjectSubmissionContextKey = 'ms-azuretools.vscode-azureresourcegroups.hasPendingProjectSubmission';
 export const canFocusContextValue = 'canFocus';
+
+export const azureProjectId = 'azureProject';
+export const azureProjectFocusCommandId = `${azureProjectId}.focus`;
 
 export const azureProjectPlanAgent = 'azure-project-plan';
 export const azureProjectScaffoldAgent = 'azure-project-scaffold';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ import { deleteResourceGroupV2 } from './commands/deleteResourceGroup/v2/deleteR
 import { registerCommands } from './commands/registerCommands';
 import { TagFileSystem } from './commands/tags/TagFileSystem';
 import { registerTagDiagnostics } from './commands/tags/registerTagDiagnostics';
-import { hasProjectPlanFilesContextKey, isEmptyWorkspaceContextKey, mcpServerId, mcpServerLabel, resourcesExtensionId } from './constants';
+import { azureProjectId, mcpServerId, mcpServerLabel, resourcesExtensionId } from './constants';
 import { registerExportAuthRecordOnSessionChange } from './exportAuthRecord';
 import { ext } from './extensionVariables';
 import { AzureResourcesApiInternal } from './hostapi.v2.internal';
@@ -51,8 +51,8 @@ import { DefaultAzureResourceBranchDataProvider } from './tree/azure/DefaultAzur
 import { registerAzureTree } from './tree/azure/registerAzureTree';
 import { registerFocusTree } from './tree/azure/registerFocusTree';
 import { AzureProjectProgressTreeDataProvider } from './tree/project/AzureProjectProgressTreeDataProvider';
-import { ProjectPlanFilesWatcher, getProjectPlanFiles } from './tree/project/projectPlanFiles';
-import { projectSubmissionState } from './tree/project/projectSubmissionState';
+import { ProjectPlanFilesWatcher } from './tree/project/projectPlanFiles';
+import { registerProjectSubmissionStateWatcher } from './tree/project/registerProjectSubmissionStateWatcher';
 import { TenantDefaultBranchDataProvider } from './tree/tenants/TenantDefaultBranchDataProvider';
 import { TenantResourceBranchDataProviderManager } from './tree/tenants/TenantResourceBranchDataProviderManager';
 import { registerTenantTree } from './tree/tenants/registerTenantTree';
@@ -61,7 +61,7 @@ import { WorkspaceResourceBranchDataProviderManager } from './tree/workspace/Wor
 import { registerWorkspaceTree } from './tree/workspace/registerWorkspaceTree';
 import { createResourceClient } from './utils/azureClients';
 import { disableAutopilot, registerAutopilot } from './webviews/copilotOnRails/extension/autopilot';
-import { resumePendingCreateWithCopilot } from './webviews/copilotOnRails/extension/createProjectWithCopilot';
+import { resumePendingCreateWithCopilot } from './webviews/copilotOnRails/extension/resumePendingCreateWithCopilot';
 import { registerRequirementsAutoOpen } from './webviews/copilotOnRails/extension/openRequirementsView';
 import { registerResumeAffordances } from './webviews/copilotOnRails/extension/resumeAffordances';
 import { registerViewHostDisposal } from './webviews/copilotOnRails/extension/utils/singletonViewHost';
@@ -79,9 +79,10 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
 
     registerUIExtensionVariables(ext);
     registerAzureUtilsExtensionVariables(ext);
-    const projectPlanFilesWatcher = new ProjectPlanFilesWatcher();
-    context.subscriptions.push(projectPlanFilesWatcher);
-    await registerProjectPlanFilesContext(context, projectPlanFilesWatcher);
+
+    const corPlanFilesWatcher = new ProjectPlanFilesWatcher();
+    context.subscriptions.push(corPlanFilesWatcher);
+    registerProjectSubmissionStateWatcher(context, corPlanFilesWatcher);
     registerRequirementsAutoOpen(context);
     registerAutopilot(context);
     registerViewHostDisposal(context);
@@ -131,7 +132,7 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
         }));
 
         registerCommands();
-        void resumePendingCreateWithCopilot(context);
+        void resumePendingCreateWithCopilot();
         survey(context);
 
         registerChatStandInParticipantIfNeeded(context);
@@ -187,11 +188,11 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
         refreshEvent: refreshWorkspaceTreeEmitter.event,
     });
 
-    const azureProjectProgressTreeDataProvider = new AzureProjectProgressTreeDataProvider(context, projectPlanFilesWatcher);
-    context.subscriptions.push(vscode.window.registerTreeDataProvider('azureProject', azureProjectProgressTreeDataProvider));
+    const azureProjectProgressTreeDataProvider = new AzureProjectProgressTreeDataProvider(context, corPlanFilesWatcher);
+    context.subscriptions.push(vscode.window.registerTreeDataProvider(azureProjectId, azureProjectProgressTreeDataProvider));
     ext.actions.refreshProjectTree = () => azureProjectProgressTreeDataProvider.refresh();
 
-    registerResumeAffordances(context, projectPlanFilesWatcher);
+    registerResumeAffordances(context, corPlanFilesWatcher);
 
     const tenantResourcesBranchDataItemCache = new BranchDataItemCache();
     registerTenantTree(context, {
@@ -349,48 +350,4 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
 export function deactivate(): void {
     ext.diagnosticWatcher?.dispose();
     void disableAutopilot();
-}
-
-async function registerProjectPlanFilesContext(context: vscode.ExtensionContext, planFilesWatcher: ProjectPlanFilesWatcher): Promise<void> {
-    const update = async (): Promise<void> => {
-        const files = await getProjectPlanFiles();
-
-        await vscode.commands.executeCommand('setContext', hasProjectPlanFilesContextKey, files.hasAny);
-        await vscode.commands.executeCommand('setContext', isEmptyWorkspaceContextKey, await isWorkspaceEmpty());
-
-        if (files.hasAny && files.currentStage >= projectSubmissionState.pendingStage) {
-            projectSubmissionState.reset();
-        }
-    };
-
-    context.subscriptions.push(planFilesWatcher.onDidChange(() => void update()));
-
-    await update();
-}
-
-async function isWorkspaceEmpty(): Promise<boolean> {
-    const folders = vscode.workspace.workspaceFolders;
-    if (!folders || folders.length === 0) {
-        return false;
-    }
-
-    // Entries that don't count as "real" project content.
-    const ignored = new Set(['.git', '.vscode', '.azure', '.github', '.agents', '.DS_Store']);
-
-    let readableFolderCount = 0;
-
-    for (const folder of folders) {
-        try {
-            const entries = await vscode.workspace.fs.readDirectory(folder.uri);
-            readableFolderCount += 1;
-            const meaningful = entries.filter(([name]) => !ignored.has(name));
-            if (meaningful.length > 0) {
-                return false;
-            }
-        } catch {
-            // Ignore unreadable folders (e.g. permission errors)
-        }
-    }
-
-    return readableFolderCount > 0;
 }

--- a/src/tree/project/projectSubmissionState.ts
+++ b/src/tree/project/projectSubmissionState.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { hasPendingProjectSubmissionContextKey } from '../../constants';
+import { azureProjectFocusCommandId } from '../../constants';
 import { type ProjectStage } from './projectPlanFiles';
 
 /**
@@ -38,7 +38,7 @@ class ProjectSubmissionState {
         }
         this._isPending = true;
         this._pendingStage = newStage;
-        void vscode.commands.executeCommand('setContext', hasPendingProjectSubmissionContextKey, true);
+        void vscode.commands.executeCommand(azureProjectFocusCommandId);
         this._emitter.fire();
     }
 
@@ -48,7 +48,6 @@ class ProjectSubmissionState {
         }
         this._isPending = false;
         this._pendingStage = 0;
-        void vscode.commands.executeCommand('setContext', hasPendingProjectSubmissionContextKey, false);
         this._emitter.fire();
     }
 }

--- a/src/tree/project/registerProjectSubmissionStateWatcher.ts
+++ b/src/tree/project/registerProjectSubmissionStateWatcher.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { getProjectPlanFiles, type ProjectPlanFilesWatcher } from './projectPlanFiles';
+import { projectSubmissionState } from './projectSubmissionState';
+
+/**
+ * Watches for project plan files to appear, and clears the pending submission
+ * state once they do. That state exists only to show progress in the gap between
+ * the user submitting and the first file being written, so it's no longer needed
+ * once the files are on disk.
+ */
+export function registerProjectSubmissionStateWatcher(context: vscode.ExtensionContext, planFilesWatcher: ProjectPlanFilesWatcher): void {
+    const update = async (): Promise<void> => {
+        const files = await getProjectPlanFiles();
+        if (files.hasAny && files.currentStage >= projectSubmissionState.pendingStage) {
+            projectSubmissionState.reset();
+        }
+    };
+
+    context.subscriptions.push(planFilesWatcher.onDidChange(() => void update()));
+
+    void update();
+}

--- a/src/webviews/copilotOnRails/extension/createProjectWithCopilot.ts
+++ b/src/webviews/copilotOnRails/extension/createProjectWithCopilot.ts
@@ -84,8 +84,6 @@ async function ensureFreshWorkspace(): Promise<boolean> {
         return true;
     }
 
-    // Warn before the picker so the empty-folder requirement doesn't come as a
-    // surprise, and so the user learns about it before we throw on a bad pick.
     const browse = vscode.l10n.t('Browse...');
     const choice = await vscode.window.showWarningMessage(
         vscode.l10n.t('Creating a project with Copilot requires an empty folder.'),

--- a/src/webviews/copilotOnRails/extension/createProjectWithCopilot.ts
+++ b/src/webviews/copilotOnRails/extension/createProjectWithCopilot.ts
@@ -3,48 +3,18 @@
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { type IActionContext } from "@microsoft/vscode-azext-utils";
+import { UserCancelledError, type IActionContext } from "@microsoft/vscode-azext-utils";
 import * as vscode from 'vscode';
 import { copilotOnRailsCommandIds } from "../../../commands/copilotOnRails/registerCopilotOnRailsCommands";
-import { ext } from "../../../extensionVariables";
 import { DEBUG_PLAN_FILE_GLOB, PROJECT_PLAN_FILE_GLOB } from "../../../tree/project/projectPlanFiles";
 import { CreateProjectViewController } from "./controllers/CreateProjectViewController";
+import { writePendingCreateMarker } from "./resumePendingCreateWithCopilot";
 
 const localDev = vscode.l10n.t('Local Development');
 const deploy = vscode.l10n.t('Deploy');
 
-/**
- * globalState key holding the epoch-ms deadline until which a pending "Create
- * with Copilot" request should auto-resume after a folder is opened.
- */
-const PENDING_CREATE_DEADLINE_KEY = 'copilotOnRails.createProjectWithCopilot.pendingDeadline';
-/** How long a pending create request stays valid across a window reload. */
-const PENDING_CREATE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
-
-/**
- * If the user previously pressed "Create with Copilot" without an open folder
- * and chose to open one, re-runs the command once the folder is open. Call this
- * during activation. No-ops when there's no pending request or it has expired.
- */
-export async function resumePendingCreateWithCopilot(context: vscode.ExtensionContext): Promise<void> {
-    const deadline = context.globalState.get<number>(PENDING_CREATE_DEADLINE_KEY);
-    if (deadline === undefined) {
-        return;
-    }
-
-    // Consume the flag regardless of outcome so it only ever fires once.
-    await context.globalState.update(PENDING_CREATE_DEADLINE_KEY, undefined);
-
-    const folders = vscode.workspace.workspaceFolders;
-    if (Date.now() > deadline || !folders || folders.length === 0) {
-        return;
-    }
-
-    await vscode.commands.executeCommand(copilotOnRailsCommandIds.createProjectWithCopilot);
-}
-
 export async function createProjectWithCopilot(_context: IActionContext): Promise<void> {
-    if (!(await ensureWorkspaceOpen())) {
+    if (!(await ensureFreshWorkspace())) {
         return;
     }
 
@@ -98,33 +68,62 @@ export async function createProjectWithCopilot(_context: IActionContext): Promis
 }
 
 /**
- * Ensures there is an open folder/workspace to create the project in. If none is
- * open, prompts the user to open or create one. Returns true when a workspace is
- * (already) open and the flow can continue, false otherwise.
+ * Ensures the flow starts from a suitable blank slate.
+ * If no folder is open, or the open folder already contains project content, we offer the
+ * native folder picker and reopen VS Code on the chosen folder.
+ *
+ * Returns true when the flow can continue in the current window, false when
+ * we're reopening on a different folder (in which case the flow resumes
+ * automatically via the pending-create marker). Throws if the user cancels or
+ * picks a folder that isn't empty.
  */
-async function ensureWorkspaceOpen(): Promise<boolean> {
-    const folders = vscode.workspace.workspaceFolders;
-    if (folders && folders.length > 0) {
+async function ensureFreshWorkspace(): Promise<boolean> {
+    const currentFolder = vscode.workspace.workspaceFolders?.[0];
+
+    if (await isWorkspaceEmpty()) {
         return true;
     }
 
-    const openFolder = vscode.l10n.t('Open Folder...');
-    const newWindow = vscode.l10n.t('New Empty Window');
-
-    const choice = await vscode.window.showInformationMessage(
-        vscode.l10n.t('Creating a project with Copilot requires an open folder. Open or create an empty folder to continue.'),
-        { modal: true },
-        openFolder,
-        newWindow,
+    // Warn before the picker so the empty-folder requirement doesn't come as a
+    // surprise, and so the user learns about it before we throw on a bad pick.
+    const browse = vscode.l10n.t('Browse...');
+    const choice = await vscode.window.showWarningMessage(
+        vscode.l10n.t('Creating a project with Copilot requires an empty folder.'),
+        {
+            modal: true,
+            detail: currentFolder
+                ? vscode.l10n.t('"{0}" already contains files. Choose an empty folder to build in — VS Code will reopen there and pick this flow back up.', folderName(currentFolder.uri))
+                : vscode.l10n.t('Choose an empty folder to build in — VS Code will reopen there and pick this flow back up.'),
+        },
+        browse,
     );
 
-    if (choice === openFolder) {
-        await ext.context.globalState.update(PENDING_CREATE_DEADLINE_KEY, Date.now() + PENDING_CREATE_TIMEOUT_MS);
-        await vscode.commands.executeCommand('workbench.action.files.openFolder');
-    } else if (choice === newWindow) {
-        await vscode.commands.executeCommand('workbench.action.newWindow');
+    if (choice !== browse) {
+        throw new UserCancelledError('selectProjectFolder');
     }
 
+    const picked = await vscode.window.showOpenDialog({
+        canSelectFiles: false,
+        canSelectFolders: true,
+        canSelectMany: false,
+        openLabel: vscode.l10n.t('Select Folder'),
+        title: vscode.l10n.t('Select an empty folder for your new project'),
+        // Start one level up from the current folder, since the whole point is
+        // to land somewhere other than where we are.
+        defaultUri: currentFolder ? vscode.Uri.joinPath(currentFolder.uri, '..') : undefined,
+    });
+
+    const target = picked?.[0];
+    if (!target) {
+        throw new UserCancelledError('selectProjectFolder');
+    }
+
+    if (!(await isFolderEmpty(target))) {
+        throw new Error(vscode.l10n.t('"{0}" already contains files. Creating a project with Copilot requires an empty folder.', folderName(target)));
+    }
+
+    await writePendingCreateMarker(target);
+    await vscode.commands.executeCommand('vscode.openFolder', target);
     return false;
 }
 
@@ -137,4 +136,27 @@ async function hasCompletedPhase(filePath: string, expectedStatus: string): Prom
     const content = Buffer.from(await vscode.workspace.fs.readFile(files[0])).toString('utf-8');
     // [*_~]* allows markdown formatting (bold, italic, strikethrough) around "status"
     return new RegExp(`status[*_~]*\\s*:\\s*${expectedStatus}`, 'i').test(content);
+}
+
+/** Display name of a folder uri, for user-facing messages. */
+function folderName(uri: vscode.Uri): string {
+    return uri.path.split('/').filter(Boolean).pop() ?? uri.fsPath;
+}
+
+/** Entries that don't count as real project content when checking for a blank slate. */
+const IGNORED_ENTRIES = new Set(['.git', '.DS_Store']);
+
+async function isFolderEmpty(folder: vscode.Uri): Promise<boolean> {
+    try {
+        const entries = await vscode.workspace.fs.readDirectory(folder);
+        return entries.every(([name]) => IGNORED_ENTRIES.has(name));
+    } catch {
+        return false;
+    }
+}
+
+async function isWorkspaceEmpty(): Promise<boolean> {
+    // Copilot on Rails isn't really intended for use with multi-root
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    return folder ? await isFolderEmpty(folder.uri) : false;
 }

--- a/src/webviews/copilotOnRails/extension/resumePendingCreateWithCopilot.ts
+++ b/src/webviews/copilotOnRails/extension/resumePendingCreateWithCopilot.ts
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { copilotOnRailsCommandIds } from '../../../commands/copilotOnRails/registerCopilotOnRailsCommands';
+import { azureProjectFocusCommandId } from '../../../constants';
+
+/**
+ * Creating a project requires an empty folder. When the user starts the flow in a
+ * workspace that already has files, we send them through the folder picker and
+ * reopen VS Code on their choice — which tears down the extension host mid-flow.
+ * The new window then has to pick the flow back up on its own, but nothing there
+ * would activate us: the folder is empty, no command was invoked, and we have no
+ * startup activation event.
+ *
+ * So the hand-off is a file on disk. `workspaceContains:**\/.azure/.pending-create`
+ * in package.json which wakes the extension exactly when the create needs to resume.
+ * The marker's presence means "resume here". It's deleted on activation so it fires
+ * at most once, and carries a timestamp so a stale marker left by an abandoned
+ * flow can't resume days later.
+ */
+
+/** Workspace-relative path of the marker. Must stay in sync with the `workspaceContains` activation event in package.json. */
+export const PENDING_CREATE_SENTINEL_PATH = '.azure/.pending-create';
+
+/**
+ * How long a pending create request stays valid. Generous enough to cover a slow
+ * window reload, short enough that a marker orphaned by a crash is ignored.
+ */
+const PENDING_CREATE_TIMEOUT_MS = 10 * 60 * 1000;
+
+interface PendingCreateMarker {
+    /** Epoch ms at which the marker was written. */
+    createdAt: number;
+}
+
+function sentinelUri(folder: vscode.Uri): vscode.Uri {
+    return vscode.Uri.joinPath(folder, ...PENDING_CREATE_SENTINEL_PATH.split('/'));
+}
+
+/**
+ * Records that the user asked to create a project in `folder`, so the flow can
+ * resume automatically once VS Code reopens on it. Failures are non-fatal: the
+ * user can still start the flow manually from the Azure Project view.
+ */
+export async function writePendingCreateMarker(folder: vscode.Uri): Promise<void> {
+    const marker: PendingCreateMarker = { createdAt: Date.now() };
+    try {
+        await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(folder, '.azure'));
+        await vscode.workspace.fs.writeFile(sentinelUri(folder), Buffer.from(JSON.stringify(marker), 'utf-8'));
+    } catch {
+        // Best effort only.
+    }
+}
+
+/**
+ * Consumes the pending-create marker in the open workspace, if any. Returns true
+ * when a valid, unexpired marker was found, meaning the caller should resume the
+ * create flow. The marker (and the `.azure` folder, when we created it solely to
+ * hold the marker) is always removed so this fires at most once.
+ */
+async function consumePendingCreateMarker(): Promise<boolean> {
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders || folders.length === 0) {
+        return false;
+    }
+
+    for (const folder of folders) {
+        const uri = sentinelUri(folder.uri);
+        let raw: Uint8Array;
+        try {
+            raw = await vscode.workspace.fs.readFile(uri);
+        } catch {
+            continue;
+        }
+
+        await deleteMarkerAndEmptyAzureFolder(folder.uri, uri);
+
+        const createdAt = parseCreatedAt(raw);
+        if (createdAt !== undefined && Date.now() - createdAt <= PENDING_CREATE_TIMEOUT_MS) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function parseCreatedAt(raw: Uint8Array): number | undefined {
+    try {
+        const parsed = JSON.parse(Buffer.from(raw).toString('utf-8')) as Partial<PendingCreateMarker>;
+        return typeof parsed.createdAt === 'number' ? parsed.createdAt : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+async function deleteMarkerAndEmptyAzureFolder(folder: vscode.Uri, marker: vscode.Uri): Promise<void> {
+    try {
+        await vscode.workspace.fs.delete(marker);
+    } catch {
+        return;
+    }
+
+    // Don't leave a stray empty `.azure` folder behind if the marker was all it held.
+    const azureFolder = vscode.Uri.joinPath(folder, '.azure');
+    try {
+        const entries = await vscode.workspace.fs.readDirectory(azureFolder);
+        if (entries.length === 0) {
+            await vscode.workspace.fs.delete(azureFolder);
+        }
+    } catch {
+        // Best effort only.
+    }
+}
+
+/**
+ * If the user previously pressed "Create with Copilot" and chose a different
+ * folder to build in, re-runs the command once VS Code reopens on that folder.
+ * Call this during activation. No-ops when there's no pending request or it has
+ * expired.
+ */
+export async function resumePendingCreateWithCopilot(): Promise<void> {
+    if (await consumePendingCreateMarker()) {
+        // Expand the (collapsed by default) Azure Project view so the resumed
+        // flow is visibly picked up in the new window.
+        await vscode.commands.executeCommand(azureProjectFocusCommandId);
+        await vscode.commands.executeCommand(copilotOnRailsCommandIds.createProjectWithCopilot);
+    }
+}

--- a/src/webviews/copilotOnRails/extension/resumePendingCreateWithCopilot.ts
+++ b/src/webviews/copilotOnRails/extension/resumePendingCreateWithCopilot.ts
@@ -25,10 +25,6 @@ import { azureProjectFocusCommandId } from '../../../constants';
 /** Workspace-relative path of the marker. Must stay in sync with the `workspaceContains` activation event in package.json. */
 export const PENDING_CREATE_SENTINEL_PATH = '.azure/.pending-create';
 
-/**
- * How long a pending create request stays valid. Generous enough to cover a slow
- * window reload, short enough that a marker orphaned by a crash is ignored.
- */
 const PENDING_CREATE_TIMEOUT_MS = 10 * 60 * 1000;
 
 interface PendingCreateMarker {
@@ -40,11 +36,6 @@ function sentinelUri(folder: vscode.Uri): vscode.Uri {
     return vscode.Uri.joinPath(folder, ...PENDING_CREATE_SENTINEL_PATH.split('/'));
 }
 
-/**
- * Records that the user asked to create a project in `folder`, so the flow can
- * resume automatically once VS Code reopens on it. Failures are non-fatal: the
- * user can still start the flow manually from the Azure Project view.
- */
 export async function writePendingCreateMarker(folder: vscode.Uri): Promise<void> {
     const marker: PendingCreateMarker = { createdAt: Date.now() };
     try {
@@ -55,12 +46,6 @@ export async function writePendingCreateMarker(folder: vscode.Uri): Promise<void
     }
 }
 
-/**
- * Consumes the pending-create marker in the open workspace, if any. Returns true
- * when a valid, unexpired marker was found, meaning the caller should resume the
- * create flow. The marker (and the `.azure` folder, when we created it solely to
- * hold the marker) is always removed so this fires at most once.
- */
 async function consumePendingCreateMarker(): Promise<boolean> {
     const folders = vscode.workspace.workspaceFolders;
     if (!folders || folders.length === 0) {
@@ -111,7 +96,7 @@ async function deleteMarkerAndEmptyAzureFolder(folder: vscode.Uri, marker: vscod
             await vscode.workspace.fs.delete(azureFolder);
         }
     } catch {
-        // Best effort only.
+        // Best effort attempt
     }
 }
 
@@ -123,8 +108,6 @@ async function deleteMarkerAndEmptyAzureFolder(folder: vscode.Uri, marker: vscod
  */
 export async function resumePendingCreateWithCopilot(): Promise<void> {
     if (await consumePendingCreateMarker()) {
-        // Expand the (collapsed by default) Azure Project view so the resumed
-        // flow is visibly picked up in the new window.
         await vscode.commands.executeCommand(azureProjectFocusCommandId);
         await vscode.commands.executeCommand(copilotOnRailsCommandIds.createProjectWithCopilot);
     }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode-azureresourcegroups/pull/1615#discussion_r3667849975

### Changes
- Azure project view will no longer conditionally appear based on immediate activation and FS read, which was previously a design choice that prevented us from lazy activation
- Now that Azure project is always showing up, we need to handle how it behaves when a non-CopilotOnRails project is already open
  - If not empty, modal to prompt user to pick a new empty project to start with
  - Then automatically resume from there in the new empty project

### Flow
1. Click create with a non-empty workspace:
  <img width="1311" height="926" alt="image" src="https://github.com/user-attachments/assets/f53ad19b-e347-4907-81c4-094ec8a0ecd7" />
2. Browse
  <img width="1500" height="585" alt="image" src="https://github.com/user-attachments/assets/ad0f32be-45e9-49c1-8fcd-ee293898dc2e" />
3. Re-opens and immediately starts the flow:
  <img width="1587" height="1021" alt="image" src="https://github.com/user-attachments/assets/d3189665-4237-4ad2-bdb9-5e5f27bf7eec" />
