### PR TITLE
CoR: In autopilot, reuse project-plan prerequisites for the debug plan rather than re-deriving

### DIFF
--- a/resources/agents/azure-debug-plan/instructions.md
+++ b/resources/agents/azure-debug-plan/instructions.md
@@ -21,6 +21,7 @@
 **Active when** the invoking chat query begins with `[AUTOPILOT MODE]`, **or** `.azure/project-plan.md` records `executionMode: auto` or equivalent. When active, run fully unattended:
 - **Phase 0–1 still run in full**.  When generating the plan `.azure/vscode-debug-plan.md`, also record `executionMode: auto` or similar.  Follow any specific instructions per the template.
 - Skip the step that instructs to run `openLocalPlanView` and do NOT wait for approval. Set status straight to `Approved`, then invoke `azure-debug-generate` as you normally would, but with the chat arg prefixed with `[AUTOPILOT MODE] `.
+- **Reuse the project-plan prerequisites.** When `.azure/project-plan.md` already lists Prerequisites, carry them over wholesale instead of re-deriving them — see [inventory.md § Step 1](references/inventory.md) for the detail.
 - Never call `ask_user` for non-destructive steps. Scan completeness is unchanged — autopilot suppresses **the preview and approval gates only**.
 
 ## Workflow
@@ -38,7 +39,7 @@ Scan the workspace for service roots. Produce a `services[]` list.
 
 | Action | Reference |
 |--------|-----------|
-| Check for `.azure/project-plan.md` — if found, read for advisory context. **Optional.** | — |
+| Check for `.azure/project-plan.md` — if found, read it for advisory context. | — |
 | Scan all subdirectories; detect project type + runtime per service root | [classify.md](references/classify.md) |
 | If 2+ service roots: assign service IDs, deduplicate emulators, plan compound debug config | [multi-service.md](references/multi-service.md) |
 

--- a/resources/agents/azure-debug-plan/references/inventory.md
+++ b/resources/agents/azure-debug-plan/references/inventory.md
@@ -6,6 +6,14 @@ Scan the workspace to populate the plan. For multi-service workspaces, loop over
 
 ## Step 1: Prerequisites
 
+### Autopilot: Reuse the Project Plan Prerequisites
+
+**Autopilot mode only.** In autopilot, if `.azure/project-plan.md` exists and lists Prerequisites (its `### Run` and `### Debug` groups), carry those prerequisites over wholesale into the debug plan instead of re-deriving them — the planning stage already inventoried them, and autopilot has no approval gate to catch a dropped prerequisite. Add any prerequisites the workspace scan reveals that project-plan is missing, and don't silently override a project-plan entry. Only when project-plan has no Prerequisites do you fall back to deriving them from the workspace scan below.
+
+In interactive (non-autopilot) mode, derive prerequisites from the workspace scan as usual; the user reviews and edits the plan before approving.
+
+### Deriving Prerequisites from the Workspace Scan
+
 Identify required tools and then inventory them by following [prerequisites.md](../../shared-references/prerequisites.md).
 
 The required tools are derived from a scan of the currently opened workspace project — check only the tools and extensions relevant to the detected project types, runtimes, and Azure bindings. Both tool sets defined in prerequisites.md apply here — the **Run** tools (Node.js, .NET SDK, Python, Functions Core Tools, ...) and the **Debug** tools (Docker, Docker Compose, VS Code extensions, ...) — since debugging exercises the full local stack.


### PR DESCRIPTION
Closes https://github.com/microsoft/azcode-internal/issues/272

In autopilot mode the debug-plan agent re-derived prerequisites from scratch and could silently drop what the planning stage already found (e.g. the detected browser), because autopilot skips the approval gate that would otherwise catch it.

My fix instructs the local debug plan agent to honor whatever was agreed to in project-plan when i autopilot mode.