### PR TITLE
Fix docker-compose credential corruption and blank local database credentials

### DIFF
--- a/resources/agents/azure-debug-generate/references/emulators/postgres.md
+++ b/resources/agents/azure-debug-generate/references/emulators/postgres.md
@@ -10,12 +10,12 @@ postgres:16
 
 ## docker-compose Service Block
 
-Declare the local credentials **once** in a workspace-root `.env` file, then reference them
-everywhere else. Docker Compose interpolates `${...}` from `.env` (or the shell environment),
-so the same values feed the database service and every application service.
+Declare the local credentials **once** in a workspace-root `.env`, then reference them everywhere
+else. Compose interpolates `${...}` from `.env` (or the shell environment), so the same values feed
+the database service and every application service.
 
-`.env` at the workspace root — this file is required; without it Compose interpolates
-`${POSTGRES_USER}` to an empty string and the database silently fails to authenticate:
+`.env` is required — without it Compose interpolates `${POSTGRES_USER}` to an empty string and the
+database silently fails to authenticate:
 
 ```
 POSTGRES_USER=postgres
@@ -23,11 +23,15 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_DB=localdev
 ```
 
-> **Never inline a concrete `user:password@host` URL** in a generated file. Build the URL from
-> the discrete variables above. Besides hard-coding credentials, concrete credential literals are
-> rewritten by secret-redaction filters, which silently corrupts the generated file — a masked
-> value starting with `*` is a fatal YAML parse error, because YAML reads a leading `*` as an
-> alias reference.
+> ⛔ **`.gitignore` must list `.env` before you create it.** A credential that reaches a commit is
+> compromised and has to be rotated — deleting it in a later commit leaves the value in history and
+> in every existing clone and fork. Private repositories are no exception. If the project has no
+> `.gitignore`, or has one that omits `.env`, fix that before writing the file.
+
+> **Never inline a concrete `user:password@host` URL** in a generated file — build it from the
+> variables above. Beyond hard-coding a credential, such literals are rewritten by secret-redaction
+> filters, and a masked value starting with `*` is a fatal YAML parse error: YAML reads a leading
+> `*` as an alias reference.
 
 ```yaml
 services:
@@ -75,15 +79,14 @@ Declare these in the workspace-root **`.env`**, alongside the `POSTGRES_*` value
 > Use whichever variable name the project's ORM or SDK expects. Both forms above are shown as reference.
 > When the value is set on a docker-compose service, replace the `localhost` host with `postgres`.
 
-> **`.env` must declare every key `.env.example` declares.** `.env.example` is documentation; nothing
-> loads it. A key that appears only in `.env.example` is undefined at run time.
+> **`.env` must declare every key `.env.example` declares.** `.env.example` is documentation —
+> nothing loads it, so a key that appears only there is undefined at run time.
 
 > **A runtime settings file does not cover host-run tasks.** `local.settings.json` is read by the
-> Azure Functions host, and a compose `environment:` block is read by the container it belongs to.
-> Neither reaches a VS Code task that runs a tool directly on the host, such as
-> `npm run db:migrate`. A migration client handed an undefined connection string fails with
-> "Unable to acquire a connection", which reads like an unready database but is a missing variable —
-> the client never opened a socket. Put the value in `.env` so both paths resolve it.
+> Azure Functions host and a compose `environment:` block by its own container; neither reaches a
+> VS Code task that runs a tool directly on the host, such as `npm run db:migrate`. That client
+> fails with "Unable to acquire a connection", which reads like an unready database but is a
+> missing variable — it never opened a socket. Put the value in `.env` so both paths resolve it.
 
 ## Healthcheck
 

--- a/resources/agents/azure-debug-generate/references/emulators/postgres.md
+++ b/resources/agents/azure-debug-generate/references/emulators/postgres.md
@@ -10,6 +10,25 @@ postgres:16
 
 ## docker-compose Service Block
 
+Declare the local credentials **once** in a workspace-root `.env` file, then reference them
+everywhere else. Docker Compose interpolates `${...}` from `.env` (or the shell environment),
+so the same values feed the database service and every application service.
+
+`.env` at the workspace root — this file is required; without it Compose interpolates
+`${POSTGRES_USER}` to an empty string and the database silently fails to authenticate:
+
+```
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=localdev
+```
+
+> **Never inline a concrete `user:password@host` URL** in a generated file. Build the URL from
+> the discrete variables above. Besides hard-coding credentials, concrete credential literals are
+> rewritten by secret-redaction filters, which silently corrupts the generated file — a masked
+> value starting with `*` is a fatal YAML parse error, because YAML reads a leading `*` as an
+> alias reference.
+
 ```yaml
 services:
   postgres:
