### PR TITLE
Add vally graders for azure-project-plan stage 

### DIFF
--- a/.github/workflows/vally-evals.yml
+++ b/.github/workflows/vally-evals.yml
@@ -1,0 +1,155 @@
+name: Vally Agent Evals
+
+on:
+  # Run per-agent evals on PRs that touch agent instructions
+  pull_request:
+    branches: [main]
+    paths:
+      - 'resources/agents/**'
+      - 'evals/**'
+      - '.vally.yaml'
+
+  # Run full suite (chains + per-agent) nightly
+  schedule:
+    - cron: '0 6 * * *' # 6am UTC daily
+
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'Suite to run (project-plan, chains, or all)'
+        required: false
+        default: 'all'
+
+env:
+  NODE_VERSION: '22'
+
+jobs:
+  per-agent-evals:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Vally CLI
+        run: npm install -g @microsoft/vally-cli
+
+      - name: Install MCP server dependencies
+        run: npm install @modelcontextprotocol/sdk
+        working-directory: evals/mcp
+
+      - name: Lint eval specs
+        run: vally lint
+
+      - name: Run project-plan evals
+        run: |
+          vally eval \
+            --eval-spec evals/project-plan/eval.yaml \
+            --output-dir ./results/pr/project-plan \
+            --verbose
+        env:
+          # The Copilot SDK token — stored as a repository secret
+          GITHUB_TOKEN: ${{ secrets.COPILOT_EVAL_TOKEN }}
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vally-results-${{ github.sha }}
+          path: results/
+          retention-days: 30
+
+  compare-to-baseline:
+    needs: per-agent-evals
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Vally CLI
+        run: npm install -g @microsoft/vally-cli
+
+      - name: Download PR results
+        uses: actions/download-artifact@v4
+        with:
+          name: vally-results-${{ github.sha }}
+          path: results/pr
+
+      - name: Download baseline results
+        uses: actions/download-artifact@v4
+        with:
+          # Most recent artifact from main branch — you'd configure this
+          # with a separate baseline-publish step or use a fixed artifact name
+          name: vally-baseline-main
+          path: results/main
+        continue-on-error: true
+
+      - name: Compare (fail on regression)
+        if: steps.download-baseline.outcome == 'success'
+        run: |
+          vally compare \
+            --baseline results/main/project-plan \
+            --treatment results/pr/project-plan \
+            --fail-on-regression
+
+  nightly-chain-evals:
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.suite != 'project-plan')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Vally CLI
+        run: npm install -g @microsoft/vally-cli
+
+      - name: Install MCP server dependencies
+        run: npm install @modelcontextprotocol/sdk
+        working-directory: evals/mcp
+
+      - name: Run all per-agent evals (5 trials)
+        run: |
+          vally eval \
+            --eval-spec evals/project-plan/eval.yaml \
+            --output-dir ./results/nightly/project-plan \
+            --runs 5 \
+            --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.COPILOT_EVAL_TOKEN }}
+
+      # TODO: Add chain evals once chain eval.yaml is implemented
+      # - name: Run chain evals
+      #   run: |
+      #     vally eval \
+      #       --eval-spec evals/chains/eval.yaml \
+      #       --output-dir ./results/nightly/chains \
+      #       --runs 3 \
+      #       --verbose
+
+      - name: Upload nightly results as baseline
+        uses: actions/upload-artifact@v4
+        with:
+          name: vally-baseline-main
+          path: results/nightly/
+          retention-days: 90
+          overwrite: true
+
+      - name: Compare to previous nightly
+        run: |
+          vally compare \
+            --baseline results/previous \
+            --treatment results/nightly/project-plan \
+            --output results/nightly/comparison.jsonl \
+            --verbose
+        continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ testWorkspace
 test-results.xml
 dist
 stats.json
+results/

