### PR TITLE
CoR: Add recent-prompt history navigation for prompts on the landing page

### DIFF
--- a/src/webviews/copilotOnRails/extension/controllers/CreateProjectViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/CreateProjectViewController.ts
@@ -19,6 +19,7 @@ import { type CreateProjectViewControllerType } from "../../views/utils/viewConf
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
 import { openLoadingView } from "../openLoadingView";
 import { recordModel } from "../projectSession";
+import { recordRecentPrompt } from "../recentPrompts";
 
 export type { CreateProjectViewControllerType };
 
@@ -57,6 +58,7 @@ export class CreateProjectViewController extends WebviewController<CreateProject
                 if (model) {
                     await recordModel(model);
                 }
+                await recordRecentPrompt(query);
 
                 const submissionOutcomeKey = 'submissionOutcome';
                 if (!(await ensureCopilotChatReady(context))) {

--- a/src/webviews/copilotOnRails/extension/createProjectWithCopilot.ts
+++ b/src/webviews/copilotOnRails/extension/createProjectWithCopilot.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { copilotOnRailsCommandIds } from "../../../commands/copilotOnRails/registerCopilotOnRailsCommands";
 import { DEBUG_PLAN_FILE_GLOB, PROJECT_PLAN_FILE_GLOB } from "../../../tree/project/projectPlanFiles";
 import { CreateProjectViewController } from "./controllers/CreateProjectViewController";
+import { getRecentPrompts } from "./recentPrompts";
 import { writePendingCreateMarker } from "./resumePendingCreateWithCopilot";
 
 const localDev = vscode.l10n.t('Local Development');
@@ -63,6 +64,7 @@ export async function createProjectWithCopilot(_context: IActionContext): Promis
             'Claude Opus 4.7 (copilot)',
             'Claude Sonnet 4.6 (copilot)',
         ],
+        recentPrompts: getRecentPrompts(),
     });
     controller.revealToForeground();
 }

--- a/src/webviews/copilotOnRails/extension/recentPrompts.ts
+++ b/src/webviews/copilotOnRails/extension/recentPrompts.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ext } from '../../../extensionVariables';
+
+export type RecentPrompt = { prompt: string; ts: number };
+
+export const RECENT_PROMPT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+export const RECENT_PROMPT_MAX_COUNT = 25;
+
+// globalState (not workspaceState): the create flow opens a fresh empty folder per
+// project, so a workspace-scoped history would never surface a prior project's prompts.
+export const RECENT_PROMPTS_KEY = 'azureResourceGroups.copilotOnRails.recentPrompts';
+
+/** Drops entries older than the retention window; keeps newest-first order. */
+export function pruneRecentPrompts(existing: RecentPrompt[], now: number): RecentPrompt[] {
+    const cutoff = now - RECENT_PROMPT_MAX_AGE_MS;
+    return existing.filter((entry) => entry.ts >= cutoff);
+}
+
+/** Records `prompt` as the newest entry; ignores blank input, dedupes by moving an existing match to the front. */
+export function addRecentPrompt(existing: RecentPrompt[], prompt: string, now: number): RecentPrompt[] {
+    const trimmed = prompt.trim();
+    if (!trimmed) {
+        return existing;
+    }
+
+    const withoutDuplicate = existing.filter((entry) => entry.prompt !== trimmed);
+    const next: RecentPrompt[] = [{ prompt: trimmed, ts: now }, ...withoutDuplicate];
+    return pruneRecentPrompts(next, now).slice(0, RECENT_PROMPT_MAX_COUNT);
+}
+
+export function toPromptStrings(existing: RecentPrompt[]): string[] {
+    return existing.map((entry) => entry.prompt);
+}
+
+export function getRecentPrompts(): string[] {
+    const stored = ext.context.globalState.get<RecentPrompt[]>(RECENT_PROMPTS_KEY) ?? [];
+    return toPromptStrings(pruneRecentPrompts(stored, Date.now()));
+}
+
+export async function recordRecentPrompt(prompt: string): Promise<void> {
+    const stored = ext.context.globalState.get<RecentPrompt[]>(RECENT_PROMPTS_KEY) ?? [];
+    const updated = addRecentPrompt(stored, prompt, Date.now());
+    await ext.context.globalState.update(RECENT_PROMPTS_KEY, updated);
+}

--- a/src/webviews/copilotOnRails/extension/recentPrompts.ts
+++ b/src/webviews/copilotOnRails/extension/recentPrompts.ts
@@ -5,44 +5,44 @@
 
 import { ext } from '../../../extensionVariables';
 