@@ -17,13 +36,13 @@ services:
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: localdev
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - ./.postgres:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -33,18 +52,38 @@ services:
 
 ## Connection String
 
+The host depends on where the client runs:
+
+| Client location | Host |
+|---|---|
+| Host machine (VS Code debug target, `npm` task) | `localhost` |
+| Another docker-compose service | `postgres` (the service name) |
+
 ```
-postgresql://postgres:postgres@localhost:5432/localdev
+postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}
 ```
 
 ## Required App Environment Variables
 
+Declare these in the workspace-root **`.env`**, alongside the `POSTGRES_*` values:
+
 | Variable | Value |
 |----------|-------|
-| `DATABASE_URL` | `postgresql://postgres:postgres@localhost:5432/localdev` |
-| `POSTGRES_CONNECTION_STRING` | `postgresql://postgres:postgres@localhost:5432/localdev` |
+| `DATABASE_URL` | `postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}` |
+| `POSTGRES_CONNECTION_STRING` | `postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}` |
 
 > Use whichever variable name the project's ORM or SDK expects. Both forms above are shown as reference.
+> When the value is set on a docker-compose service, replace the `localhost` host with `postgres`.
+
+> **`.env` must declare every key `.env.example` declares.** `.env.example` is documentation; nothing
+> loads it. A key that appears only in `.env.example` is undefined at run time.
+
+> **A runtime settings file does not cover host-run tasks.** `local.settings.json` is read by the
+> Azure Functions host, and a compose `environment:` block is read by the container it belongs to.
+> Neither reaches a VS Code task that runs a tool directly on the host, such as
+> `npm run db:migrate`. A migration client handed an undefined connection string fails with
+> "Unable to acquire a connection", which reads like an unready database but is a missing variable —
+> the client never opened a socket. Put the value in `.env` so both paths resolve it.
 
 ## Healthcheck
 
@@ -52,7 +91,7 @@ The healthcheck is included in the docker-compose service block above. It uses `
 
 ```yaml
 healthcheck:
-  test: ["CMD-SHELL", "pg_isready -U postgres"]
+  test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
   interval: 5s
   timeout: 5s
   retries: 5
@@ -62,5 +101,5 @@ healthcheck:
 ## Notes
 
 - Port 5432 is the standard PostgreSQL port.
-- Default credentials (`postgres`/`postgres`) are intentionally simple for local dev. Never use in production.
+- Default credentials (`postgres`/`postgres`) are intentionally simple for local dev and are declared in the workspace-root `.env`. Never use in production.
 - Data is persisted to `./.postgres/`.

--- a/resources/agents/azure-debug-generate/references/generate.md
+++ b/resources/agents/azure-debug-generate/references/generate.md
@@ -77,6 +77,11 @@ or the shell environment, never from a service's own `environment:` block. Whene
 file references a variable — a compose service, a host task, or a connection string — `.env` must
 declare every variable it needs, or the value silently becomes an empty string.
 
+> ⛔ **`.gitignore` must list `.env` before you create it.** A credential that reaches a commit is
+> compromised and has to be rotated — deleting it in a later commit leaves it in history, in every
+> clone, and in every fork. Private repositories are no exception. If the project has no
+> `.gitignore`, or has one that omits `.env`, fix that first.
+
 See `emulators/{name}.md` § Required App Environment Variables for the per-emulator variable set.
 
 ---

