### PR TITLE
CoR: Add `debugAnyway` as a default workspace setting

### DIFF
--- a/resources/agents/azure-debug-generate/instructions.md
+++ b/resources/agents/azure-debug-generate/instructions.md
@@ -73,7 +73,7 @@ Follow the generation steps in [generate.md](references/generate.md) in order.
 | VS Code Debug Config | `.vscode/launch.json` — see [project-types/](references/project-types/) and [runtimes/](references/runtimes/) |
 | VS Code Build Config | `.vscode/tasks.json` — see [project-types/](references/project-types/) and [runtimes/](references/runtimes/) |
 | VS Code Extensions | `.vscode/extensions.json` — see [generate.md](references/generate.md) § assembly protocol |
-| VS Code Settings | `.vscode/settings.json` — always includes `"debug.onTaskErrors": "debugAnyway"` (merged, not overwritten); see [generate.md](references/generate.md) § assembly protocol and § Required Debug Settings |
+| VS Code Settings | `.vscode/settings.json` — see [generate.md](references/generate.md) § assembly protocol |
 | Connection Strings | `local.settings.json` or `.env` |
 | Convenience Scripts | Runtime-specific script runner (see [runtimes/](references/runtimes/)) |
 | API Test Collections | `api-test-collections/{service-id}/<test-name>/invoke.{sh,ps1}` |

--- a/resources/agents/azure-debug-generate/instructions.md
+++ b/resources/agents/azure-debug-generate/instructions.md
@@ -73,7 +73,7 @@ Follow the generation steps in [generate.md](references/generate.md) in order.
 | VS Code Debug Config | `.vscode/launch.json` — see [project-types/](references/project-types/) and [runtimes/](references/runtimes/) |
 | VS Code Build Config | `.vscode/tasks.json` — see [project-types/](references/project-types/) and [runtimes/](references/runtimes/) |
 | VS Code Extensions | `.vscode/extensions.json` — see [generate.md](references/generate.md) § assembly protocol |
-| VS Code Settings | `.vscode/settings.json` — see [generate.md](references/generate.md) § assembly protocol |
+| VS Code Settings | `.vscode/settings.json` — always includes `"debug.onTaskErrors": "debugAnyway"` (merged, not overwritten); see [generate.md](references/generate.md) § assembly protocol and § Required Debug Settings |
 | Connection Strings | `local.settings.json` or `.env` |
 | Convenience Scripts | Runtime-specific script runner (see [runtimes/](references/runtimes/)) |
 | API Test Collections | `api-test-collections/{service-id}/<test-name>/invoke.{sh,ps1}` |

--- a/resources/agents/azure-debug-generate/references/generate.md
+++ b/resources/agents/azure-debug-generate/references/generate.md
@@ -218,7 +218,24 @@ Aggregate workspace settings from the detected **runtime**, **project type**, an
 | 1. Collect | Gather from runtime | Read settings from `runtimes/{rt}.md § VS Code Workspace Settings` |
 | 2. Collect | Gather from project type | Read settings from `project-types/{type}.md § VS Code Workspace Settings` |
 | 3. Collect | Gather emulator exclusions | Derive data directory exclusions from `docker-compose.yml` `volumes:` mounts |
-| 4. Write | Output `.vscode/settings.json` | Contribute to the file — do not replace existing entries or user customizations |
+| 4. Add required debug settings | Merge the mandatory debug settings | See generate.md § Required Debug Settings - always include, every run |
+| 5. Write | Output `.vscode/settings.json` | Contribute to the file — do not replace existing entries or user customizations |
+
+### Required Debug Settings
+
+Regardless of runtime, project type, or emulator configuration, **always** merge the following key into `.vscode/settings.json` on **every** generate run:
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `debug.onTaskErrors` | `"debugAnyway"` | When F5 launches a debug configuration, VS Code otherwise shows a blocking "task errors" modal whenever anything is registered in the Problems panel - even unrelated pre-existing problems that do not actually block debugging. This modal scares users into thinking the project is broken when it launches fine. Setting `debugAnyway` suppresses the modal and starts debugging directly. |
+
+```json
+{
+  "debug.onTaskErrors": "debugAnyway"
+}
+```
+
+> ⛔ This key is **mandatory and deterministic** - emit it on every run. **Merge** it into any existing `.vscode/settings.json` (preserving all existing entries and user customizations); never overwrite the file. If the key is already present, leave the existing value untouched.
 
 ### Emulator Data Directory Exclusions
 

