### PR TITLE
CoR: Separate system info recording behavior for diagnostics vs. telemetry

### DIFF
--- a/src/utils/copilotOnRails/diagnosticUtils.ts
+++ b/src/utils/copilotOnRails/diagnosticUtils.ts
@@ -36,6 +36,22 @@ export function getCreatedAt(): string | undefined {
 
 // #endregion
 
+// #region systemInfo
+const systemInfoKey: string = 'copilotOnRails.systemInfo';
+
+/**
+ * Records the machine/runtime information for the workspace project as diagnostics metadata.
+ */
+export function recordSystemInfo(systemInfo: Record<string, string>): void {
+    void ext.context.workspaceState.update(systemInfoKey, systemInfo);
+}
+
+export function getRecordedSystemInfo(): Record<string, string> {
+    return ext.context.workspaceState.get<Record<string, string>>(systemInfoKey, {});
+}
+
+// #endregion
+
 // #region diagnosticEvents
 const maxCachedEvents: number = 50;
 const eventsKey: string = 'copilotOnRails.diagnosticEvents';
@@ -57,8 +73,8 @@ export function getDiagnosticEvents(): DiagnosticEvent[] {
 }
 
 /**
- * Aggregates the workspace-cached diagnostics (originating prompt, created-at stamp, and
- * recorded events) into a single {@link DiagnosticsMetadata} object.
+ * Aggregates the workspace-cached diagnostics and other important information
+ * into a single {@link DiagnosticsMetadata} object.
  *
  * The returned data is only ever surfaced for inspection or to pre-populate a GitHub issue
  * draft the user reviews - it is never sent to telemetry or submitted automatically.
@@ -67,6 +83,7 @@ export function getDiagnosticsMetadata(): DiagnosticsMetadata {
     return {
         prompt: getPrompt() ?? '',
         createdAt: getCreatedAt() ?? '',
+        systemInfo: getRecordedSystemInfo(),
         diagnosticEvents: getDiagnosticEvents(),
     };
 }
@@ -153,6 +170,10 @@ export interface DiagnosticsMetadata {
      * Date first prompted, as an ISO 8601 string (`.toISOString()`).
      */
     createdAt: string;
+    /**
+     * The machine/runtime information captured when the project was first created.
+     */
+    systemInfo: Record<string, string>;
     /**
      * The events recorded over a CoR workspace project's lifetime.
      */

--- a/src/utils/copilotOnRails/prepareNewCorProject.ts
+++ b/src/utils/copilotOnRails/prepareNewCorProject.ts
@@ -6,7 +6,8 @@
 import { ext } from "../../extensionVariables";
 import { projectSubmissionState } from "../../tree/project/projectSubmissionState";
 import { disableAutopilot } from "../../webviews/copilotOnRails/extension/autopilot";
-import { recordCreatedAt, recordPrompt } from "./diagnosticUtils";
+import { recordCreatedAt, recordPrompt, recordSystemInfo } from "./diagnosticUtils";
+import { getSystemInfo } from "./telemetryUtils";
 
 /**
  * Prepares a new Copilot on Rails project to be run in the current workspace
@@ -19,6 +20,7 @@ export async function prepareNewCorProject(prompt: string): Promise<void> {
 
     recordPrompt(prompt);
     recordCreatedAt();
+    recordSystemInfo(getSystemInfo());
 }
 
 const corStateKeyPattern: RegExp = /copilotOnRails/i;

--- a/src/utils/copilotOnRails/telemetryUtils.ts
+++ b/src/utils/copilotOnRails/telemetryUtils.ts
@@ -60,8 +60,9 @@ export async function callWithDiagnosticsAndTelemetryHandling<T>(
 
     const corContext: CopilotOnRailsContext = ensureRequiredCopilotOnRailsContext(context);
 
-    for (const [key, value] of Object.entries(getSystemTelemetry())) {
-        setCorProp(corContext, key, value);
+    // Intentionally telemetry only since this data was already cached on the worspace level for diagnostics
+    for (const [key, value] of Object.entries(getSystemInfo())) {
+        context.telemetry.properties[key] = value;
     }
 
     const copilotModel: string | undefined = readSessionState()?.model;
@@ -74,8 +75,8 @@ export async function callWithDiagnosticsAndTelemetryHandling<T>(
     return await withDiagnosticEvents(corContext, { type: eventDetails.type, name: eventDetails.name }, async () => await command(corContext));
 }
 
-export function getSystemTelemetry(): Record<string, string> {
-    const systemTelemetry: Record<string, string> = {
+export function getSystemInfo(): Record<string, string> {
+    const systemInfo: Record<string, string> = {
         osPlatform: os.platform(),
         osRelease: os.release(),
         osArch: os.arch(),
@@ -85,10 +86,10 @@ export function getSystemTelemetry(): Record<string, string> {
 
     const cpuModel: string | undefined = os.cpus()[0]?.model;
     if (cpuModel) {
-        systemTelemetry.cpuModel = cpuModel;
+        systemInfo.cpuModel = cpuModel;
     }
 
-    return systemTelemetry;
+    return systemInfo;
 }
 
 /**


### PR DESCRIPTION
Only caching the system specs on the initial run rather than on each command reduces the amount of information clutter by quite a bit.