--- a/resources/agents/azure-debug-generate/references/generate.md
+++ b/resources/agents/azure-debug-generate/references/generate.md
@@ -58,6 +58,29 @@ Before writing any script or task command that invokes a CLI tool (e.g., `rimraf
 
 ---
 
+## Local Credentials
+
+> ⚠️ **Never inline a literal credential into a task or a compose file.** Declare local credentials
+> once in a workspace-root `.env` and reference them through Compose `${VAR}` interpolation
+> everywhere else.
+
+| Correct | Do **not** generate |
+|---|---|
+| Compose `${VAR}` interpolation from `.env` | A literal credential inlined into a task or compose file |
+
+A concrete credential literal is rewritten by secret-redaction filters, and a masked value that
+begins with `*` is a fatal YAML parse error — YAML reads a leading `*` as an alias reference, so the
+whole compose file stops parsing.
+
+Interpolation only resolves if the variable is actually defined: Compose reads `${...}` from `.env`
+or the shell environment, never from a service's own `environment:` block. Whenever a generated
+file references a variable — a compose service, a host task, or a connection string — `.env` must
+declare every variable it needs, or the value silently becomes an empty string.
+
+See `emulators/{name}.md` § Required App Environment Variables for the per-emulator variable set.
+
+---
+
 ## VS Code Debug & Task Configuration
 
 Assemble `.vscode/launch.json` and `.vscode/tasks.json` by combining properties from the detected **project type** and **runtime** references. Use the source ownership table below to determine which file provides each property.

--- a/resources/agents/azure-project-plan/plan.md
+++ b/resources/agents/azure-project-plan/plan.md
@@ -93,7 +93,7 @@ Write `.azure/project-plan.md` from the template below in a **single pass** (fil
 | Azure Service | Role in App | Environment Variable | Default Value (Local) | Classification |
 |---------------|------------|---------------------|----------------------|----------------|
 | {Blob Storage} | {Store uploaded images} | {STORAGE_CONNECTION_STRING} | {UseDevelopmentStorage=true} | {Essential} |
-| {PostgreSQL} | {Primary data store} | {DATABASE_URL} | {postgresql://localdev:localdevpassword@localhost:5432/appdb} | {Essential} |
+| {PostgreSQL} | {Primary data store} | {DATABASE_URL} | {postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/appdb} | {Essential} |
 
 ---
 
@@ -401,7 +401,7 @@ The webview watches the entire `.azure/.preview-temp/` folder, so the manifest u
 | Blob Storage | `STORAGE_CONNECTION_STRING` | `UseDevelopmentStorage=true` |
 | Queue Storage | `STORAGE_CONNECTION_STRING` | `UseDevelopmentStorage=true` |
 | Table Storage | `STORAGE_CONNECTION_STRING` | `UseDevelopmentStorage=true` |
-| PostgreSQL | `DATABASE_URL` | `postgresql://localdev:localdevpassword@localhost:5432/{dbname}` |
+| PostgreSQL | `DATABASE_URL` | `postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/{dbname}` |
 | CosmosDB | `COSMOSDB_CONNECTION_STRING` | `AccountEndpoint=https://localhost:8081/;AccountKey=...` |
 | Redis | `REDIS_URL` | `redis://localhost:6379` |
 | Azure SQL | `SQL_CONNECTION_STRING` | `Server=localhost,1433;Database={db};...` |

--- a/resources/agents/azure-project-scaffold/instructions.md
+++ b/resources/agents/azure-project-scaffold/instructions.md
@@ -191,7 +191,7 @@ If you find yourself writing a command that wouldn't run on the other OS, stop a
 |------|---------|
 | Initialize project | `package.json` + `tsconfig.json` (Node.js) / `pyproject.toml` (Python) / `*.csproj` + `*.sln` (.NET) |
 | Configure linter/formatter | ESLint + Prettier (Node.js) / Ruff (Python) / dotnet format (.NET) |
-| Create `.gitignore` | Runtime-appropriate ignores (node_modules, .env, data/, etc.) |
+| Create `.gitignore` | Runtime-appropriate ignores (node_modules, data/, etc.). **Write it before any file that holds credentials** — `.env` and `local.settings.json` must be ignored from the first commit, never added and removed later. See architecture.md § .gitignore Additions |
 | Create directory structure | `services/functions/`, `services/functions/src/utils/`, `services/shared/` (do NOT create `services/web/` — may exist from frontend generation) |
 
 **Reference**: [architecture.md](.github/agents/shared-references/architecture.md)

--- a/resources/agents/shared-references/architecture.md
+++ b/resources/agents/shared-references/architecture.md
@@ -496,6 +496,12 @@ packages = [
 
 ## .gitignore Additions
 
+> ⛔ **Ignore `.env` and `local.settings.json` before creating them.** They hold real credential
+> values. A secret that reaches a commit is compromised the moment it is pushed, and deleting it in
+> a later commit does **not** undo that — the value stays in history and in every clone and fork
+> that already has it. Recovery means rotating the credential, not editing a file. This applies to
+> private repositories exactly as it does to public ones: no secret belongs in any commit, ever.
+
 ```gitignore
 # Environment
 .env

--- a/resources/agents/shared-references/resilience.md
+++ b/resources/agents/shared-references/resilience.md
@@ -106,7 +106,7 @@ describe('auto-initialization', () => {
   it('should survive missing Enhancement service config', () => {
     clearServices();
     // Only set Essential service env vars
-    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/testdb';
+    process.env.DATABASE_URL = `postgresql://${process.env.POSTGRES_USER}:${process.env.POSTGRES_PASSWORD}@localhost:5432/testdb`;
     process.env.STORAGE_CONNECTION_STRING = 'UseDevelopmentStorage=true';
     // Enhancement env vars intentionally NOT set
     delete process.env.AZURE_OPENAI_ENDPOINT;

--- a/resources/agents/shared-references/runtimes/python.md
+++ b/resources/agents/shared-references/runtimes/python.md
@@ -44,7 +44,7 @@ pip install -r requirements.txt
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "ENVIRONMENT": "development",
     "STORAGE_CONNECTION_STRING": "UseDevelopmentStorage=true",
-    "DATABASE_URL": "postgresql://localdev:localdevpassword@localhost:5432/appdb",
+    "DATABASE_URL": "postgresql://<POSTGRES_USER>:<POSTGRES_PASSWORD>@localhost:5432/appdb",
     "REDIS_URL": "redis://localhost:6379"
   },
   "Host": {
@@ -53,6 +53,12 @@ pip install -r requirements.txt
   }
 }
 ```
+
+> `local.settings.json` is plain JSON and does **not** support `${...}` interpolation.
+> Replace `<POSTGRES_USER>` / `<POSTGRES_PASSWORD>` with the same discrete values declared in the
+> workspace-root `.env` used by docker-compose. Never leave the angle-bracket placeholders in the
+> generated file, and never paste a credential value copied out of tool output — redaction filters
+> rewrite concrete credential URLs, and a masked value beginning with `*` corrupts YAML/JSON config.
 
 ### pyproject.toml
 

--- a/resources/agents/shared-references/runtimes/typescript.md
+++ b/resources/agents/shared-references/runtimes/typescript.md
@@ -44,7 +44,7 @@ npm install
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "NODE_ENV": "development",
     "STORAGE_CONNECTION_STRING": "UseDevelopmentStorage=true",
-    "DATABASE_URL": "postgresql://localdev:localdevpassword@localhost:5432/appdb",
+    "DATABASE_URL": "postgresql://<POSTGRES_USER>:<POSTGRES_PASSWORD>@localhost:5432/appdb",
     "REDIS_URL": "redis://localhost:6379"
   },
   "Host": {
@@ -53,6 +53,12 @@ npm install
   }
 }
 ```