--- a/resources/agents/azure-debug-generate/references/generate.md
+++ b/resources/agents/azure-debug-generate/references/generate.md
@@ -223,11 +223,11 @@ Aggregate workspace settings from the detected **runtime**, **project type**, an
 
 ### Required Debug Settings
 
-Always merge these keys into the workspace `.vscode/settings.json` on **every** run (workspace scope only — never the user/global settings). Preserve any existing entries; if a key is already present, leave its value untouched.
+Always merge these keys into the workspace `.vscode/settings.json` on **every** run which is workspace scope only. Preserve any existing entries; if a key is already present, leave its value untouched.
 
 | Setting | Value | Why |
 |---------|-------|-----|
-| `debug.onTaskErrors` | `"debugAnyway"` | Suppresses VS Code's blocking "task errors" modal on F5, which otherwise appears for unrelated pre-existing Problems-panel entries and makes users think the project is broken when it actually launches fine. |
+| `debug.onTaskErrors` | `"debugAnyway"` | Suppresses VS Code's blocking "task errors" modal on F5, which can appear as a project launching blocker when it's often not. |
 
 ```json
 {

--- a/resources/agents/azure-debug-generate/references/generate.md
+++ b/resources/agents/azure-debug-generate/references/generate.md
@@ -218,24 +218,22 @@ Aggregate workspace settings from the detected **runtime**, **project type**, an
 | 1. Collect | Gather from runtime | Read settings from `runtimes/{rt}.md § VS Code Workspace Settings` |
 | 2. Collect | Gather from project type | Read settings from `project-types/{type}.md § VS Code Workspace Settings` |
 | 3. Collect | Gather emulator exclusions | Derive data directory exclusions from `docker-compose.yml` `volumes:` mounts |
-| 4. Add required debug settings | Merge the mandatory debug settings | See generate.md § Required Debug Settings - always include, every run |
-| 5. Write | Output `.vscode/settings.json` | Contribute to the file — do not replace existing entries or user customizations |
+| 4. Collect | Gather required debug settings | Add the mandatory keys from generate.md § Required Debug Settings |
+| 5. Write | Output `.vscode/settings.json` | Merge into the file — contribute without replacing existing entries or user customizations |
 
 ### Required Debug Settings
 
-Regardless of runtime, project type, or emulator configuration, **always** merge the following key into `.vscode/settings.json` on **every** generate run:
+Always merge these keys into the workspace `.vscode/settings.json` on **every** run (workspace scope only — never the user/global settings). Preserve any existing entries; if a key is already present, leave its value untouched.
 
 | Setting | Value | Why |
 |---------|-------|-----|
-| `debug.onTaskErrors` | `"debugAnyway"` | When F5 launches a debug configuration, VS Code otherwise shows a blocking "task errors" modal whenever anything is registered in the Problems panel - even unrelated pre-existing problems that do not actually block debugging. This modal scares users into thinking the project is broken when it launches fine. Setting `debugAnyway` suppresses the modal and starts debugging directly. |
+| `debug.onTaskErrors` | `"debugAnyway"` | Suppresses VS Code's blocking "task errors" modal on F5, which otherwise appears for unrelated pre-existing Problems-panel entries and makes users think the project is broken when it actually launches fine. |
 
 ```json
 {
   "debug.onTaskErrors": "debugAnyway"
 }
 ```
-
-> ⛔ This key is **mandatory and deterministic** - emit it on every run. **Merge** it into any existing `.vscode/settings.json` (preserving all existing entries and user customizations); never overwrite the file. If the key is already present, leave the existing value untouched.
 
 ### Emulator Data Directory Exclusions
 


### PR DESCRIPTION
Closes https://github.com/microsoft/azcode-internal/issues/271

Sometimes something shows up in the problems pane after a project gets created, but often not even a blocker for launching.  This will lead to a user's first interaction appearing like an error modal even though there's nothing that would stop them from running and testing the project.