-export type RecentPrompt = { prompt: string; ts: number };
-
+export const RECENT_PROMPTS_KEY = 'azureResourceGroups.copilotOnRails.recentPrompts';
 export const RECENT_PROMPT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 export const RECENT_PROMPT_MAX_COUNT = 25;
 
-// globalState (not workspaceState): the create flow opens a fresh empty folder per
-// project, so a workspace-scoped history would never surface a prior project's prompts.
-export const RECENT_PROMPTS_KEY = 'azureResourceGroups.copilotOnRails.recentPrompts';
+export type CopilotOnRailsRecentPrompt = {
+    prompt: string;
+    /** Epoch ms at which the prompt was submitted (i.e. `Date.now()`). */
+    timestamp: number;
+};
 
-/** Drops entries older than the retention window; keeps newest-first order. */
-export function pruneRecentPrompts(existing: RecentPrompt[], now: number): RecentPrompt[] {
+export function pruneRecentPrompts(existing: CopilotOnRailsRecentPrompt[], now: number): CopilotOnRailsRecentPrompt[] {
     const cutoff = now - RECENT_PROMPT_MAX_AGE_MS;
-    return existing.filter((entry) => entry.ts >= cutoff);
+    return existing.filter((entry) => entry.timestamp >= cutoff);
 }
 
-/** Records `prompt` as the newest entry; ignores blank input, dedupes by moving an existing match to the front. */
-export function addRecentPrompt(existing: RecentPrompt[], prompt: string, now: number): RecentPrompt[] {
+export function addRecentPrompt(existing: CopilotOnRailsRecentPrompt[], prompt: string, now: number): CopilotOnRailsRecentPrompt[] {
     const trimmed = prompt.trim();
     if (!trimmed) {
         return existing;
     }
 
     const withoutDuplicate = existing.filter((entry) => entry.prompt !== trimmed);
-    const next: RecentPrompt[] = [{ prompt: trimmed, ts: now }, ...withoutDuplicate];
+    const next: CopilotOnRailsRecentPrompt[] = [{ prompt: trimmed, timestamp: now }, ...withoutDuplicate];
     return pruneRecentPrompts(next, now).slice(0, RECENT_PROMPT_MAX_COUNT);
 }
 
-export function toPromptStrings(existing: RecentPrompt[]): string[] {
+export function toPromptStrings(existing: CopilotOnRailsRecentPrompt[]): string[] {
     return existing.map((entry) => entry.prompt);
 }
 
+/** Returns recent prompts ordered from most to least recent (index 0 is the newest prompt). */
 export function getRecentPrompts(): string[] {
-    const stored = ext.context.globalState.get<RecentPrompt[]>(RECENT_PROMPTS_KEY) ?? [];
+    const stored = ext.context.globalState.get<CopilotOnRailsRecentPrompt[]>(RECENT_PROMPTS_KEY) ?? [];
     return toPromptStrings(pruneRecentPrompts(stored, Date.now()));
 }
 
 export async function recordRecentPrompt(prompt: string): Promise<void> {
-    const stored = ext.context.globalState.get<RecentPrompt[]>(RECENT_PROMPTS_KEY) ?? [];
+    const stored = ext.context.globalState.get<CopilotOnRailsRecentPrompt[]>(RECENT_PROMPTS_KEY) ?? [];
     const updated = addRecentPrompt(stored, prompt, Date.now());
     await ext.context.globalState.update(RECENT_PROMPTS_KEY, updated);
 }

--- a/src/webviews/copilotOnRails/views/CreateProjectView.tsx
+++ b/src/webviews/copilotOnRails/views/CreateProjectView.tsx
@@ -7,7 +7,7 @@ import { Button, Textarea } from '@fluentui/react-components';
 import { ClipboardTaskListLtrRegular } from '@fluentui/react-icons';
 import { useConfiguration, WebviewContext } from '@microsoft/vscode-azext-webview/webview';
 import * as React from 'react';
-import { useContext, useState, type JSX } from 'react';
+import { useContext, useLayoutEffect, useRef, useState, type JSX } from 'react';
 import './styles/createProjectView.scss';
 import { type CreateProjectViewControllerType } from './utils/viewConfigTypes';
 
@@ -16,6 +16,24 @@ export const CreateProjectView = (): JSX.Element => {
     const { vscodeApi } = useContext(WebviewContext);
     const config = useConfiguration<CreateProjectViewControllerType>();
     const [selectedModel, setSelectedModel] = useState(config.modelOptions[0] ?? '');
+
+    const recentPrompts = config.recentPrompts ?? [];
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    // -1 means editing the live draft rather than navigating history.
+    const historyIndexRef = useRef(-1);
+    const draftRef = useRef('');
+    const caretToEndRef = useRef(false);
+
+    useLayoutEffect(() => {
+        if (caretToEndRef.current) {
+            caretToEndRef.current = false;
+            const el = textareaRef.current;
+            if (el) {
+                const end = el.value.length;
+                el.setSelectionRange(end, end);
+            }
+        }
+    }, [prompt]);
 
     const displayName = (model: string) => model.replace(/\s*\(copilot\)\s*$/i, '');
 
@@ -30,10 +48,60 @@ export const CreateProjectView = (): JSX.Element => {
         });
     };
 
+    const navigateToOlder = (): boolean => {
+        if (historyIndexRef.current >= recentPrompts.length - 1) {
+            return false;
+        }
+        if (historyIndexRef.current === -1) {
+            draftRef.current = prompt;
+        }
+        const newIndex = historyIndexRef.current + 1;
+        historyIndexRef.current = newIndex;
+        caretToEndRef.current = true;
+        setPrompt(recentPrompts[newIndex]);
+        return true;
+    };
+
+    const navigateToNewer = (): boolean => {
+        if (historyIndexRef.current < 0) {
+            return false;
+        }
+        const newIndex = historyIndexRef.current - 1;
+        historyIndexRef.current = newIndex;
+        caretToEndRef.current = true;
+        setPrompt(newIndex < 0 ? draftRef.current : recentPrompts[newIndex]);
+        return true;
+    };
+
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
             planClicked();
+            return;
         }
+
+        if (recentPrompts.length === 0) {
+            return;
+        }
+
+        const el = e.currentTarget;
+        if (e.key === 'ArrowUp') {
+            // Only navigate history at the caret's start, so multi-line caret movement is unaffected.
+            if (el.selectionStart === 0 && el.selectionEnd === 0 && navigateToOlder()) {
+                e.preventDefault();
+            }
+        } else if (e.key === 'ArrowDown') {
+            // Only step to a newer entry while navigating and at the caret's end.
+            if (historyIndexRef.current >= 0 && el.selectionStart === el.value.length && navigateToNewer()) {
+                e.preventDefault();
+            }
+        }
+    };
+
+    // A user edit starts a fresh draft. Fluent's onChange only fires on genuine input,
+    // not programmatic value changes, so this never runs during navigation.
+    const handleChange = (value: string) => {
+        historyIndexRef.current = -1;
+        setPrompt(value);
     };
 
     return (
@@ -51,10 +119,11 @@ export const CreateProjectView = (): JSX.Element => {
 
                 <div className='promptCard'>
                     <Textarea
+                        ref={textareaRef}
                         className='promptInput'
                         placeholder={config.promptPlaceholder}
                         value={prompt}
-                        onChange={(_e, data) => setPrompt(data.value)}
+                        onChange={(_e, data) => handleChange(data.value)}
                         onKeyDown={handleKeyDown}
                         rows={6}
                         resize='vertical'

--- a/src/webviews/copilotOnRails/views/CreateProjectView.tsx
+++ b/src/webviews/copilotOnRails/views/CreateProjectView.tsx
@@ -3,35 +3,30 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Button, Textarea } from "@fluentui/react-components";
-import { ClipboardTaskListLtrRegular } from "@fluentui/react-icons";
-import {
-    useConfiguration,
-    WebviewContext,
-} from "@microsoft/vscode-azext-webview/webview";
-import * as React from "react";
-import { useContext, useLayoutEffect, useRef, useState, type JSX } from "react";
-import "./styles/createProjectView.scss";
-import { type CreateProjectViewControllerType } from "./utils/viewConfigTypes";
+import { Button, Textarea } from '@fluentui/react-components';
+import { ClipboardTaskListLtrRegular } from '@fluentui/react-icons';
+import { useConfiguration, WebviewContext } from '@microsoft/vscode-azext-webview/webview';
+import * as React from 'react';
+import { useContext, useLayoutEffect, useRef, useState, type JSX } from 'react';
+import './styles/createProjectView.scss';
+import { type CreateProjectViewControllerType } from './utils/viewConfigTypes';
 
 export const CreateProjectView = (): JSX.Element => {
-    const [prompt, setPrompt] = useState("");
+    const [prompt, setPrompt] = useState('');
     const { vscodeApi } = useContext(WebviewContext);
     const config = useConfiguration<CreateProjectViewControllerType>();
-    const [selectedModel, setSelectedModel] = useState(
-        config.modelOptions[0] ?? "",
-    );
+    const [selectedModel, setSelectedModel] = useState(config.modelOptions[0] ?? '');
 
     const recentPrompts = config.recentPrompts ?? [];
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     // -1 means editing the live draft rather than navigating history.
     const historyIndexRef = useRef(-1);
-    const draftRef = useRef("");
+    const draftRef = useRef('');
     // After navigating history, park the caret on the edge matching the travel direction
     // (front when going to older, end when going to newer) so continued presses in the same
     // direction stay on the first/last line and keep cycling without an extra keystroke.
     // This behavior mirrors VS Code's Copilot Chat.
-    const caretTargetRef = useRef<"start" | "end" | null>(null);
+    const caretTargetRef = useRef<'start' | 'end' | null>(null);
 
     useLayoutEffect(() => {
         if (caretTargetRef.current) {
@@ -39,21 +34,20 @@ export const CreateProjectView = (): JSX.Element => {
             caretTargetRef.current = null;
             const el = textareaRef.current;
             if (el) {
-                const pos = target === "start" ? 0 : el.value.length;
+                const pos = target === 'start' ? 0 : el.value.length;
                 el.setSelectionRange(pos, pos);
             }
         }
     }, [prompt]);
 
-    const displayName = (model: string) =>
-        model.replace(/\s*\(copilot\)\s*$/i, "");
+    const displayName = (model: string) => model.replace(/\s*\(copilot\)\s*$/i, '');
 
     const planClicked = () => {
         if (!prompt.trim()) {
             return;
         }
         vscodeApi.postMessage({
-            command: "plan",
+            command: 'plan',
             prompt: prompt.trim(),
             model: selectedModel,
         });
@@ -69,7 +63,7 @@ export const CreateProjectView = (): JSX.Element => {
         const newIndex = historyIndexRef.current + 1;
         historyIndexRef.current = newIndex;
         // Older entries land at the front so the next ArrowUp is still on the first line.
-        caretTargetRef.current = "start";
+        caretTargetRef.current = 'start';
         setPrompt(recentPrompts[newIndex]);
         return true;
     };
@@ -81,13 +75,13 @@ export const CreateProjectView = (): JSX.Element => {
         const newIndex = historyIndexRef.current - 1;
         historyIndexRef.current = newIndex;
         // Newer entries land at the end so the next ArrowDown is still on the last line.
-        caretTargetRef.current = "end";
+        caretTargetRef.current = 'end';
         setPrompt(newIndex < 0 ? draftRef.current : recentPrompts[newIndex]);
         return true;
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+        if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
             planClicked();
             return;
         }
@@ -98,23 +92,16 @@ export const CreateProjectView = (): JSX.Element => {
 
         const el = e.currentTarget;
         const hasSelection = el.selectionStart !== el.selectionEnd;
-        if (e.key === "ArrowUp") {
+        if (e.key === 'ArrowUp') {
             // Only navigate history from the first line, so multi-line caret movement is unaffected.
-            const onFirstLine = !el.value
-                .slice(0, el.selectionStart)
-                .includes("\n");
+            const onFirstLine = !el.value.slice(0, el.selectionStart).includes('\n');
             if (!hasSelection && onFirstLine && navigateToOlder()) {
                 e.preventDefault();
             }
-        } else if (e.key === "ArrowDown") {
+        } else if (e.key === 'ArrowDown') {
             // Only step to a newer entry while navigating and from the last line.
-            const onLastLine = !el.value.slice(el.selectionEnd).includes("\n");
-            if (
-                !hasSelection &&
-                historyIndexRef.current >= 0 &&
-                onLastLine &&
-                navigateToNewer()
-            ) {
+            const onLastLine = !el.value.slice(el.selectionEnd).includes('\n');
+            if (!hasSelection && historyIndexRef.current >= 0 && onLastLine && navigateToNewer()) {
                 e.preventDefault();
             }
         }
@@ -128,47 +115,45 @@ export const CreateProjectView = (): JSX.Element => {
     };
 
     return (
-        <div className="createProjectView">
-            <div className="content">
-                <div className="headerSection">
-                    <div className="headerIcon">
-                        <div className="codicon codicon-copilot"></div>
+        <div className='createProjectView'>
+            <div className='content'>
+                <div className='headerSection'>
+                    <div className='headerIcon'>
+                        <div className='codicon codicon-copilot'></div>
                     </div>
                     <h1>{config.heading}</h1>
-                    <p className="subtitle">{config.subtitle}</p>
+                    <p className='subtitle'>
+                        {config.subtitle}
+                    </p>
                 </div>
 
-                <div className="promptCard">
+                <div className='promptCard'>
                     <Textarea
                         ref={textareaRef}
-                        className="promptInput"
+                        className='promptInput'
                         placeholder={config.promptPlaceholder}
                         value={prompt}
                         onChange={(_e, data) => handleChange(data.value)}
                         onKeyDown={handleKeyDown}
                         rows={6}
-                        resize="vertical"
+                        resize='vertical'
                     />
-                    <div className="promptActions">
-                        <div className="actionsLeft">
+                    <div className='promptActions'>
+                        <div className='actionsLeft'>
                             <select
-                                className="modelDropdown"
+                                className='modelDropdown'
                                 value={selectedModel}
-                                onChange={(e) =>
-                                    setSelectedModel(e.target.value)
-                                }
+                                onChange={(e) => setSelectedModel(e.target.value)}
                             >
                                 {config.modelOptions.map((model) => (
-                                    <option key={model} value={model}>
-                                        {displayName(model)}
-                                    </option>
+                                    <option key={model} value={model}>{displayName(model)}</option>
                                 ))}
                             </select>
-                            <span className="hint">{config.hint}</span>
+                            <span className='hint'>{config.hint}</span>
                         </div>
-                        <div className="buttonGroup">
+                        <div className='buttonGroup'>
                             <Button
-                                appearance="primary"
+                                appearance='primary'
                                 onClick={planClicked}
                                 disabled={!prompt.trim()}
                                 icon={<ClipboardTaskListLtrRegular />}

--- a/src/webviews/copilotOnRails/views/CreateProjectView.tsx
+++ b/src/webviews/copilotOnRails/views/CreateProjectView.tsx
@@ -3,46 +3,57 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Button, Textarea } from '@fluentui/react-components';
-import { ClipboardTaskListLtrRegular } from '@fluentui/react-icons';
-import { useConfiguration, WebviewContext } from '@microsoft/vscode-azext-webview/webview';
-import * as React from 'react';
-import { useContext, useLayoutEffect, useRef, useState, type JSX } from 'react';
-import './styles/createProjectView.scss';
-import { type CreateProjectViewControllerType } from './utils/viewConfigTypes';
+import { Button, Textarea } from "@fluentui/react-components";
+import { ClipboardTaskListLtrRegular } from "@fluentui/react-icons";
+import {
+    useConfiguration,
+    WebviewContext,
+} from "@microsoft/vscode-azext-webview/webview";
+import * as React from "react";
+import { useContext, useLayoutEffect, useRef, useState, type JSX } from "react";
+import "./styles/createProjectView.scss";
+import { type CreateProjectViewControllerType } from "./utils/viewConfigTypes";
 
 export const CreateProjectView = (): JSX.Element => {
-    const [prompt, setPrompt] = useState('');
+    const [prompt, setPrompt] = useState("");
     const { vscodeApi } = useContext(WebviewContext);
     const config = useConfiguration<CreateProjectViewControllerType>();
-    const [selectedModel, setSelectedModel] = useState(config.modelOptions[0] ?? '');
+    const [selectedModel, setSelectedModel] = useState(
+        config.modelOptions[0] ?? "",
+    );
 
     const recentPrompts = config.recentPrompts ?? [];
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     // -1 means editing the live draft rather than navigating history.
     const historyIndexRef = useRef(-1);
-    const draftRef = useRef('');
-    const caretToEndRef = useRef(false);
+    const draftRef = useRef("");
+    // After navigating history, park the caret on the edge matching the travel direction
+    // (front when going to older, end when going to newer) so continued presses in the same
+    // direction stay on the first/last line and keep cycling without an extra keystroke.
+    // This behavior mirrors VS Code's Copilot Chat.
+    const caretTargetRef = useRef<"start" | "end" | null>(null);
 
     useLayoutEffect(() => {
-        if (caretToEndRef.current) {
-            caretToEndRef.current = false;
+        if (caretTargetRef.current) {
+            const target = caretTargetRef.current;
+            caretTargetRef.current = null;
             const el = textareaRef.current;
             if (el) {
-                const end = el.value.length;
-                el.setSelectionRange(end, end);
+                const pos = target === "start" ? 0 : el.value.length;
+                el.setSelectionRange(pos, pos);
             }
         }
     }, [prompt]);
 
-    const displayName = (model: string) => model.replace(/\s*\(copilot\)\s*$/i, '');
+    const displayName = (model: string) =>
+        model.replace(/\s*\(copilot\)\s*$/i, "");
 
     const planClicked = () => {
         if (!prompt.trim()) {
             return;
         }
         vscodeApi.postMessage({
-            command: 'plan',
+            command: "plan",
             prompt: prompt.trim(),
             model: selectedModel,
         });
@@ -57,7 +68,8 @@ export const CreateProjectView = (): JSX.Element => {
         }
         const newIndex = historyIndexRef.current + 1;
         historyIndexRef.current = newIndex;
-        caretToEndRef.current = true;
+        // Older entries land at the front so the next ArrowUp is still on the first line.
+        caretTargetRef.current = "start";
         setPrompt(recentPrompts[newIndex]);
         return true;
     };
@@ -68,13 +80,14 @@ export const CreateProjectView = (): JSX.Element => {
         }
         const newIndex = historyIndexRef.current - 1;
         historyIndexRef.current = newIndex;
-        caretToEndRef.current = true;
+        // Newer entries land at the end so the next ArrowDown is still on the last line.
+        caretTargetRef.current = "end";
         setPrompt(newIndex < 0 ? draftRef.current : recentPrompts[newIndex]);
         return true;
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+        if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
             planClicked();
             return;
         }
@@ -84,14 +97,24 @@ export const CreateProjectView = (): JSX.Element => {
         }
 
         const el = e.currentTarget;
-        if (e.key === 'ArrowUp') {
-            // Only navigate history at the caret's start, so multi-line caret movement is unaffected.
-            if (el.selectionStart === 0 && el.selectionEnd === 0 && navigateToOlder()) {
+        const hasSelection = el.selectionStart !== el.selectionEnd;
+        if (e.key === "ArrowUp") {
+            // Only navigate history from the first line, so multi-line caret movement is unaffected.
+            const onFirstLine = !el.value
+                .slice(0, el.selectionStart)
+                .includes("\n");
+            if (!hasSelection && onFirstLine && navigateToOlder()) {
                 e.preventDefault();
             }
-        } else if (e.key === 'ArrowDown') {
-            // Only step to a newer entry while navigating and at the caret's end.
-            if (historyIndexRef.current >= 0 && el.selectionStart === el.value.length && navigateToNewer()) {
+        } else if (e.key === "ArrowDown") {
+            // Only step to a newer entry while navigating and from the last line.
+            const onLastLine = !el.value.slice(el.selectionEnd).includes("\n");
+            if (
+                !hasSelection &&
+                historyIndexRef.current >= 0 &&
+                onLastLine &&
+                navigateToNewer()
+            ) {
                 e.preventDefault();
             }
         }
@@ -105,45 +128,47 @@ export const CreateProjectView = (): JSX.Element => {
     };
 
     return (
-        <div className='createProjectView'>
-            <div className='content'>
-                <div className='headerSection'>
-                    <div className='headerIcon'>
-                        <div className='codicon codicon-copilot'></div>
+        <div className="createProjectView">
+            <div className="content">
+                <div className="headerSection">
+                    <div className="headerIcon">
+                        <div className="codicon codicon-copilot"></div>
                     </div>
                     <h1>{config.heading}</h1>
-                    <p className='subtitle'>
-                        {config.subtitle}
-                    </p>
+                    <p className="subtitle">{config.subtitle}</p>
                 </div>
 
-                <div className='promptCard'>
+                <div className="promptCard">
                     <Textarea
                         ref={textareaRef}
-                        className='promptInput'
+                        className="promptInput"
                         placeholder={config.promptPlaceholder}
                         value={prompt}
                         onChange={(_e, data) => handleChange(data.value)}
                         onKeyDown={handleKeyDown}
                         rows={6}
-                        resize='vertical'
+                        resize="vertical"
                     />
-                    <div className='promptActions'>
-                        <div className='actionsLeft'>
+                    <div className="promptActions">
+                        <div className="actionsLeft">
                             <select
-                                className='modelDropdown'
+                                className="modelDropdown"
                                 value={selectedModel}
-                                onChange={(e) => setSelectedModel(e.target.value)}
+                                onChange={(e) =>
+                                    setSelectedModel(e.target.value)
+                                }
                             >
                                 {config.modelOptions.map((model) => (
-                                    <option key={model} value={model}>{displayName(model)}</option>
+                                    <option key={model} value={model}>
+                                        {displayName(model)}
+                                    </option>
                                 ))}
                             </select>
-                            <span className='hint'>{config.hint}</span>
+                            <span className="hint">{config.hint}</span>
                         </div>
-                        <div className='buttonGroup'>
+                        <div className="buttonGroup">
                             <Button
-                                appearance='primary'
+                                appearance="primary"
                                 onClick={planClicked}
                                 disabled={!prompt.trim()}
                                 icon={<ClipboardTaskListLtrRegular />}

--- a/src/webviews/copilotOnRails/views/utils/viewConfigTypes.ts
+++ b/src/webviews/copilotOnRails/views/utils/viewConfigTypes.ts
@@ -12,6 +12,8 @@ export type CreateProjectViewControllerType = {
     planButtonLabel: string;
     modelLabel: string;
     modelOptions: string[];
+    /** Recently submitted project-creation prompts, newest-first, for input-history navigation. */
+    recentPrompts: string[];
 }
 
 export type DeploymentPlanViewStrings = {

--- a/test/copilotOnRails/recentPrompts.test.ts
+++ b/test/copilotOnRails/recentPrompts.test.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import {
+    addRecentPrompt,
+    pruneRecentPrompts,
+    RECENT_PROMPT_MAX_AGE_MS,
+    RECENT_PROMPT_MAX_COUNT,
+    toPromptStrings,
+    type RecentPrompt,
+} from '../../src/webviews/copilotOnRails/extension/recentPrompts';
+
+const NOW = 1_700_000_000_000;
+
+suite('recentPrompts', () => {
+    suite('addRecentPrompt', () => {
+        test('records the newest prompt first', () => {
+            let history: RecentPrompt[] = [];
+            history = addRecentPrompt(history, 'first', NOW);
+            history = addRecentPrompt(history, 'second', NOW + 1);
+
+            assert.deepStrictEqual(toPromptStrings(history), ['second', 'first']);
+        });
+
+        test('trims the prompt before recording', () => {
+            const history = addRecentPrompt([], '  padded  ', NOW);
+            assert.strictEqual(history[0].prompt, 'padded');
+        });
+
+        test('ignores empty/whitespace-only prompts and returns existing unchanged', () => {
+            const existing: RecentPrompt[] = [{ prompt: 'keep', ts: NOW }];
+            assert.strictEqual(addRecentPrompt(existing, '', NOW), existing);
+            assert.strictEqual(addRecentPrompt(existing, '   \n\t ', NOW), existing);
+        });
+
+        test('dedupes an identical trimmed prompt by moving it to the front', () => {
+            let history: RecentPrompt[] = [];
+            history = addRecentPrompt(history, 'a', NOW);
+            history = addRecentPrompt(history, 'b', NOW + 1);
+            history = addRecentPrompt(history, 'a', NOW + 2);
+
+            assert.deepStrictEqual(toPromptStrings(history), ['a', 'b']);
+            assert.strictEqual(history[0].ts, NOW + 2);
+        });
+
+        test('treats an untrimmed duplicate as the same entry', () => {
+            let history: RecentPrompt[] = [];
+            history = addRecentPrompt(history, 'dup', NOW);
+            history = addRecentPrompt(history, '  dup  ', NOW + 1);
+
+            assert.deepStrictEqual(toPromptStrings(history), ['dup']);
+        });
+
+        test('caps the history to the max count, newest-first', () => {
+            let history: RecentPrompt[] = [];
+            for (let i = 0; i < RECENT_PROMPT_MAX_COUNT + 5; i++) {
+                history = addRecentPrompt(history, `prompt-${i}`, NOW + i);
+            }
+
+            assert.strictEqual(history.length, RECENT_PROMPT_MAX_COUNT);
+            assert.strictEqual(history[0].prompt, `prompt-${RECENT_PROMPT_MAX_COUNT + 4}`);
+            assert.strictEqual(history[history.length - 1].prompt, `prompt-5`);
+        });
+
+        test('prunes entries older than the retention window when adding', () => {
+            const stale: RecentPrompt[] = [{ prompt: 'stale', ts: NOW - RECENT_PROMPT_MAX_AGE_MS - 1 }];
+            const history = addRecentPrompt(stale, 'fresh', NOW);
+
+            assert.deepStrictEqual(toPromptStrings(history), ['fresh']);
+        });
+    });
+
+    suite('pruneRecentPrompts', () => {
+        test('removes entries older than the retention window relative to now', () => {
+            const existing: RecentPrompt[] = [
+                { prompt: 'fresh', ts: NOW - 1000 },
+                { prompt: 'edge', ts: NOW - RECENT_PROMPT_MAX_AGE_MS },
+                { prompt: 'stale', ts: NOW - RECENT_PROMPT_MAX_AGE_MS - 1 },
+            ];
+
+            assert.deepStrictEqual(toPromptStrings(pruneRecentPrompts(existing, NOW)), ['fresh', 'edge']);
+        });
+
+        test('preserves newest-first ordering', () => {
+            const existing: RecentPrompt[] = [
+                { prompt: 'newest', ts: NOW },
+                { prompt: 'older', ts: NOW - 1000 },
+            ];
+
+            assert.deepStrictEqual(toPromptStrings(pruneRecentPrompts(existing, NOW)), ['newest', 'older']);
+        });
+    });
+});

--- a/test/copilotOnRails/recentPrompts.test.ts
+++ b/test/copilotOnRails/recentPrompts.test.ts
@@ -10,7 +10,7 @@ import {
     RECENT_PROMPT_MAX_AGE_MS,
     RECENT_PROMPT_MAX_COUNT,
     toPromptStrings,
-    type RecentPrompt,
+    type CopilotOnRailsRecentPrompt,
 } from '../../src/webviews/copilotOnRails/extension/recentPrompts';
 
 const NOW = 1_700_000_000_000;
@@ -18,7 +18,7 @@ const NOW = 1_700_000_000_000;
 suite('recentPrompts', () => {
     suite('addRecentPrompt', () => {
         test('records the newest prompt first', () => {
-            let history: RecentPrompt[] = [];
+            let history: CopilotOnRailsRecentPrompt[] = [];
             history = addRecentPrompt(history, 'first', NOW);
             history = addRecentPrompt(history, 'second', NOW + 1);
 
@@ -30,24 +30,18 @@ suite('recentPrompts', () => {
             assert.strictEqual(history[0].prompt, 'padded');
         });
 
-        test('ignores empty/whitespace-only prompts and returns existing unchanged', () => {
-            const existing: RecentPrompt[] = [{ prompt: 'keep', ts: NOW }];
-            assert.strictEqual(addRecentPrompt(existing, '', NOW), existing);
-            assert.strictEqual(addRecentPrompt(existing, '   \n\t ', NOW), existing);
-        });
-
         test('dedupes an identical trimmed prompt by moving it to the front', () => {
-            let history: RecentPrompt[] = [];
+            let history: CopilotOnRailsRecentPrompt[] = [];
             history = addRecentPrompt(history, 'a', NOW);
             history = addRecentPrompt(history, 'b', NOW + 1);
             history = addRecentPrompt(history, 'a', NOW + 2);
 
             assert.deepStrictEqual(toPromptStrings(history), ['a', 'b']);
-            assert.strictEqual(history[0].ts, NOW + 2);
+            assert.strictEqual(history[0].timestamp, NOW + 2);
         });
 
         test('treats an untrimmed duplicate as the same entry', () => {
-            let history: RecentPrompt[] = [];
+            let history: CopilotOnRailsRecentPrompt[] = [];
             history = addRecentPrompt(history, 'dup', NOW);
             history = addRecentPrompt(history, '  dup  ', NOW + 1);
 
@@ -55,7 +49,7 @@ suite('recentPrompts', () => {
         });
 
         test('caps the history to the max count, newest-first', () => {
-            let history: RecentPrompt[] = [];
+            let history: CopilotOnRailsRecentPrompt[] = [];
             for (let i = 0; i < RECENT_PROMPT_MAX_COUNT + 5; i++) {
                 history = addRecentPrompt(history, `prompt-${i}`, NOW + i);
             }
@@ -66,7 +60,7 @@ suite('recentPrompts', () => {
         });
 
         test('prunes entries older than the retention window when adding', () => {
-            const stale: RecentPrompt[] = [{ prompt: 'stale', ts: NOW - RECENT_PROMPT_MAX_AGE_MS - 1 }];
+            const stale: CopilotOnRailsRecentPrompt[] = [{ prompt: 'stale', timestamp: NOW - RECENT_PROMPT_MAX_AGE_MS - 1 }];
             const history = addRecentPrompt(stale, 'fresh', NOW);
 
             assert.deepStrictEqual(toPromptStrings(history), ['fresh']);
@@ -75,19 +69,19 @@ suite('recentPrompts', () => {
 
     suite('pruneRecentPrompts', () => {
         test('removes entries older than the retention window relative to now', () => {
-            const existing: RecentPrompt[] = [
-                { prompt: 'fresh', ts: NOW - 1000 },
-                { prompt: 'edge', ts: NOW - RECENT_PROMPT_MAX_AGE_MS },
-                { prompt: 'stale', ts: NOW - RECENT_PROMPT_MAX_AGE_MS - 1 },
+            const existing: CopilotOnRailsRecentPrompt[] = [
+                { prompt: 'fresh', timestamp: NOW - 1000 },
+                { prompt: 'edge', timestamp: NOW - RECENT_PROMPT_MAX_AGE_MS },
+                { prompt: 'stale', timestamp: NOW - RECENT_PROMPT_MAX_AGE_MS - 1 },
             ];
 
             assert.deepStrictEqual(toPromptStrings(pruneRecentPrompts(existing, NOW)), ['fresh', 'edge']);
         });
 
         test('preserves newest-first ordering', () => {
-            const existing: RecentPrompt[] = [
-                { prompt: 'newest', ts: NOW },
-                { prompt: 'older', ts: NOW - 1000 },
+            const existing: CopilotOnRailsRecentPrompt[] = [
+                { prompt: 'newest', timestamp: NOW },
+                { prompt: 'older', timestamp: NOW - 1000 },
             ];
 
             assert.deepStrictEqual(toPromptStrings(pruneRecentPrompts(existing, NOW)), ['newest', 'older']);


### PR DESCRIPTION
Let users cycle through their most recently submitted Copilot on Rails project-creation prompts with the Up/Down arrow keys, terminal/chat-style.