+
+> `local.settings.json` is plain JSON and does **not** support `${...}` interpolation.
+> Replace `<POSTGRES_USER>` / `<POSTGRES_PASSWORD>` with the same discrete values declared in the
+> workspace-root `.env` used by docker-compose. Never leave the angle-bracket placeholders in the
+> generated file, and never paste a credential value copied out of tool output — redaction filters
+> rewrite concrete credential URLs, and a masked value beginning with `*` corrupts YAML/JSON config.
 
 ### tsconfig.json
 

--- a/resources/agents/shared-references/service-abstraction.md
+++ b/resources/agents/shared-references/service-abstraction.md
@@ -277,7 +277,7 @@ describe('ServiceRegistry', () => {
   it('should auto-initialize without throwing when Enhancement config is missing (Rule 13)', () => {
     clearServices();
     // Set only Essential service env vars
-    process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/testdb';
+    process.env.DATABASE_URL = `postgresql://${process.env.POSTGRES_USER}:${process.env.POSTGRES_PASSWORD}@localhost:5432/testdb`;
     process.env.STORAGE_CONNECTION_STRING = 'UseDevelopmentStorage=true';
     // Enhancement env vars intentionally NOT set
     delete process.env.AZURE_OPENAI_ENDPOINT;


### PR DESCRIPTION
## Problem

Reference docs under `resources/` inlined concrete credentials — for example a literal `DATABASE_URL: postgresql://user:password@host:5432/db`. The `azure-debug-generate` skill then wrote the same shape into generated local dev files such as `docker-compose.yml`. This produced two distinct failure modes.

### 1. Fatal YAML corruption

A secret-redaction filter rewrites the credential literal to a masked value. In YAML a leading `*` is an **alias indicator**, so the moment a redacted value lands in `docker-compose.yml` the file stops parsing entirely.

This is why redaction is fatal here rather than merely cosmetic: the masked text isn't just an unusable value, it's a syntax error. Local dev is dead on arrival, and the error the user sees points at YAML syntax — not at the credential that caused it.

### 2. Silent blank credentials

Where compose *did* use `${POSTGRES_USER}` / `${POSTGRES_PASSWORD}`, the skill often generated no workspace-root `.env`. Docker Compose interpolates `${...}` from `.env` or the shell environment — **never** from a service's own `environment:` block. With no `.env`, the variables resolve to empty strings and Postgres starts with blank credentials, producing auth failures that look like application bugs.

## Fix

The guidance now:

- Declares local credentials **once** in a workspace-root `.env`, and references them via `${...}` everywhere else.
- Forbids inlining a concrete `user:password@host` URL into any generated file, and explains the YAML-alias rationale so the rule isn't mistaken for style advice.
- Requires `.env` to exist and to declare **every** variable compose references — including a note that `.env.example` is documentation only and nothing loads it.
- Documents which host to use in a connection string: `localhost` for clients running on the host machine (VS Code debug target, `npm` task) vs. the `postgres` service name for clients running inside compose.
- Notes that `local.settings.json` is plain JSON with no `${...}` interpolation, and that a runtime settings file does not cover host-run tasks such as `npm run db:migrate`.

## `.env` must be gitignored, and secrets belong in no commit

Per review feedback: the guidance told the agent to create a workspace-root `.env` holding real credential values, but never said it must be ignored.

`.gitignore` must now list `.env` before the file is created, stated at each point where it actually gets written (`emulators/postgres.md`, `references/generate.md`), with an explicit instruction to fix a missing or incomplete `.gitignore` first. `shared-references/architecture.md` § .gitignore Additions carries the rule in full, since that section defines the generated `.gitignore` contents: a secret that reaches a commit is compromised the moment it is pushed, deleting it in a later commit does **not** undo that because the value stays in history and in every clone and fork, recovery means rotating the credential rather than editing a file, and private repositories are no exception.

`azure-project-scaffold/instructions.md` makes the ordering explicit — `.gitignore` is written in Step 2 (Foundation), before Step 3 (Configuration & Environment) creates env files.

## Audit: no reference doc can seed a masked value

The remaining reference docs carrying a concrete credential literal are fixed too. This matters because a reference doc is read by the agent *before* it writes anything — the literal is masked in the agent's context by secret redaction and then transcribed verbatim into the generated project. **All concrete credential literals under `resources/` are now eliminated, so no reference doc can seed a masked value into a generated project.**

- `azure-project-plan/plan.md` — the two connection-string table rows are templates the planning agent fills in, so a masked value propagates into `.azure/project-plan.md` and downstream into generated code. Highest-impact of the set.
- `shared-references/resilience.md` and `shared-references/service-abstraction.md` — the sample test setup now builds the URL from `process.env` via a template literal (quoting changed from single quotes to backticks accordingly).

Verified with `git grep -lE '://[A-Za-z0-9_.-]+:[A-Za-z0-9_.!$-]+@' HEAD -- resources/` → zero files.

## Files changed

- `resources/agents/azure-debug-generate/references/emulators/postgres.md`
- `resources/agents/azure-debug-generate/references/generate.md`
- `resources/agents/azure-project-plan/plan.md`
- `resources/agents/azure-project-scaffold/instructions.md`
- `resources/agents/shared-references/architecture.md`
- `resources/agents/shared-references/resilience.md`
- `resources/agents/shared-references/runtimes/python.md`
- `resources/agents/shared-references/runtimes/typescript.md`
- `resources/agents/shared-references/service-abstraction.md`

Markdown instruction files only — no extension source changes, nothing to compile.

## Related

The accompanying evaluation-system detection for this defect ships separately in #1669.