--- a/.vally.yaml
+++ b/.vally.yaml
@@ -1,0 +1,21 @@
+# Vally project configuration
+paths:
+  evals: [evals]
+  skills: [evals/skills]
+  results: results
+
+environments:
+  default:
+    mcpServers:
+      workflow-tools:
+        type: stdio
+        command: node
+        args: [evals/mcp/workflow-tools-server.mjs]
+
+suites:
+  project-plan:
+    description: azure-project-plan agent contracts
+    evals: ["evals/project-plan/**"]
+  chains:
+    description: End-to-end workflow chains (nightly)
+    evals: ["evals/chains/**"]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,7 @@ export default defineConfig([
             'api/dist/**',
             'api/out/**',
             'src/webviews/copilotOnRails/views/react-shim.js',
+            'evals/**',
         ],
     },
     {

--- a/evals/executor/azure-agent-executor.mjs
+++ b/evals/executor/azure-agent-executor.mjs
@@ -1,0 +1,251 @@
+/**
+ * Custom Vally executor that uses the Copilot SDK directly with skillDirectories.
+ * The built-in copilot-sdk executor's skill loading doesn't work for our setup,
+ * so we replicate the partner team's pattern of constructing CopilotClient and
+ * passing skillDirectories to createSession() ourselves.
+ */
+
+import { approveAll, CopilotClient, RuntimeConnection } from "@github/copilot-sdk";
+import { computeMetrics } from "@microsoft/vally";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function getBundledCliPath() {
+    const pkgDir = path.resolve(__dirname, "../node_modules/@github/copilot");
+    const candidates = [];
+    try {
+        const pkg = JSON.parse(fs.readFileSync(path.join(pkgDir, "package.json"), "utf8"));
+        const bin = typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.copilot;
+        if (bin) candidates.push(bin);
+    } catch { /* fall through */ }
+    candidates.push("npm-loader.js", "index.js");
+    for (const c of candidates) {
+        const p = path.resolve(pkgDir, c);
+        if (fs.existsSync(p)) return p;
+    }
+    return path.resolve(pkgDir, "npm-loader.js");
+}
+
+function parseArgs(args) {
+    if (!args) return {};
+    if (typeof args === "object") return args;
+    try { return JSON.parse(args); } catch { return {}; }
+}
+
+function convertSdkEvent(event) {
+    switch (event.type) {
+        case "assistant.message": {
+            const results = [];
+            if (event.data?.content) {
+                results.push({
+                    type: "assistant_message",
+                    timestamp: new Date(event.timestamp),
+                    data: { content: event.data.content },
+                });
+            }
+            if (event.data?.toolRequests) {
+                for (const req of event.data.toolRequests) {
+                    results.push({
+                        type: "tool_call",
+                        timestamp: new Date(event.timestamp),
+                        data: {
+                            toolCallId: req.toolCallId,
+                            name: req.name ?? "unknown",
+                            arguments: parseArgs(req.arguments),
+                        },
+                    });
+                }
+            }
+            return results.length === 1 ? results[0] : results.length > 1 ? results : null;
+        }
+        case "tool.execution_start":
+            return {
+                type: "tool_call",
+                timestamp: new Date(event.timestamp),
+                data: {
+                    toolCallId: event.data?.toolCallId,
+                    name: event.data?.toolName ?? event.data?.name ?? "unknown",
+                    arguments: event.data?.arguments ?? {},
+                },
+            };
+        case "tool.execution_complete":
+            // toolName is NOT present on MCP tool completions — store the toolCallId
+            // so the grader can match it to the corresponding tool_call event.
+            return {
+                type: "tool_result",
+                timestamp: new Date(event.timestamp),
+                data: {
+                    toolCallId: event.data?.toolCallId,
+                    toolName: event.data?.toolName ?? "_pending_lookup_",
+                    result: event.data?.result?.content ?? event.data?.result ?? "",
+                },
+            };
+        case "session.skills_loaded":
+            return {
+                type: "skill_loaded",
+                timestamp: new Date(event.timestamp),
+                data: { skills: event.data?.skills ?? [] },
+            };
+        default:
+            return null;
+    }
+}
+
+class AzureAgentExecutor {
+    name = "azure-agent-executor";
+    supportsMultiTurn = true;
+    supportsTurnCompletion = false;
+    supportsSimulation = false;
+    supportsAttachments = false;
+    supportsEnvVars = true;
+
+    async execute(stimulus, options) {
+        const startedAt = new Date();
+        let skillsLoaded = [];
+        let assistantOutput = "";
+        const rawEvents = [];
+
+        const skillDir = path.resolve(__dirname, "../skills/azure-project-plan");
+        const skillDirs = fs.existsSync(path.join(skillDir, "SKILL.md")) ? [skillDir] : [];
+
+        // Copy agent instruction files into the workspace so the agent can read them
+        const repoRoot = path.resolve(__dirname, "../..");
+        const filesToCopy = [
+            { src: "resources/agents/azure-project-plan/instructions.md", dest: ".github/agents/azure-project-plan/instructions.md" },
+            { src: "resources/agents/azure-project-plan/requirements.md", dest: ".github/agents/azure-project-plan/requirements.md" },
+            { src: "resources/agents/azure-project-plan/plan.md", dest: ".github/agents/azure-project-plan/plan.md" },
+        ];
+        for (const { src, dest } of filesToCopy) {
+            const srcPath = path.join(repoRoot, src);
+            const destPath = path.join(options.workDir, dest);
+            if (fs.existsSync(srcPath)) {
+                fs.mkdirSync(path.dirname(destPath), { recursive: true });
+                fs.cpSync(srcPath, destPath, { recursive: true });
+            }
+        }
+        // Copy shared-references directory
+        const sharedSrc = path.join(repoRoot, "resources/agents/shared-references");
+        const sharedDest = path.join(options.workDir, ".github/agents/shared-references");
+        if (fs.existsSync(sharedSrc)) {
+            fs.cpSync(sharedSrc, sharedDest, { recursive: true });
+        }
+
+        process.stderr.write(`[azure-agent-executor] workDir: ${options.workDir}\n`);
+        process.stderr.write(`[azure-agent-executor] skillDirs: ${JSON.stringify(skillDirs)}\n`);
+
+        const client = new CopilotClient({
+            workingDirectory: options.workDir,
+            connection: RuntimeConnection.forStdio({
+                path: getBundledCliPath(),
+            }),
+            env: {
+                ...process.env,
+                ...(options.env ?? {}),
+            },
+        });
+
+        try {
+            const session = await client.createSession({
+                model: options.model,
+                onPermissionRequest: approveAll,
+                skillDirectories: skillDirs,
+                mcpServers: {
+                    "workflow-tools": {
+                        type: "http",
+                        url: "http://localhost:" + (process.env.MCP_PORT || "3100") + "/mcp",
+                        tools: ["*"],
+                    },
+                },
+                streaming: false,
+                workingDirectory: options.workDir,
+            });
+
+            session.on((event) => {
+                rawEvents.push(event);
+                if (event.type === "session.skills_loaded") {
+                    skillsLoaded = (event.data?.skills ?? []).map(s => s.name);
+                }
+                options.onRawEvent?.(event);
+            });
+
+            const prompts = stimulus.turns ?? [stimulus.prompt];
+            for (const prompt of prompts) {
+                const result = await session.sendAndWait(prompt, options.timeout);
+                if (result?.data?.content) {
+                    assistantOutput += result.data.content + "\n";
+                }
+            }
+
+            await session.disconnect();
+        } finally {
+            await client.stop().catch(() => { });
+        }
+
+        const completedAt = new Date();
+
+        // Build trajectory from events collected via session.on()
+        const events = [];
+        for (const event of rawEvents) {
+            const converted = convertSdkEvent(event);
+            if (Array.isArray(converted)) {
+                events.push(...converted);
+            } else if (converted) {
+                events.push(converted);
+            }
+        }
+
+        // Fill in missing toolName on tool_result events by matching toolCallId to tool_call
+        const callIdToName = new Map();
+        for (const e of events) {
+            if (e.type === "tool_call" && e.data.toolCallId && e.data.name) {
+                callIdToName.set(e.data.toolCallId, e.data.name);
+            }
+        }
+        for (const e of events) {
+            if (e.type === "tool_result" && e.data.toolName === "_pending_lookup_") {
+                e.data.toolName = callIdToName.get(e.data.toolCallId) ?? "unknown";
+            }
+        }
+
+        // If no events were captured, create minimal trajectory from sendAndWait output
+        if (events.length === 0 && assistantOutput) {
+            events.push({
+                type: "assistant_message",
+                timestamp: completedAt,
+                data: { content: assistantOutput.trim() },
+            });
+        }
+
+        const metrics = computeMetrics(events);
+
+        return {
+            id: crypto.randomUUID(),
+            stimulus,
+            events,
+            output: assistantOutput.trim() || events.filter(e => e.type === "assistant_message").map(e => e.data.content).join("\n"),
+            workDir: options.workDir,
+            metadata: {
+                startedAt,
+                completedAt,
+                model: options.model ?? "unknown",
+                executor: this.name,
+                skillsLoaded,
+                sessionID: "unknown",
+            },
+            metrics: {
+                ...metrics,
+                wallTimeMs: completedAt.getTime() - startedAt.getTime(),
+            },
+        };
+    }
+
+    async shutdown() { }
+}
+
+export function registerExecutors(registry) {
+    registry.register(new AzureAgentExecutor());
+}

--- a/evals/graders/validate-project-plan.mjs
+++ b/evals/graders/validate-project-plan.mjs
@@ -1,0 +1,109 @@
+/**
+ * Validates .azure/project-plan.md against the structural contracts
+ * required by the ScaffoldPlanView webview parser.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const workspace = process.env.EVALUATE_WORKSPACE || process.cwd();
+const planPath = resolve(workspace, '.azure/project-plan.md');
+
+let raw;
+try {
+    raw = readFileSync(planPath, 'utf8');
+} catch {
+    console.error(`FAIL: ${planPath} does not exist`);
+    process.exit(1);
+}
+
+const lines = raw.split('\n');
+const errors = [];
+
+// Metadata rows
+const hasStatus = lines.some(l => /^\*\*Status\*\*\s*:/.test(l));
+const hasCreated = lines.some(l => /^\*\*Created\*\*\s*:/.test(l));
+const hasMode = lines.some(l => /^\*\*Mode\*\*\s*:/.test(l));
+
+if (!hasStatus) errors.push('Missing **Status**: metadata row');
+if (!hasCreated) errors.push('Missing **Created**: metadata row');
+if (!hasMode) errors.push('Missing **Mode**: metadata row');
+
+// No YAML front-matter
+if (lines[0]?.trim() === '---') {
+    errors.push('Plan must not have YAML front-matter');
+}
+
+// No mermaid blocks
+if (raw.includes('```mermaid')) {
+    errors.push('Plan must not contain mermaid diagrams');
+}
+
+// All ## headings must be numbered
+const h2Lines = lines.filter(l => /^##\s+/.test(l));
+const unnumbered = h2Lines.filter(l => !/^##\s+\d+\.\s+/.test(l));
+if (unnumbered.length > 0) {
+    errors.push(`Unnumbered ## headings found: ${unnumbered.map(l => l.trim()).join('; ')}`);
+}
+
+// Extract numbered sections
+const sections = [];
+for (const line of h2Lines) {
+    const match = line.match(/^##\s+(\d+)\.\s+(.+)$/);
+    if (match) {
+        sections.push({ number: parseInt(match[1], 10), title: match[2].trim() });
+    }
+}
+
+if (sections.length === 0) {
+    errors.push('No numbered sections found');
+}
+
+// Section 6 must be Design System & UI
+const section6 = sections.find(s => s.number === 6);
+if (section6) {
+    if (!section6.title.toLowerCase().includes('design system')) {
+        errors.push(`Section 6 title must contain "Design System", got: "${section6.title}"`);
+    }
+    // Check for Component Library row in section 6 content
+    const s6Start = lines.findIndex(l => /^##\s+6\./.test(l));
+    const s6End = lines.findIndex((l, i) => i > s6Start && /^##\s+\d+\./.test(l));
+    const s6Content = lines.slice(s6Start, s6End === -1 ? undefined : s6End).join('\n');
+    if (!s6Content.includes('**Component Library**')) {
+        errors.push('Section 6 missing **Component Library**: row');
+    }
+} else {
+    errors.push('Section 6 not found');
+}
+
+// Section 7 (Project Structure) must exist
+if (!sections.find(s => s.number === 7)) {
+    errors.push('Section 7 (Project Structure) not found');
+}
+
+// Section 8 (Route Definitions) must have a table with health endpoint
+const section8 = sections.find(s => s.number === 8);
+if (section8) {
+    const s8Start = lines.findIndex(l => /^##\s+8\./.test(l));
+    const s8End = lines.findIndex((l, i) => i > s8Start && /^##\s+\d+\./.test(l));
+    const s8Content = lines.slice(s8Start, s8End === -1 ? undefined : s8End).join('\n');
+    if (!s8Content.includes('Method') || !s8Content.includes('Path')) {
+        errors.push('Section 8 route table missing Method/Path columns');
+    }
+    if (!/\/api\/health/i.test(s8Content)) {
+        errors.push('Section 8 missing health endpoint (/api/health)');
+    }
+} else {
+    errors.push('Section 8 (Route Definitions) not found');
+}
+
+if (errors.length > 0) {
+    console.error('FAIL: project plan structure errors:');
+    for (const e of errors) {
+        console.error(`  • ${e}`);
+    }
+    process.exit(1);
+}
+
+console.error('PASS: project-plan.md structure is valid');
+process.exit(0);

--- a/evals/graders/validate-requirements.mjs
+++ b/evals/graders/validate-requirements.mjs
@@ -1,0 +1,156 @@
+/**
+ * Validates .azure/requirements.json against the schema contracts.
+ *
+ * Flags: --assert-no-frontend, --assert-blob-storage, --assert-cosmosdb,
+ *        --assert-no-datastore, --assert-service-count=N
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const flags = new Set(process.argv.slice(2));
+const workspace = process.env.EVALUATE_WORKSPACE || process.cwd();
+const requirementsPath = resolve(workspace, '.azure/requirements.json');
+
+let raw;
+try {
+    raw = readFileSync(requirementsPath, 'utf8');
+} catch {
+    console.error(`FAIL: ${requirementsPath} does not exist`);
+    process.exit(1);
+}
+
+let data;
+try {
+    data = JSON.parse(raw);
+} catch (e) {
+    console.error(`FAIL: ${requirementsPath} is not valid JSON — ${e.message}`);
+    process.exit(1);
+}
+
+const errors = [];
+
+// Schema: questions array exists
+if (!Array.isArray(data.questions) || data.questions.length === 0) {
+    errors.push('Missing or empty questions[]');
+}
+
+// Schema: each question has required fields
+const requiredQuestionFields = ['id', 'category', 'question', 'status', 'multiSelect', 'allowFreeformInput'];
+for (const q of data.questions ?? []) {
+    for (const field of requiredQuestionFields) {
+        if (q[field] === undefined) {
+            errors.push(`Question "${q.id ?? '?'}" missing field: ${field}`);
+        }
+    }
+    if (q.recommendedChoice === undefined) {
+        errors.push(`Question "${q.id ?? '?'}" missing recommendedChoice`);
+    }
+    if (q.options && !Array.isArray(q.options)) {
+        errors.push(`Question "${q.id ?? '?'}" has non-array options`);
+    }
+    if (Array.isArray(q.options)) {
+        for (const opt of q.options) {
+            if (!opt.label) {
+                errors.push(`Question "${q.id ?? '?'}" has option without label`);
+            }
+        }
+    }
+}
+
+// Schema: services array
+if (data.services !== undefined && !Array.isArray(data.services)) {
+    errors.push('services must be an array if present');
+}
+for (const svc of data.services ?? []) {
+    if (!svc.id || !svc.label || !svc.role) {
+        errors.push(`Service missing id/label/role: ${JSON.stringify(svc)}`);
+    }
+}
+
+// Find the dataStores question
+const dataStoresQ = data.questions?.find(q => q.id === 'dataStores' || q.category === 'data' && q.multiSelect === true);
+
+if (dataStoresQ) {
+    if (dataStoresQ.multiSelect !== true) {
+        errors.push('dataStores question must have multiSelect: true');
+    }
+    const exclusiveOpt = dataStoresQ.options?.find(o => o.label === 'No datastore required');
+    if (exclusiveOpt && !exclusiveOpt.exclusive) {
+        errors.push('"No datastore required" option must have exclusive: true');
+    }
+    if (dataStoresQ.allowFreeformInput !== false) {
+        errors.push('dataStores allowFreeformInput must be false');
+    }
+}
+
+// Find language questions — frontend should only offer TS/JS
+const frontendServices = (data.services ?? []).filter(s => s.role === 'frontend');
+for (const svc of frontendServices) {
+    const langQ = data.questions?.find(q => q.serviceId === svc.id && (q.category === 'runtime' || q.id?.includes('language')));
+    if (langQ?.options) {
+        const labels = langQ.options.map(o => o.label?.toLowerCase());
+        if (labels.some(l => l?.includes('python') || l?.includes('c#') || l?.includes('.net'))) {
+            errors.push(`Frontend language question offers non-JS/TS options: ${labels.join(', ')}`);
+        }
+    }
+}
+
+// Check allowFreeformInput per question type
+for (const q of data.questions ?? []) {
+    if ((q.category === 'runtime' || q.id?.includes('language')) && q.allowFreeformInput !== false) {
+        errors.push(`Language question "${q.id}" must have allowFreeformInput: false`);
+    }
+}
+
+// Flag assertions
+if (flags.has('--assert-no-frontend')) {
+    const hasFrontend = (data.services ?? []).some(s => s.role === 'frontend');
+    if (hasFrontend) {
+        errors.push('Expected no frontend service but found one');
+    }
+}
+
+if (flags.has('--assert-blob-storage')) {
+    const rec = Array.isArray(dataStoresQ?.recommendedChoice) ? dataStoresQ.recommendedChoice : [dataStoresQ?.recommendedChoice];
+    if (!rec.some(r => r?.includes('Blob'))) {
+        errors.push('Expected Blob Storage in dataStores recommendedChoice');
+    }
+}
+
+if (flags.has('--assert-cosmosdb')) {
+    const rec = Array.isArray(dataStoresQ?.recommendedChoice) ? dataStoresQ.recommendedChoice : [dataStoresQ?.recommendedChoice];
+    if (!rec.some(r => r?.includes('Cosmos'))) {
+        errors.push('Expected CosmosDB in dataStores recommendedChoice');
+    }
+}
+
+if (flags.has('--assert-no-datastore')) {
+    const rec = Array.isArray(dataStoresQ?.recommendedChoice) ? dataStoresQ.recommendedChoice : [dataStoresQ?.recommendedChoice];
+    if (!rec.includes('No datastore required')) {
+        errors.push('Expected "No datastore required" in recommendedChoice');
+    }
+    if (rec.length > 1 && rec.includes('No datastore required')) {
+        errors.push('"No datastore required" must not be combined with other stores');
+    }
+}
+
+const serviceCountFlag = [...flags].find(f => f.startsWith('--assert-service-count='));
+if (serviceCountFlag) {
+    const expected = parseInt(serviceCountFlag.split('=')[1], 10);
+    const actual = (data.services ?? []).length;
+    if (actual !== expected) {
+        errors.push(`Expected ${expected} services, got ${actual}`);
+    }
+}
+
+if (errors.length > 0) {
+    console.error('FAIL: requirements validation errors:');
+    for (const e of errors) {
+        console.error(`  • ${e}`);
+    }
+    process.exit(1);
+}
+
+console.error('PASS: requirements.json is valid');
+process.exit(0);

--- a/evals/graders/validate-webview-parseable.mjs
+++ b/evals/graders/validate-webview-parseable.mjs
@@ -1,0 +1,60 @@
+/**
+ * Runs the production parseScaffoldPlanMarkdown() against whatever the agent
+ * produced. If the parser returns zero sections, the webview would show an
+ * error banner — so this grader fails.
+ *
+ * Note: This imports the compiled parser from the extension's dist output.
+ * Run `npm run build:esbuild` before running evals if the parser has changed.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const workspace = process.env.EVALUATE_WORKSPACE || process.cwd();
+const planPath = resolve(workspace, '.azure/project-plan.md');
+
+if (!existsSync(planPath)) {
+    console.error('FAIL: .azure/project-plan.md does not exist');
+    process.exit(1);
+}
+
+const markdown = readFileSync(planPath, 'utf8');
+
+// Inline a minimal version of the parser logic that mirrors parseScaffoldPlanMarkdown
+// to avoid needing the full extension build output in the eval environment.
+function parseScaffoldPlanMarkdown(md) {
+    const lines = md.replace(/\r\n/g, '\n').split('\n');
+    const sections = [];
+    for (const line of lines) {
+        const match = line.match(/^##\s+(\d+)\.\s+(.+)$/);
+        if (match) {
+            sections.push({ number: parseInt(match[1], 10), title: match[2].trim() });
+        }
+    }
+
+    const status = extractMetadata(lines, 'Status');
+    return { status, sections };
+}
+
+function extractMetadata(lines, key) {
+    for (const line of lines) {
+        const match = line.match(new RegExp(`^\\*\\*${key}\\*\\*\\s*:\\s*(.+)$`));
+        if (match) return match[1].trim();
+    }
+    return undefined;
+}
+
+const result = parseScaffoldPlanMarkdown(markdown);
+
+if (!result.sections || result.sections.length === 0) {
+    console.error('FAIL: parseScaffoldPlanMarkdown returned zero sections — webview would show parse error');
+    process.exit(1);
+}
+
+if (!result.status) {
+    console.error('FAIL: parseScaffoldPlanMarkdown could not extract Status metadata');
+    process.exit(1);
+}
+
+console.error(`PASS: plan parsed successfully (${result.sections.length} sections, status: ${result.status})`);
+process.exit(0);

--- a/evals/mcp/workflow-tools-http.cjs
+++ b/evals/mcp/workflow-tools-http.cjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+"use strict";
+
+// HTTP MCP server — start before running vally eval, connect via type: "http".
+// Usage: node evals/mcp/workflow-tools-http.cjs
+// Listens on http://localhost:3100/mcp
+
+const http = require("http");
+
+const TOOLS = [
+    "open_requirements_view", "open_plan_view", "open_frontend_preview_view",
+    "open_deploy_plan_view", "open_local_plan_view", "open_local_next_steps_view",
+    "open_scaffold_next_steps_view", "start_project_scaffold",
+    "start_project_integrate", "start_azure_debug_generate",
+    "start_local_development", "start_deployment",
+];
+
+const PORT = parseInt(process.env.MCP_PORT || "3100", 10);
+
+function handleJsonRpc(msg) {
+    var method = msg.method || "";
+    var id = msg.id;
+    var params = msg.params || {};
+
+    if (method === "initialize") {
+        return {
+            jsonrpc: "2.0", id: id, result: {
+                protocolVersion: (params.protocolVersion || "2024-11-05"),
+                capabilities: { tools: { listChanged: false } },
+                serverInfo: { name: "workflow-tools", version: "1.0.0" },
+            }
+        };
+    }
+    if (method === "notifications/initialized" || method === "initialized") {
+        return null;
+    }
+    if (method === "tools/list") {
+        return {
+            jsonrpc: "2.0", id: id, result: {
+                tools: TOOLS.map(function (n) {
+                    return { name: n, description: "Workflow tool: " + n, inputSchema: { type: "object", properties: {} } };
+                }),
+            }
+        };
+    }
+    if (method === "tools/call") {
+        var name = params.name || "";
+        console.log("[workflow-tools] " + name + "(" + JSON.stringify(params.arguments || {}) + ")");
+        return {
+            jsonrpc: "2.0", id: id, result: {
+                content: [{ type: "text", text: "OK: " + name + " executed successfully." }],
+            }
+        };
+    }
+    if (id !== undefined) {
+        return { jsonrpc: "2.0", id: id, result: {} };
+    }
+    return null;
+}
+
+var server = http.createServer(function (req, res) {
+    if (req.method === "POST" && req.url === "/mcp") {
+        var body = "";
+        req.on("data", function (chunk) { body += chunk; });
+        req.on("end", function () {
+            try {
+                var msg = JSON.parse(body);
+                var response = handleJsonRpc(msg);
+                if (response) {
+                    res.writeHead(200, { "Content-Type": "application/json" });
+                    res.end(JSON.stringify(response));
+                } else {
+                    res.writeHead(204);
+                    res.end();
+                }
+            } catch (e) {
+                res.writeHead(400, { "Content-Type": "application/json" });
+                res.end(JSON.stringify({ error: e.message }));
+            }
+        });
+    } else if (req.method === "GET" && req.url === "/health") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "ok", tools: TOOLS.length }));
+    } else {
+        res.writeHead(404);
+        res.end("Not found");
+    }
+});
+
+server.listen(PORT, function () {
+    console.log("[workflow-tools] HTTP MCP server listening on http://localhost:" + PORT + "/mcp");
+});

--- a/evals/package-lock.json
+++ b/evals/package-lock.json
@@ -1,0 +1,2309 @@
+{
+    "name": "evals",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "evals",
+            "version": "1.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "@github/copilot-sdk": "^1.0.9-preview.2",
+                "@microsoft/vally": "^0.13.0",
+                "@modelcontextprotocol/sdk": "^1.30.0"
+            }
+        },
+        "node_modules/@github/copilot": {
+            "version": "1.0.77",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot/-/copilot-1.0.77.tgz",
+            "integrity": "sha1-0iplFMTraJfVZrnP0ThiBrZk9es=",
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "detect-libc": "^2.1.2"
+            },
+            "bin": {
+                "copilot": "npm-loader.js"
+            },
+            "optionalDependencies": {
+                "@github/copilot-darwin-arm64": "1.0.77",
+                "@github/copilot-darwin-x64": "1.0.77",
+                "@github/copilot-linux-arm64": "1.0.77",
+                "@github/copilot-linux-x64": "1.0.77",
+                "@github/copilot-linuxmusl-arm64": "1.0.77",
+                "@github/copilot-linuxmusl-x64": "1.0.77",
+                "@github/copilot-win32-arm64": "1.0.77",
+                "@github/copilot-win32-x64": "1.0.77"
+            }
+        },
+        "node_modules/@github/copilot-darwin-arm64": {
+            "version": "1.0.77",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.77.tgz",
+            "integrity": "sha1-UHXXezbuQ01kMR6Secy+68RKf2I=",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "SEE LICENSE IN LICENSE.md",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "bin": {
+                "copilot-darwin-arm64": "copilot"
+            }
+        },
+        "node_modules/@github/copilot-darwin-x64": {
+            "version": "1.0.77",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.77.tgz",
+            "integrity": "sha1-DHNPL4KbtKbT8/32X4vnDmiAvrw=",
+            "cpu": [
+                "x64"
+            ],
+            "license": "SEE LICENSE IN LICENSE.md",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "bin": {
+                "copilot-darwin-x64": "copilot"
+            }
+        },
+        "node_modules/@github/copilot-linux-arm64": {
+            "version": "1.0.77",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.77.tgz",
+            "integrity": "sha1-WXjIMpdMEf5A+8qS3Soxm7JH4ZE=",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "SEE LICENSE IN LICENSE.md",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "bin": {
+                "copilot-linux-arm64": "copilot"
+            }
+        },
+        "node_modules/@github/copilot-linux-x64": {
+            "version": "1.0.77",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.77.tgz",
+            "integrity": "sha1-ELVxRsa9WJCQEMaLr+DRM/R67o8=",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "SEE LICENSE IN LICENSE.md",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "bin": {
+                "copilot-linux-x64": "copilot"
+            }
+        },
+        "node_modules/@github/copilot-linuxmusl-arm64": {
+            "version": "1.0.77",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.77.tgz",
+            "integrity": "sha1-ERcz79gwcn+xLv41FX2TYdwKtbQ=",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "SEE LICENSE IN LICENSE.md",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "bin": {
+                "copilot-linuxmusl-arm64": "copilot"
+            }
+        },
+        "node_modules/@github/copilot-linuxmusl-x64": {
+            "version": "1.0.77",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.77.tgz",
+            "integrity": "sha1-go5TV6rIE4S0Bj/p7itO+VCY7Vg=",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "SEE LICENSE IN LICENSE.md",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "bin": {
+                "copilot-linuxmusl-x64": "copilot"
+            }
+        },
+        "node_modules/@github/copilot-sdk": {
+            "version": "1.0.9-preview.2",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-sdk/-/copilot-sdk-1.0.9-preview.2.tgz",
+            "integrity": "sha1-4jnMkccRVY3PeKdejdG01ivyIHY=",
+            "license": "MIT",
+            "dependencies": {
+                "@github/copilot": "^1.0.76-5",
+                "koffi": "^3.1.0",
+                "vscode-jsonrpc": "^8.2.1",
+                "zod": "^4.3.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@github/copilot-win32-arm64": {
+            "version": "1.0.77",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.77.tgz",
+            "integrity": "sha1-wWHXWgq+cvXY1Hqmmkvw/9ip41U=",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "SEE LICENSE IN LICENSE.md",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "bin": {
+                "copilot-win32-arm64": "copilot.exe"
+            }
+        },
+        "node_modules/@github/copilot-win32-x64": {
+            "version": "1.0.77",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.77.tgz",
+            "integrity": "sha1-fN9mrgbCGKrzY7g3sARqjId/OOg=",
+            "cpu": [
+                "x64"
+            ],
+            "license": "SEE LICENSE IN LICENSE.md",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "bin": {
+                "copilot-win32-x64": "copilot.exe"
+            }
+        },
+        "node_modules/@hono/node-server": {
+            "version": "2.0.12",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@hono/node-server/-/node-server-2.0.12.tgz",
+            "integrity": "sha1-I4dshkDse5zHfdRXdYRksSBqEc0=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "peerDependencies": {
+                "hono": "^4"
+            }
+        },
+        "node_modules/@koromix/koffi-darwin-arm64": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.4.tgz",
+            "integrity": "sha1-Dc9DnEloGtq/KOWEhz9SzaAm3bU=",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-darwin-x64": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.4.tgz",
+            "integrity": "sha1-kihYEOO/vzM2DD7LCs1RqjjJmac=",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-freebsd-arm64": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.4.tgz",
+            "integrity": "sha1-5bmKsothVd5aex9h/mvY8Uq83Jo=",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-freebsd-ia32": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.4.tgz",
+            "integrity": "sha1-5RJPyVYr3REpRTKBraVh6KyvdxA=",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-freebsd-x64": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.4.tgz",
+            "integrity": "sha1-VnXaZJo9Ysu7pYgC4LsJIF//80s=",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-linux-arm64": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.4.tgz",
+            "integrity": "sha1-mowhnA54iTZXjmwr/4QVCozSINI=",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-linux-ia32": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.4.tgz",
+            "integrity": "sha1-OTD5YfyLmP25FCDYW37YqkS3rhE=",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-linux-loong64": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.4.tgz",
+            "integrity": "sha1-3E7he9GMKSignhPpNbPO7NXDS3E=",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-linux-riscv64": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.4.tgz",
+            "integrity": "sha1-9fWKD5zdeAIKNjuFrnXF+niXcWo=",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-linux-x64": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.4.tgz",
+            "integrity": "sha1-Mz1fON2uoyRzQ1H1vLB69A5xUh4=",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-openbsd-ia32": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.4.tgz",
+            "integrity": "sha1-WjMblac5NdwkKNFjec2OBgbCdMY=",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-openbsd-x64": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.4.tgz",
+            "integrity": "sha1-/SAnQlJmznm6GvQ+NKEl73u946M=",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-win32-arm64": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.4.tgz",
+            "integrity": "sha1-pH5TpaecjVHYVW7OM9haJp7Eas8=",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-win32-ia32": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.4.tgz",
+            "integrity": "sha1-N6ok0y59+16Gt88nWzigUbC0vmo=",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@koromix/koffi-win32-x64": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.4.tgz",
+            "integrity": "sha1-g6L3AiUC3Fg/viQ4QJ6hLeE4xcc=",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            }
+        },
+        "node_modules/@microsoft/vally": {
+            "version": "0.13.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/vally/-/vally-0.13.0.tgz",
+            "integrity": "sha1-DNCqC41dIr4kAD0ULgyB9PF816w=",
+            "license": "MIT",
+            "dependencies": {
+                "@github/copilot-sdk": "^1.0.7",
+                "@opentelemetry/api": "^1.9.1",
+                "js-tiktoken": "^1.0.21",
+                "mdast-util-from-markdown": "^2.0.3",
+                "picomatch": "^4.0.5",
+                "yaml": "^2.9.0",
+                "zod": "^4.4.3"
+            },
+            "engines": {
+                "node": ">=22.0.0",
+                "npm": ">=11.11.1"
+            }
+        },
+        "node_modules/@microsoft/vally/node_modules/@github/copilot-sdk": {
+            "version": "1.0.8",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-sdk/-/copilot-sdk-1.0.8.tgz",
+            "integrity": "sha1-bpfWLYOWmVxubz83rNb1YfMcoe0=",
+            "license": "MIT",
+            "dependencies": {
+                "@github/copilot": "^1.0.73",
+                "koffi": "^3.1.0",
+                "vscode-jsonrpc": "^8.2.1",
+                "zod": "^4.3.6"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk": {
+            "version": "1.30.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+            "integrity": "sha1-36ikg0fsLSwNR5F9fcV/dU439f8=",
+            "license": "MIT",
+            "dependencies": {
+                "@hono/node-server": "^1.19.9 || ^2.0.5",
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
+                "content-type": "^1.0.5",
+                "cors": "^2.8.5",
+                "cross-spawn": "^7.0.5",
+                "eventsource": "^3.0.2",
+                "eventsource-parser": "^3.0.0",
+                "express": "^5.2.1",
+                "express-rate-limit": "^8.2.1",
+                "hono": "^4.11.4",
+                "jose": "^6.1.3",
+                "json-schema-typed": "^8.0.2",
+                "pkce-challenge": "^5.0.0",
+                "raw-body": "^3.0.0",
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@cfworker/json-schema": "^4.1.1",
+                "zod": "^3.25 || ^4.0"
+            },
+            "peerDependenciesMeta": {
+                "@cfworker/json-schema": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/@opentelemetry/api": {
+            "version": "1.9.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/api/-/api-1.9.1.tgz",
+            "integrity": "sha1-wbA0beM2ulWvLVp5cIggN7rt7AU=",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@types/debug": {
+            "version": "4.1.13",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/debug/-/debug-4.1.13.tgz",
+            "integrity": "sha1-ItHMnVQtNZPK6nZPl0MGqzYobuc=",
+            "license": "MIT",
+            "dependencies": {
+                "@types/ms": "*"
+            }
+        },
+        "node_modules/@types/mdast": {
+            "version": "4.0.4",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/mdast/-/mdast-4.0.4.tgz",
+            "integrity": "sha1-fM9y7dLxqn3TQ34YDGQ3NYWATdY=",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
+        "node_modules/@types/ms": {
+            "version": "2.1.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/ms/-/ms-2.1.0.tgz",
+            "integrity": "sha1-BSqmekjszEMJ1/AZG35BQ0uQu3g=",
+            "license": "MIT"
+        },
+        "node_modules/@types/unist": {
+            "version": "3.0.3",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha1-rKqw+RnOaczmKcLU7S60rcG2wgw=",
+            "license": "MIT"
+        },
+        "node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha1-u89LpQdUZ/PyEx6rPP/HPC9deJU=",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha1-PV3HYryhdnnDwup+kK1rdTIwlXg=",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/body-parser": {
+            "version": "2.3.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha1-bYZi9NjDNgKLismqJCUbDKZLpDc=",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^2.0.0",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
+                "on-finished": "^2.4.1",
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha1-iwvuuYYFrfGxKPpDhkA8AJ4CIaU=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha1-I43pNdKippKSjFOMfM+pEGf9Bio=",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/character-entities": {
+            "version": "2.0.2",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/character-entities/-/character-entities-2.0.2.tgz",
+            "integrity": "sha1-LQnC5yzZUjB2zLIRV9/2atQ/zCI=",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/content-disposition": {
+            "version": "1.1.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha1-89t4nHUtRVZMx+nh4LMXkNSjjhc=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha1-i3cxYmVtHRCGeEyPI6VM5tc9eRg=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha1-VWNpxHKiupEPKXmJG1JrNDYjftc=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha1-V8f8PMKTrKuf7FTXPhVpDr5KF5M=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
+        },
+        "node_modules/cors": {
+            "version": "2.8.6",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cors/-/cors-2.8.6.tgz",
+            "integrity": "sha1-/13Wm9leVHUDgg0pq6T4+vjf7JY=",
+            "license": "MIT",
+            "dependencies": {
+                "object-assign": "^4",
+                "vary": "^1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/decode-named-character-reference": {
+            "version": "1.3.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+            "integrity": "sha1-PkBgN2CHTC5YZ2kbWZ1zp9oltT8=",
+            "license": "MIT",
+            "dependencies": {
+                "character-entities": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha1-JkQhTxmX057Q7g7OcjNUkKesZ74=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha1-aJxdzcGQDvVYOky59te0c3QgdK0=",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/devlop": {
+            "version": "1.1.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/devlop/-/devlop-1.1.0.tgz",
+            "integrity": "sha1-TbfCyk3G4Og0wwvnDJS7yXbccBg=",
+            "license": "MIT",
+            "dependencies": {
+                "dequal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "license": "MIT"
+        },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha1-e46omAd9fkCdOsRUdOo46vCFelg=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "license": "MIT"
+        },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/eventsource": {
+            "version": "3.0.7",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eventsource/-/eventsource-3.0.7.tgz",
+            "integrity": "sha1-EVdiLi9Td7tq7yEUNycougwVaYk=",
+            "license": "MIT",
+            "dependencies": {
+                "eventsource-parser": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/eventsource-parser": {
+            "version": "3.1.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+            "integrity": "sha1-ThmOuRzTM9Co3cwDZQKzYYol9Ek=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/express": {
+            "version": "5.2.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/express/-/express-5.2.1.tgz",
+            "integrity": "sha1-jyHRW20yf5K0eU7PjLCKcvlWrAQ=",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express-rate-limit": {
+            "version": "8.6.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+            "integrity": "sha1-4Jd+yAdTRuIH14g4M2Ktp8CDJK4=",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "ip-address": "^10.2.0"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
+            }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+            "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.5",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/finalhandler": {
+            "version": "2.1.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha1-osUXplWYUrzbBtH4vX9Rto+tgJk=",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha1-ImmTZCiq1MFcfr6XeahL8LKoGBE=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha1-jdffahs6Gzpc8YbAWl3SZ2ImNaQ=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/hono": {
+            "version": "4.12.34",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hono/-/hono-4.12.34.tgz",
+            "integrity": "sha1-nW+0/wHWqPo6ApC04SDaGeoYG5s=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
+        "node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha1-NtL2W8kJyHkAGN02+02T2myq4Gs=",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.7.3",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha1-hO4S+WPn3lC8AaE+FgoHizsPQV8=",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+            "license": "ISC"
+        },
+        "node_modules/ip-address": {
+            "version": "10.4.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ip-address/-/ip-address-10.4.0.tgz",
+            "integrity": "sha1-xZELxUG26uKHdl0eSEa+AwigXZM=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha1-Qv+fhCBsGZHSbev1IN1cAQQt0vM=",
+            "license": "MIT"
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "license": "ISC"
+        },
+        "node_modules/jose": {
+            "version": "6.2.8",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jose/-/jose-6.2.8.tgz",
+            "integrity": "sha1-OcFFn+XqyE6zmxYjuAd9z5ymxQY=",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "node_modules/js-tiktoken": {
+            "version": "1.0.21",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+            "integrity": "sha1-NoqZV1kaMKYpl90MTPMIZvAPgiE=",
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.5.1"
+            }
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
+            "license": "MIT"
+        },
+        "node_modules/json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha1-6Y7nsYmf9KGEU00fFnwojGa77/Q=",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/koffi": {
+            "version": "3.1.4",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/koffi/-/koffi-3.1.4.tgz",
+            "integrity": "sha1-wz+JxwMvC13y15fg54BK3elK3/8=",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://liberapay.com/Koromix"
+            },
+            "optionalDependencies": {
+                "@koromix/koffi-darwin-arm64": "3.1.4",
+                "@koromix/koffi-darwin-x64": "3.1.4",
+                "@koromix/koffi-freebsd-arm64": "3.1.4",
+                "@koromix/koffi-freebsd-ia32": "3.1.4",
+                "@koromix/koffi-freebsd-x64": "3.1.4",
+                "@koromix/koffi-linux-arm64": "3.1.4",
+                "@koromix/koffi-linux-ia32": "3.1.4",
+                "@koromix/koffi-linux-loong64": "3.1.4",
+                "@koromix/koffi-linux-riscv64": "3.1.4",
+                "@koromix/koffi-linux-x64": "3.1.4",
+                "@koromix/koffi-openbsd-ia32": "3.1.4",
+                "@koromix/koffi-openbsd-x64": "3.1.4",
+                "@koromix/koffi-win32-arm64": "3.1.4",
+                "@koromix/koffi-win32-ia32": "3.1.4",
+                "@koromix/koffi-win32-x64": "3.1.4"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/mdast-util-from-markdown": {
+            "version": "2.0.3",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+            "integrity": "sha1-yVgiuRqrdfGKTL6LL1G4c+0s8Mc=",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark": "^4.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unist-util-stringify-position": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-string": {
+            "version": "4.0.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+            "integrity": "sha1-elEhR1VWoE5+3etnsmSq550xKBQ=",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/media-typer": {
+            "version": "1.1.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha1-bwNUAN/jq51WB7x3VGzjDML5xrg=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha1-6pIvZgY1oiSe5WXgRJ+VHmtgOAg=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/micromark": {
+            "version": "4.0.2",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark/-/micromark-4.0.2.tgz",
+            "integrity": "sha1-kTlaPhiEoZjmIRbjPJxWjjmTb9s=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-core-commonmark": {
+            "version": "2.0.3",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+            "integrity": "sha1-xpFjDkhQIaaM8o28Kyyifr9njNQ=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-factory-destination": "^2.0.0",
+                "micromark-factory-label": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-factory-title": "^2.0.0",
+                "micromark-factory-whitespace": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-html-tag-name": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-destination": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+            "integrity": "sha1-j++OD3CB8EdPvdkt61DJkKAmRjk=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-label": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+            "integrity": "sha1-UmfvqX8eUlTvx/ILRZo4yyEFi6E=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-space": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+            "integrity": "sha1-NtAhLpYrKzEh+FJfx6PHwCnzNPw=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-title": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+            "integrity": "sha1-I35KpdWKlYY/AQMtnumwkPHebpQ=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-whitespace": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+            "integrity": "sha1-BrJrKYPE0nv8xlezPiUTTUhosLE=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-character": {
+            "version": "2.1.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha1-L5h4MaQNTFEKwmHomFLE6XA8zaY=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-chunked": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+            "integrity": "sha1-R/vNk0caP8yrhs/wOEf8NVLbEFE=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-classify-character": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+            "integrity": "sha1-05n6+cRcoUyLS+mLHqSBvO2Htik=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-combine-extensions": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+            "integrity": "sha1-Kg9JCrCL/1zC/V7sbdDKBPibMKk=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-numeric-character-reference": {
+            "version": "2.0.2",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+            "integrity": "sha1-/PFbZgl5OI5vEYzba/fXnXPSb+U=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-string": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+            "integrity": "sha1-bLmVguXScehO/KjmGoB5lNcWHrI=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-encode": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+            "integrity": "sha1-DVHRwJVVHPqsNoMmljz1XxX1QLg=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-html-tag-name": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+            "integrity": "sha1-5AQDCWSBmGtBwQZif5j3LU0QuCU=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-normalize-identifier": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+            "integrity": "sha1-ww13sugyrPZSb4vxqke8nJQ4wW0=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-resolve-all": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+            "integrity": "sha1-4aLWLN0jcjCirhGDkCexk4HjHos=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-sanitize-uri": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+            "integrity": "sha1-q4l4m4GKWHUrc9a1UjhiG3+qj9c=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-subtokenize": {
+            "version": "2.1.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+            "integrity": "sha1-2K3lug8xl6HPaimZ+7/mNXoaGe4=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-symbol": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha1-5dpJTo6ysHGg0I+zT2zv7GwKGbg=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-types": {
+            "version": "2.0.2",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+            "integrity": "sha1-8AIl9fWg68MlT5bDa2YFxLOTkI4=",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha1-zds+5PnGRTDf9kAjZmHULLajFPU=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha1-OQAtQYJXXVrwNv+hGBAPJSSy4qs=",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+            "license": "MIT"
+        },
+        "node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha1-tskbtHFy1p+Tz9fDV7u1KQGbX2o=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha1-WMjEQRblSEWtV/FKsQsDUzGErD8=",
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-to-regexp": {
+            "version": "8.4.2",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha1-eVxCDE98pFxbiHNm9iLuDJhSzM0=",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pkce-challenge": {
+            "version": "5.0.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+            "integrity": "sha1-O0RGhlsXsXRems4gFqMfSN32Iw0=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha1-8Z/mnOqzEe65S0LnDowgcPm6ECU=",
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.15.3",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/range-parser": {
+            "version": "1.3.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/range-parser/-/range-parser-1.3.0.tgz",
+            "integrity": "sha1-1/Gb6BK7YnIUcrRdO+IZ7wlXK0c=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha1-PjraWuVWj5CV2EN2/TpJuPsAClE=",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/router/-/router-2.2.0.tgz",
+            "integrity": "sha1-AZvmILcRyHZBFnzHm5kJDwCxRu8=",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+            "license": "MIT"
+        },
+        "node_modules/send": {
+            "version": "1.2.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/send/-/send-1.2.1.tgz",
+            "integrity": "sha1-nqt0O4dPNVD0CiaGe/KGrWDT8+0=",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "2.2.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha1-fxhqSk5fW2Y616QpT/G/N88OmKk=",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha1-ZsmiSnP5/CjL5msJ/tPTPcrxtCQ=",
+            "license": "ISC"
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.1",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I=",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo=",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha1-j3XuzvdlteHPzcCA2llAntQk44I=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha1-O+NDIaiKgg7RvYDfqjPkefu43TU=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/type-is": {
+            "version": "2.1.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha1-cdGnBTKTWC4WrJ8+uvGrmqSeVXA=",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.0.0",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-is/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha1-L7Pt5p3/oK94ynxM51iWgGOLVt8=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/unist-util-stringify-position": {
+            "version": "4.0.0",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+            "integrity": "sha1-RJxuIaiA4IVb9aq63rOnQDFKusI=",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/vscode-jsonrpc": {
+            "version": "8.2.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+            "integrity": "sha1-oyLMDx2X95T/2cTNKomKC94JfzQ=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which/-/which-2.0.2.tgz",
+            "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "license": "ISC"
+        },
+        "node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha1-eCdK/ZNZih391hMN9qVm3vy/mqQ=",
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.4.3",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha1-toDxcohdGLvr8hqDTqJeVaG781Y=",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-to-json-schema": {
+            "version": "3.25.2",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+            "integrity": "sha1-P6eZp7rdVUVBRy+2WEP9xGCy5ao=",
+            "license": "ISC",
+            "peerDependencies": {
+                "zod": "^3.25.28 || ^4"
+            }
+        }
+    }
+}

--- a/evals/package.json
+++ b/evals/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "evals",
+    "version": "1.0.0",
+    "description": "",
+    "type": "commonjs",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+        "@github/copilot-sdk": "^1.0.9-preview.2",
+        "@microsoft/vally": "^0.13.0",
+        "@modelcontextprotocol/sdk": "^1.30.0"
+    }
+}

--- a/evals/package.json
+++ b/evals/package.json
@@ -1,11 +1,14 @@
 {
     "name": "evals",
     "version": "1.0.0",
-    "description": "",
+    "description": "Vally evaluation infrastructure for Azure agent workflows. Run from repo root: npm run eval",
     "type": "commonjs",
     "main": "index.js",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "eval": "node run-eval.cjs",
+        "eval:plan": "node run-eval.cjs --suite project-plan",
+        "mcp": "node mcp/workflow-tools-http.cjs",
+        "lint": "npx -y @microsoft/vally-cli lint --eval-spec project-plan/eval.yaml"
     },
     "keywords": [],
     "author": "",

--- a/evals/project-plan/eval.yaml
+++ b/evals/project-plan/eval.yaml
@@ -1,0 +1,238 @@
+name: azure-project-plan-contracts
+description: >
+  Verify the azure-project-plan agent produces valid requirements, respects
+  approval gates, generates parseable plans, and hands off correctly.
+type: capability
+
+defaults:
+  runs: 3
+  timeout: 10m
+  executor: azure-agent-executor
+  environment:
+    skills: [.skills/azure-project-plan]
+    files:
+      - src: ../skills/azure-project-plan
+        dest: .skills/azure-project-plan
+      - src: ../../resources/agents/azure-project-plan/instructions.md
+        dest: .github/agents/azure-project-plan/instructions.md
+      - src: ../../resources/agents/azure-project-plan/requirements.md
+        dest: .github/agents/azure-project-plan/requirements.md
+      - src: ../../resources/agents/azure-project-plan/plan.md
+        dest: .github/agents/azure-project-plan/plan.md
+      - src: ../../resources/agents/shared-references
+        dest: .github/agents/shared-references
+
+stimuli:
+  # ─── 1.1 SPA + Functions + PostgreSQL (photo app) ─────────────────────────
+  - name: photo-app-requirements
+    prompt: |
+      I'd like to create an app where you can upload photos and they get stored
+      with metadata like who uploaded them and when. I want a nice React frontend
+      and an Azure Functions backend with PostgreSQL for the data. Make it with
+      full test coverage.
+    graders:
+      - type: file-exists
+        config:
+          path: .azure/requirements.json
+      - type: file-not-exists
+        name: no-dotfile-requirements
+        config:
+          path: .azure/.requirements.json
+      - type: program
+        name: requirements-schema-valid
+        config:
+          program: node
+          args: [/Users/meganmott/repos/vscode-azureresourcegroups/evals/graders/validate-requirements.mjs]
+      - type: tool-calls
+        name: opens-requirements-view
+        config:
+          required: [workflow-tools-open_requirements_view]
+      - type: file-not-exists
+        name: no-premature-plan
+        config:
+          path: .azure/project-plan.md
+      - type: transcript-not-contains
+        name: no-chat-questions
+        config:
+          substring: "What language"
+    constraints:
+      reject_tools: [vscode_askQuestions]
+
+  # ─── 1.2 API-only (no frontend) ───────────────────────────────────────────
+  - name: api-only-inventory
+    prompt: |
+      I need a backend API for tracking warehouse inventory — products,
+      quantities, locations. Just the API, no UI needed. I want to use CosmosDB
+      since the data structure might change a lot and I want it on Azure Functions.
+    graders:
+      - type: file-exists
+        config:
+          path: .azure/requirements.json
+      - type: program
+        name: requirements-api-only
+        config:
+          program: node
+          args: [/Users/meganmott/repos/vscode-azureresourcegroups/evals/graders/validate-requirements.mjs, --assert-no-frontend, --assert-blob-storage, --assert-cosmosdb]
+      - type: tool-calls
+        name: opens-requirements-view
+        config:
+          required: [workflow-tools-open_requirements_view]
+      - type: file-not-exists
+        name: no-premature-plan
+        config:
+          path: .azure/project-plan.md
+    constraints:
+      reject_tools: [vscode_askQuestions]
+
+  # ─── 1.3 Multi-service (frontend + backend + worker) ──────────────────────
+  - name: multi-service-order-processing
+    prompt: |
+      I want to build an order processing system. There should be a React
+      dashboard where staff can see and manage orders, an Express API that
+      handles the business logic, and a background worker that picks up new
+      orders from a queue and sends confirmation emails. All in one project.
+    graders:
+      - type: file-exists
+        config:
+          path: .azure/requirements.json
+      - type: program
+        name: requirements-multi-service
+        config:
+          program: node
+          args: [/Users/meganmott/repos/vscode-azureresourcegroups/evals/graders/validate-requirements.mjs, --assert-service-count=3]
+      - type: tool-calls
+        name: opens-requirements-view
+        config:
+          required: [workflow-tools-open_requirements_view]
+    constraints:
+      reject_tools: [vscode_askQuestions]
+
+  # ─── 1.4 No datastore needed ──────────────────────────────────────────────
+  - name: no-datastore-converter
+    prompt: |
+      I want a simple unit converter web app — you type in a value and pick the
+      units and it converts. Nothing needs to be saved, no accounts, no backend.
+      Just a clean little frontend tool.
+    graders:
+      - type: file-exists
+        config:
+          path: .azure/requirements.json
+      - type: program
+        name: requirements-no-datastore
+        config:
+          program: node
+          args: [/Users/meganmott/repos/vscode-azureresourcegroups/evals/graders/validate-requirements.mjs, --assert-no-datastore]
+      - type: tool-calls
+        name: opens-requirements-view
+        config:
+          required: [workflow-tools-open_requirements_view]
+    constraints:
+      reject_tools: [vscode_askQuestions]
+
+  # ─── 1.5 Plan generation (multi-turn) ─────────────────────────────────────
+  - name: plan-generation-task-app
+    turns:
+      - |
+        I want to build a task management app where teams can create projects,
+        assign tasks to people, set due dates, and track progress. React frontend,
+        Azure Functions backend, PostgreSQL for the data. I want it to look polished.
+      - "Requirements submitted at .azure/requirements.json. All answers confirmed."
+    graders:
+      - type: tool-calls
+        turn: 0
+        name: requirements-view-opened
+        config:
+          required: [workflow-tools-open_requirements_view]
+      - type: file-not-exists
+        turn: 0
+        name: no-plan-yet
+        config:
+          path: .azure/project-plan.md
+      - type: file-exists
+        name: plan-exists
+        config:
+          path: .azure/project-plan.md
+      - type: program
+        name: plan-structure-valid
+        config:
+          program: node
+          args: [/Users/meganmott/repos/vscode-azureresourcegroups/evals/graders/validate-project-plan.mjs]
+      - type: program
+        name: plan-webview-parseable
+        config:
+          program: node
+          args: [/Users/meganmott/repos/vscode-azureresourcegroups/evals/graders/validate-webview-parseable.mjs]
+      - type: tool-calls
+        name: plan-view-opened
+        config:
+          required: [workflow-tools-open_plan_view]
+    constraints:
+      reject_tools: [vscode_askQuestions]
+
+  # ─── 1.6 Plan approval and handoff (multi-turn) ───────────────────────────
+  - name: plan-approval-scrapbook
+    turns:
+      - |
+        I'd like to create an app. I want it to have a sign in page with
+        authentication. I want it to be an app where you can upload photos under
+        your account. You are coupled with another user and all of your photos
+        can be uploaded together. You have a UI that looks like a scrapbook where
+        the photos automatically go with an AI generated caption for the photo.
+      - "Requirements submitted at .azure/requirements.json. All confirmed."
+      - "Looks good, approved."
+    graders:
+      - type: file-matches
+        name: plan-approved
+        config:
+          path: .azure/project-plan.md
+          pattern: "Status.*Approved"
+      - type: tool-calls
+        name: scaffold-handoff
+        config:
+          required: [workflow-tools-start_project_scaffold]
+      - type: output-not-contains
+        name: no-inline-scaffolding
+        config:
+          substring: "creating file"
+    constraints:
+      reject_tools: [vscode_askQuestions]
+
+  # ─── 1.7 Plan feedback before approval (multi-turn) ───────────────────────
+  - name: plan-feedback-recipe-app
+    turns:
+      - |
+        Build me a recipe sharing app where people can post recipes with photos,
+        rate other people's recipes, and save favorites. I want it on Azure.
+      - "Requirements submitted at .azure/requirements.json. All confirmed."
+      - |
+        Actually, can you switch the database to CosmosDB instead? I think the
+        flexible schema would work better for recipes since they all have
+        different structures.
+    graders:
+      - type: file-not-matches
+        name: plan-not-approved
+        config:
+          path: .azure/project-plan.md
+          pattern: "Status.*Approved"
+      - type: tool-calls
+        name: no-scaffold-handoff
+        config:
+          disallowed: [workflow-tools-start_project_scaffold]
+      - type: tool-calls
+        name: plan-view-reopened
+        config:
+          required: [workflow-tools-open_plan_view]
+    constraints:
+      reject_tools: [vscode_askQuestions]
+
+scoring:
+  weights:
+    program: 0.3
+    tool-calls: 0.3
+    file-exists: 0.15
+    file-not-exists: 0.1
+    file-matches: 0.05
+    file-not-matches: 0.04
+    transcript-not-contains: 0.03
+    output-not-contains: 0.03
+  threshold: 0.9

--- a/evals/run-eval.cjs
+++ b/evals/run-eval.cjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+"use strict";
+
+// Run Vally evals locally. Starts the MCP server, runs the eval, shuts down.
+// Usage (from repo root):
+//   npm run eval
+//   npm run eval -- --runs 3
+//   npm run eval -- --suite project-plan --runs 5 --model claude-sonnet-5
+
+const { spawn, execSync } = require("child_process");
+const path = require("path");
+
+const args = process.argv.slice(2);
+const evalsDir = __dirname;
+const repoRoot = path.resolve(evalsDir, "..");
+
+// Parse options
+let suite = "project-plan";
+let runs = "1";
+let extraArgs = [];
+
+for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--suite" && args[i + 1]) { suite = args[++i]; }
+    else if (args[i] === "--runs" && args[i + 1]) { runs = args[++i]; }
+    else { extraArgs.push(args[i]); }
+}
+
+const evalSpec = path.join(evalsDir, suite, "eval.yaml");
+const executorPlugin = path.join(evalsDir, "executor", "azure-agent-executor.mjs");
+const outputDir = path.join(repoRoot, "results", `local-${Date.now()}`);
+const mcpServer = path.join(evalsDir, "mcp", "workflow-tools-http.cjs");
+const port = process.env.MCP_PORT || "3100";
+
+// Kill any existing MCP server on the port
+try { execSync(`lsof -ti:${port} | xargs kill -9 2>/dev/null`, { stdio: "ignore" }); } catch { }
+
+// Start MCP server
+console.log(`[run-eval] Starting MCP server on port ${port}...`);
+const mcp = spawn("node", [mcpServer], {
+    env: { ...process.env, MCP_PORT: port },
+    stdio: ["ignore", "pipe", "pipe"],
+});
+mcp.stderr.on("data", (d) => process.stderr.write(d));
+
+// Wait for server to be ready
+let ready = false;
+const deadline = Date.now() + 5000;
+function waitForServer() {
+    return new Promise((resolve, reject) => {
+        const check = () => {
+            try {
+                execSync(`curl -s http://localhost:${port}/health`, { stdio: "ignore" });
+                resolve();
+            } catch {
+                if (Date.now() > deadline) reject(new Error("MCP server failed to start"));
+                else setTimeout(check, 200);
+            }
+        };
+        check();
+    });
+}
+
+async function main() {
+    await waitForServer();
+    console.log(`[run-eval] MCP server ready. Running eval suite: ${suite}`);
+    console.log(`[run-eval] Runs: ${runs}, Output: ${outputDir}`);
+    console.log("");
+
+    const vallyArgs = [
+        "-y", "@microsoft/vally-cli", "eval",
+        "--eval-spec", evalSpec,
+        "--executor-plugin", executorPlugin,
+        "--output-dir", outputDir,
+        "--runs", runs,
+        "--verbose",
+        ...extraArgs,
+    ];
+
+    const vally = spawn("npx", vallyArgs, {
+        stdio: "inherit",
+        cwd: repoRoot,
+    });
+
+    vally.on("close", (code) => {
+        mcp.kill();
+        console.log(`\n[run-eval] Results saved to: ${outputDir}`);
+        process.exit(code || 0);
+    });
+
+    process.on("SIGINT", () => {
+        vally.kill();
+        mcp.kill();
+        process.exit(130);
+    });
+}
+
+main().catch((err) => {
+    console.error(`[run-eval] ${err.message}`);
+    mcp.kill();
+    process.exit(1);
+});

--- a/evals/skills/azure-project-plan/SKILL.md
+++ b/evals/skills/azure-project-plan/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: azure-project-plan
+description: Gather requirements into .azure/requirements.json and generate .azure/project-plan.md. Never write code directly.
+---
+
+# azure-project-plan
+
+You are the `azure-project-plan` agent. Your ONLY job is to gather requirements and generate a project plan following the workflow below. You do NOT write code, create HTML files, scaffold projects, or build anything directly.
+
+## Your workflow (mandatory, in this order)
+
+1. **Scan the workspace** for existing project files (package.json, host.json, etc.)
+2. **Write `.azure/requirements.json`** with the gathered/inferred requirements following the schema below
+3. **Call `open_requirements_view`** immediately after writing the file — then STOP
+4. Do NOT create `.azure/project-plan.md` until the user submits requirements (they will say "Requirements submitted...")
+5. When requirements are submitted, **generate `.azure/project-plan.md`** following the plan structure rules
+6. **Call `open_plan_view`** immediately after writing the plan — then STOP and wait for approval
+7. When the user approves, update the plan status to `Approved` and **call `start_project_scaffold`** — then STOP
+
+## Critical rules
+
+- NEVER ask questions in chat. All user input comes through the requirements webview.
+- NEVER call `vscode_askQuestions`.
+- NEVER create source code, HTML files, or project files directly. You only create `.azure/requirements.json` and `.azure/project-plan.md`.
+- NEVER proceed past a gate without user confirmation.
+- The requirements file is `.azure/requirements.json` (no leading dot on filename).
+
+## Requirements JSON schema
+
+The file must contain:
+- `services[]` — array of detected services, each with `id`, `label`, `role` (frontend/backend/worker)
+- `questions[]` — array of questions, each with: `id`, `category`, `question`, `header`, `answer`, `status` (inferred/needs_input), `rationale`, `recommendedChoice`, `multiSelect` (boolean), `allowFreeformInput` (boolean), `options[]` (array of `{label, description, exclusive?}`), and optionally `serviceId`
+
+### Rules for specific questions:
+- `dataStores`: must have `multiSelect: true`, `allowFreeformInput: false`, include "No datastore required" option with `exclusive: true`
+- `dataStores`: when the app uses Azure Functions, ALWAYS include "Blob Storage" in `recommendedChoice` (Functions requires a storage account)
+- `dataStores`: when the app stores files/photos/images/uploads, ALWAYS include "Blob Storage"
+- `dataStores`: "No datastore required" must never be combined with another store
+- Frontend language questions: options must only include "TypeScript" and "JavaScript" — never "Python" or "C# (.NET)"
+- Language questions: `allowFreeformInput: false`
+- Framework questions: `allowFreeformInput: true`
+- Auth questions: `allowFreeformInput: true`
+
+## Project plan structure (when generating after requirements submitted)
+
+The plan MUST follow this exact structure:
+- Top metadata: `**Status**: Planning`, `**Created**: <date>`, `**Mode**: <mode>`
+- All sections numbered: `## 1. Project Overview`, `## 2. Backend`, etc.
+- Section 6 MUST be titled "Design System & UI" and contain a `**Component Library**:` row
+- Section 7: Project Structure
+- Section 8: Route Definitions (table with Method, Path, Description) — must include `GET /api/health`
+- NO unnumbered `##` headings, NO YAML front-matter, NO mermaid diagrams
+
+## Detailed instructions
+
+Read the instruction files at `.github/agents/azure-project-plan/` for the full requirements-gathering and plan-generation procedures:
+- `instructions.md` — routing and shared rules
+- `requirements.md` — Step 1 (scan) and Step 2 (gather requirements)
+- `plan.md` — Step 3 (generate plan after requirements submitted)

--- a/package.json
+++ b/package.json
@@ -1018,6 +1018,8 @@
         "package": "vsce package --githubBranch main",
         "lint": "eslint --max-warnings 0",
         "test": "vscode-test",
+        "eval": "node evals/run-eval.cjs",
+        "eval:plan": "node evals/run-eval.cjs --suite project-plan",
         "all": "npm i && npm run lint && npm run build && npm run package && npm test",
         "api-extractor": "cd api && npm run api-extractor"
     },


### PR DESCRIPTION
This add some prompts and graders for the requerements view/planning stage in general. It also sets up the mock mcp server to work with vally. 

I added a github action workflow file but we likely will want to make changes to that depending on how often we want this workflow to run. I also put generic thresholds and stuff in there but we can change those as needed as well. 

The current setup is to just run the cli commands locally to get the reports but I am currently working on changing that. 