### PR TITLE
Add initial set of local dev evals 

### DIFF
--- a/.github/workflows/msbench-evals.yml
+++ b/.github/workflows/msbench-evals.yml
@@ -99,6 +99,14 @@ jobs:
           tenant-id: ${{ secrets.MSBENCH_AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.MSBENCH_AZURE_SUBSCRIPTION_ID }}
 
+      # assets/ is generated rather than tracked, so the suite config, the grader
+      # bundle and the workspace seed have to be assembled before run.sh reads them.
+      # preflight catches a broken config offline, before ~15 minutes of container time.
+      - name: Stage project-plan assets
+        run: |
+          ./evals/msbench/stage.sh project-plan
+          ./evals/msbench/preflight.sh project-plan
+
       - name: Run project-plan eval
         run: ./evals/msbench/run.sh --skip-build --output "$RUNNER_TEMP/report.json" --data_dir "$RUNNER_TEMP/msbench-data"
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,10 @@ results/
 
 # Generated eval skills (built from resources/agents/*.agent.md at run time)
 evals/.generated/
+
+# MSBench assets are assembled by evals/msbench/stage.sh from the repo's own
+# graders and fixtures. Committing them would create a second copy of the
+# contracts that could silently drift from the originals.
+evals/msbench/assets/graders/
+evals/msbench/assets/workspace-seed/
+evals/msbench/assets/user-overrides.yaml

--- a/evals/executor/azure-agent-executor.mjs
+++ b/evals/executor/azure-agent-executor.mjs
@@ -21,7 +21,26 @@ import { workflowToolDefinitions } from "../mcp/workflow-tools.mjs";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "../..");
-const AGENT_NAME = "azure-project-plan";
+/**
+ * Which shipped agents to load into the session.
+ *
+ * A suite sets `AZURE_EVAL_AGENTS` (comma-separated) via `environment.env` when it
+ * needs more than one — the local-dev suite loads the scaffold and both debug agents
+ * so a multi-turn stimulus can walk the real Plan → Scaffold → Debug chain and skill
+ * activation is chosen by the model from the shipped descriptions, exactly as in VS Code.
+ * Defaults to the plan agent so the existing project-plan suite is unaffected.
+ */
+const DEFAULT_AGENTS = ["azure-project-plan"];
+
+function resolveAgentNames(options) {
+    const raw = options?.env?.AZURE_EVAL_AGENTS ?? process.env.AZURE_EVAL_AGENTS;
+    if (!raw) { return DEFAULT_AGENTS; }
+    const names = raw.split(",").map(n => n.trim()).filter(Boolean);
+    if (names.length === 0) {
+        throw new Error("AZURE_EVAL_AGENTS was set but contained no agent names.");
+    }
+    return names;
+}
 
 function getBundledCliPath() {
     const pkgDir = path.resolve(__dirname, "../node_modules/@github/copilot");
@@ -125,15 +144,26 @@ class AzureAgentExecutor {
         let assistantOutput = "";
         const rawEvents = [];
 
-        const skillDir = buildEvalSkill(repoRoot, AGENT_NAME, path.resolve(__dirname, "../.generated/skills"));
-        const skillDirs = [skillDir];
+        const agentNames = resolveAgentNames(options);
+        const skillDirs = agentNames.map(agentName =>
+            buildEvalSkill(repoRoot, agentName, path.resolve(__dirname, "../.generated/skills")));
 
-        // Put the shipped instruction folder (including references/) in the workspace,
-        // exactly as the extension writes it to a user's .github/agents.
-        const copiedFolders = prepareAgentWorkspace(repoRoot, options.workDir, AGENT_NAME);
-        const { model, supported } = resolveEvalModel(repoRoot, AGENT_NAME, options.model);
+        // Put the shipped instruction folders (including references/) in the workspace,
+        // exactly as the extension writes them to a user's .github/agents.
+        const copiedFolders = [...new Set(agentNames.flatMap(agentName =>
+            prepareAgentWorkspace(repoRoot, options.workDir, agentName)))];
+
+        // Validate the pinned model against every agent in the chain, not just the first, so a
+        // hand-off into an agent that doesn't support it fails before the run starts.
+        const resolvedModels = agentNames.map(agentName =>
+            resolveEvalModel(repoRoot, agentName, options.model));
+        const model = resolvedModels[0].model;
+        const supported = resolvedModels.reduce(
+            (shared, resolved) => shared.filter(name => resolved.supported.includes(name)),
+            resolvedModels[0].supported);
 
         process.stderr.write(`[azure-agent-executor] workDir: ${options.workDir}\n`);
+        process.stderr.write(`[azure-agent-executor] agents: ${agentNames.join(", ")}\n`);
         process.stderr.write(`[azure-agent-executor] skillDirs: ${JSON.stringify(skillDirs)}\n`);
         process.stderr.write(`[azure-agent-executor] agent assets: ${copiedFolders.join(", ") || "none"}\n`);
         process.stderr.write(`[azure-agent-executor] model: ${model} (agent supports: ${supported.join(", ")})\n`);

--- a/evals/grader-certification/manifest.json
+++ b/evals/grader-certification/manifest.json
@@ -8,7 +8,10 @@
             "requirements",
             "project-plan",
             "plan-gate",
-            "preview"
+            "preview",
+            "debug-plan",
+            "debug-config",
+            "debug-artifacts"
         ]
     },
     "mutations": [
@@ -59,6 +62,144 @@
             "search": "\"previewStatus\": \"ready\"",
             "replacement": "\"previewStatus\": \"draft\"",
             "expectedCode": "previewNotReady"
+        },
+        {
+            "id": "debug-plan-table-concatenated",
+            "tier": "offline",
+            "validator": "debug-plan",
+            "file": ".azure/vscode-debug-plan.md",
+            "operation": "replace",
+            "search": "|---|---|---|---|---|---|---|---|\n",
+            "replacement": "|---|---|---|---|---|---|---|---|| [x] | Ghost App (debug) | Ghost App | `./ghost` | Backend | Node.js | 22.x | None |\n",
+            "expectedCode": "tableRowConcatenated"
+        },
+        {
+            "id": "debug-plan-checklist-stub",
+            "tier": "offline",
+            "validator": "debug-plan",
+            "file": ".azure/vscode-debug-plan.md",
+            "operation": "replace",
+            "search": "\u2705 Persistence \u2014 Created project remained visible after restarting the service, confirming the local JSON store is written through.",
+            "replacement": "\u2705 Persistence \u2014 TBD",
+            "expectedCode": "checklistStub"
+        },
+        {
+            "id": "debug-plan-diagram-dropped",
+            "tier": "offline",
+            "validator": "debug-plan",
+            "file": ".azure/vscode-debug-plan.md",
+            "operation": "replace",
+            "search": "## Architecture Diagram",
+            "replacement": "## Architecture Notes",
+            "expectedCode": "missingSection"
+        },
+        {
+            "id": "debug-plan-status-regressed",
+            "tier": "offline",
+            "validator": "debug-plan",
+            "file": ".azure/vscode-debug-plan.md",
+            "operation": "replace",
+            "search": "> **Status:** Implemented",
+            "replacement": "> **Status:** Planning",
+            "expectedCode": "unexpectedStatus"
+        },
+        {
+            "id": "debug-config-prelaunch-dangling",
+            "tier": "offline",
+            "validator": "debug-config",
+            "file": ".vscode/launch.json",
+            "operation": "replace",
+            "search": "\"preLaunchTask\": \"prepare\"",
+            "replacement": "\"preLaunchTask\": \"prepare-everything\"",
+            "expectedCode": "preLaunchTaskUnresolved"
+        },
+        {
+            "id": "debug-config-dependson-dangling",
+            "tier": "offline",
+            "validator": "debug-config",
+            "file": ".vscode/tasks.json",
+            "operation": "replace",
+            "search": "\"dependsOn\": \"install\"",
+            "replacement": "\"dependsOn\": \"restore\"",
+            "expectedCode": "dependsOnUnresolved"
+        },
+        {
+            "id": "debug-config-dependson-cycle",
+            "tier": "offline",
+            "validator": "debug-config",
+            "file": ".vscode/tasks.json",
+            "operation": "replace",
+            "search": "\"command\": \"npm ci --ignore-scripts\",",
+            "replacement": "\"command\": \"npm ci --ignore-scripts\",\n            \"dependsOn\": \"prepare\",",
+            "expectedCode": "dependsOnCycle"
+        },
+        {
+            "id": "debug-artifacts-unchecked-config-generated",
+            "tier": "offline",
+            "validator": "debug-artifacts",
+            "file": ".azure/vscode-debug-plan.md",
+            "operation": "replace",
+            "search": "| [x] | Golden App (debug) |",
+            "replacement": "| [ ] | Golden App (debug) |",
+            "expectedCode": "uncheckedConfigGenerated"
+        },
+        {
+            "id": "debug-artifacts-script-not-registered",
+            "tier": "offline",
+            "validator": "debug-artifacts",
+            "file": ".azure/vscode-debug-plan.md",
+            "operation": "replace",
+            "search": "| [x] | start | ./package.json |",
+            "replacement": "| [x] | serve | ./package.json |",
+            "expectedCode": "scriptNotRegistered"
+        },
+        {
+            "id": "debug-artifacts-api-collection-empty",
+            "tier": "offline",
+            "validator": "debug-artifacts",
+            "file": "api-test-collections/golden-app/health/invoke.sh",
+            "operation": "delete",
+            "expectedCode": "apiCollectionEmpty"
+        },
+        {
+            "id": "debug-config-task-run-options",
+            "tier": "offline",
+            "validator": "debug-config",
+            "file": ".vscode/tasks.json",
+            "operation": "replace",
+            "search": "\"instancePolicy\": \"silent\"",
+            "replacement": "\"instancePolicy\": \"prompt\"",
+            "expectedCode": "invalidTaskRunOptions"
+        },
+        {
+            "id": "debug-config-duplicate-task-label",
+            "tier": "offline",
+            "validator": "debug-config",
+            "file": ".vscode/tasks.json",
+            "operation": "replace",
+            "search": "\"label\": \"build\",",
+            "replacement": "\"label\": \"install\",",
+            "expectedCode": "duplicateTaskLabels"
+        },
+        {
+            "id": "debug-artifacts-extension-recommendations",
+            "tier": "offline",
+            "validator": "debug-artifacts",
+            "file": ".vscode/extensions.json",
+            "operation": "replace",
+            "search": "\"ms-vscode.js-debug\"",
+            "replacement": "\"js-debug\"",
+            "expectedCode": "invalidExtensionRecommendations"
+        },
+        {
+            "id": "debug-artifacts-redacted-secret",
+            "tier": "offline",
+            "validator": "debug-artifacts",
+            "file": ".env.example",
+            "operation": "replace",
+            "replacement": "DATABASE_URL=postgres://golden:******@localhost:5432/golden",
+            "expectedCode": "redactedSecretPlaceholder",
+            "search": "PORT=7071"
         }
     ]
 }

--- a/evals/grader-certification/reference-node-fullstack/.azure/vscode-debug-plan.md
+++ b/evals/grader-certification/reference-node-fullstack/.azure/vscode-debug-plan.md
@@ -2,47 +2,56 @@
 
 > **Status:** Implemented
 > **Execution Mode:** Auto
+> **Created:** 2026-08-07T00:00:00.000Z
 > **Last Updated:** 2026-08-07T00:00:00.000Z
 
 ## Prerequisites
 
-| Tool | Installed |
-|---|---|
-| Node.js 22 | Yes |
-| npm | Yes |
+| Tool | Required Version | Installed | Action Required |
+|---|---|---|---|
+| Node.js | 22.x | ✅ | None |
+| npm | 10.x | ✅ | None |
 
 ## Debug Configurations
 
-| Generate | Debug Config Name | Service Root | Project Type | Runtime | Notes |
-|---|---|---|---|---|---|
-| [x] | Golden App (debug) | `.` | Backend | Node.js | Launch with CDP inspector |
+| Generate | Debug Config Name | Service Label | Service Root | Project Type | Runtime | Version | Azure Dependencies |
+|---|---|---|---|---|---|---|---|
+| [x] | Golden App (debug) | Golden App | `.` | Backend | Node.js | 22.x | None |
 
 ## Orchestrator
 
 | Orchestrator | Selected | Notes |
 |---|---|---|
-| VS Code task and launch configuration | Yes | Build before launch |
-
-## Architecture
-
-```text
-Browser -> Node.js API and static server -> JSON file
-             |
-             +-> CDP inspector on port 9229
-```
+| VS Code task and launch configuration | Yes | Single service, so no compound configuration is required. |
 
 ## Emulators
 
-No emulators are required.
+No emulators are required. The app persists to a local JSON file, so no containerized dependency is started.
+
+## Architecture Diagram
+
+```mermaid
+graph LR
+    Browser[Browser] --> App[Golden App<br/>Node.js API + static server]
+    App --> Store[(Local JSON file)]
+    Debugger[VS Code debugger] -. CDP :9229 .-> App
+```
+
+## Convenience Scripts
+
+| Generate | Script | Registered In | Purpose |
+|---|---|---|---|
+| [x] | start | ./package.json | Run the Golden App outside the debugger. |
 
 ## API Test Collections
 
-No generated API test collection is required.
+| Generate | Service | Endpoints | Notes |
+|---|---|---|---|
+| [x] | Golden App | GET /api/health | Health probe used to confirm the service is listening. |
 
 ## Debug Configuration Checklist
 
 Debug Configuration Checklist:
-
-✅ Golden App (debug) — HTTP health returned 200 and CDP inspector metadata was available.
-✅ Golden Project Tracker — browser interaction and accessibility checks passed.
-✅ Persistence — created project remained visible after service restart.
+✅ Golden App (debug) — Ready signal `Server listening on :3000` observed on the `prepare` task chain; `curl http://localhost:3000/api/health` → `200`; CDP inspector metadata available on `ws://127.0.0.1:9229`.
+✅ Golden Project Tracker — Browser interaction and accessibility checks passed against the served UI at `http://localhost:3000`.
+✅ Persistence — Created project remained visible after restarting the service, confirming the local JSON store is written through.

--- a/evals/grader-certification/reference-node-fullstack/.env.example
+++ b/evals/grader-certification/reference-node-fullstack/.env.example
@@ -1,0 +1,3 @@
+# Copy to .env before launching the Golden App (debug) configuration.
+PORT=7071
+DATA_FILE=./data/projects.json

--- a/evals/grader-certification/reference-node-fullstack/api-test-collections/golden-app/health/invoke.sh
+++ b/evals/grader-certification/reference-node-fullstack/api-test-collections/golden-app/health/invoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Health probe for the Golden App debug configuration.
+set -euo pipefail
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+curl --fail --silent --show-error "${BASE_URL}/api/health"

--- a/evals/graders/graderHarness.ts
+++ b/evals/graders/graderHarness.ts
@@ -28,8 +28,20 @@ export const EXIT_GRADER_ERROR = 3;
 /** Raised for a bad artifact — anything else thrown is treated as a harness fault. */
 export class ProductFailure extends Error { }
 
+/**
+ * The directory being graded. Vally runs a grader with its cwd already set to the
+ * workspace, so cwd is a legitimate fallback — but when someone runs a grader by hand
+ * and forgets `EVALUATE_WORKSPACE`, that fallback silently grades the wrong tree.
+ * `describeWorkspaceSource` exists so the failure says which one was used.
+ */
 export function workspacePath(relativePath: string): string {
     return resolve(process.env.EVALUATE_WORKSPACE || process.cwd(), relativePath);
+}
+
+function describeWorkspaceSource(): string {
+    return process.env.EVALUATE_WORKSPACE
+        ? 'workspace from EVALUATE_WORKSPACE'
+        : 'workspace defaulted to the current directory because EVALUATE_WORKSPACE is not set';
 }
 
 /** Read an artifact the agent was contracted to produce; a missing file is a product failure. */
@@ -38,7 +50,7 @@ export function readArtifact(relativePath: string): string {
     try {
         return readFileSync(absolute, 'utf8');
     } catch {
-        throw new ProductFailure(`${absolute} does not exist`);
+        throw new ProductFailure(`${absolute} does not exist (${describeWorkspaceSource()})`);
     }
 }
 
@@ -59,13 +71,31 @@ export function runGrader(name: string, body: () => void): void {
     try {
         body();
     } catch (error) {
-        if (error instanceof ProductFailure) {
-            console.error(`FAIL: ${name} — ${error.message}`);
-            process.exit(EXIT_PRODUCT_FAILURE);
-        }
-        console.error(`GRADER ERROR: ${name} threw ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
-        process.exit(EXIT_GRADER_ERROR);
+        exitForError(name, error);
     }
     console.error(`PASS: ${name}`);
     process.exit(EXIT_PASS);
+}
+
+/**
+ * Same contract as `runGrader`, for graders that must inspect the workspace on disk
+ * and therefore await filesystem reads.
+ */
+export async function runGraderAsync(name: string, body: () => Promise<void>): Promise<void> {
+    try {
+        await body();
+    } catch (error) {
+        exitForError(name, error);
+    }
+    console.error(`PASS: ${name}`);
+    process.exit(EXIT_PASS);
+}
+
+function exitForError(name: string, error: unknown): never {
+    if (error instanceof ProductFailure) {
+        console.error(`FAIL: ${name} — ${error.message}`);
+        process.exit(EXIT_PRODUCT_FAILURE);
+    }
+    console.error(`GRADER ERROR: ${name} threw ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+    process.exit(EXIT_GRADER_ERROR);
 }

--- a/evals/graders/validate-debug-artifacts.ts
+++ b/evals/graders/validate-debug-artifacts.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Grades the generated workspace against the plan that specified it.
+ *
+ * The plan is the contract: every row marked `[x]` must have produced exactly one
+ * artifact, and every row marked `[ ]` must have produced none. This grader catches
+ * the case where generation quietly diverges from what the user approved.
+ */
+
+import { validateDebugArtifacts } from '../src/artifacts/debugArtifacts.ts';
+import { failWithIssues, runGraderAsync, workspacePath } from './graderHarness.ts';
+
+await runGraderAsync('generated debug artifacts match the approved plan', async () => {
+    const result = await validateDebugArtifacts(workspacePath('.'));
+    if (!result.valid) {
+        failWithIssues('plan/artifact conformance errors:', result.issues);
+    }
+});

--- a/evals/graders/validate-debug-config.ts
+++ b/evals/graders/validate-debug-config.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Grades the generated `.vscode/launch.json` and `.vscode/tasks.json` for structural
+ * soundness: named configurations, resolvable `preLaunchTask` and `dependsOn` chains,
+ * terminating dependency graphs, and compounds that start each service exactly once.
+ *
+ * These are the defects a user hits on the first F5, and they are all detectable
+ * without running anything.
+ *
+ * Flags: --assert-compound, --assert-no-compound, --assert-config-count=N
+ */
+
+import { existsSync } from 'node:fs';
+import { readLaunchDocument, validateDebugLaunchConfiguration } from '../src/artifacts/launchConfig.ts';
+import { fail, failWithIssues, readArtifact, runGrader, workspacePath } from './graderHarness.ts';
+
+runGrader('launch.json and tasks.json are structurally sound', () => {
+    const args = process.argv.slice(2);
+    const launchText = readArtifact('.vscode/launch.json');
+    // A workspace whose configurations declare no preLaunchTask legitimately has no
+    // tasks file; the validator reports a dangling reference if one is needed.
+    const tasksText = existsSync(workspacePath('.vscode/tasks.json')) ? readArtifact('.vscode/tasks.json') : undefined;
+
+    const result = validateDebugLaunchConfiguration(launchText, tasksText);
+    if (!result.valid) {
+        failWithIssues('debug configuration errors:', result.issues);
+    }
+
+    const launch = readLaunchDocument(launchText);
+    if (args.includes('--assert-compound') && launch.compounds.length === 0) {
+        fail('Expected a compound configuration for a multi-service project, found none');
+    }
+    if (args.includes('--assert-no-compound') && launch.compounds.length > 0) {
+        fail(`Expected no compound configuration for a single-service project, found ${launch.compounds.length}`);
+    }
+
+    const countFlag = args.find(arg => arg.startsWith('--assert-config-count='));
+    if (countFlag) {
+        const expected = Number(countFlag.split('=')[1]);
+        if (!Number.isInteger(expected) || expected < 0) {
+            // A bad flag is a miswired eval spec, not a product defect.
+            throw new Error(`Invalid ${countFlag}: expected a non-negative integer`);
+        }
+        if (launch.configurations.length !== expected) {
+            fail(`Expected ${expected} launch configurations, got ${launch.configurations.length}`);
+        }
+    }
+});

--- a/evals/graders/validate-debug-gate.ts
+++ b/evals/graders/validate-debug-gate.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Grades the approval gate at the end of the planning phase.
+ *
+ * `azure-debug-plan` is contracted to produce the plan and then STOP: it must not
+ * write launch/tasks configuration, a compose file, or scripts before the user has
+ * approved. Generating early is the failure mode this grader exists to catch, so it
+ * asserts both that the plan is present and reviewable, and that nothing downstream
+ * of the gate has appeared yet.
+ *
+ * Flags: --assert-status=<status>   (defaults to Planning)
+ */
+
+import { existsSync } from 'node:fs';
+import { validateLocalDebugPlanArtifact } from '../src/artifacts/localDebugPlan.ts';
+import { fail, failWithIssues, readArtifact, runGrader, workspacePath } from './graderHarness.ts';
+
+/**
+ * Artifacts that *only* the generation phase can create.
+ *
+ * Compose files are deliberately absent. A scaffolded project may already ship a
+ * `docker-compose.yml` for its own dependencies — `azure-debug-plan` is contracted to
+ * *merge* into an existing compose file rather than overwrite it — so its presence at
+ * the gate proves nothing about whether generation ran. Detecting a premature *merge*
+ * would need a pre-gate baseline to diff against, which a post-hoc grader does not have.
+ * These three are unambiguous: nothing upstream of the gate writes them.
+ */
+const POST_GATE_ARTIFACTS = [
+    '.vscode/launch.json',
+    '.vscode/tasks.json',
+    'api-test-collections',
+];
+
+runGrader('debug planning stopped at the approval gate', () => {
+    const args = process.argv.slice(2);
+    const expectedStatus = args.find(arg => arg.startsWith('--assert-status='))?.split('=')[1] || 'Planning';
+
+    const content = readArtifact('.azure/vscode-debug-plan.md');
+    const result = validateLocalDebugPlanArtifact(content, { expectedStatus });
+    if (!result.valid) {
+        failWithIssues('debug plan is not in a reviewable state at the gate:', result.issues);
+    }
+
+    const premature = POST_GATE_ARTIFACTS.filter(relativePath => existsSync(workspacePath(relativePath)));
+    if (premature.length > 0) {
+        fail(`Generation ran before approval — found ${premature.join(', ')}`);
+    }
+});

--- a/evals/graders/validate-debug-plan.ts
+++ b/evals/graders/validate-debug-plan.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Grades `.azure/vscode-debug-plan.md` against the certified debug-plan validator.
+ *
+ * Contract checks (header, table integrity, required sections, checklist) live in
+ * `evals/src/artifacts/localDebugPlan.ts`. Only scenario-specific expectations —
+ * how many services this project has, which emulators it needs — are expressed here.
+ *
+ * Flags: --assert-status=<Planning|Approved|Executing|Implemented>
+ *        --assert-service-count=N
+ *        --assert-emulator=<substring>   (repeatable)
+ *        --assert-no-emulators
+ *        --assert-checklist
+ */
+
+import type { LocalDebugPlanExpectations } from '../src/artifacts/localDebugPlan.ts';
+import { validateLocalDebugPlanArtifact } from '../src/artifacts/localDebugPlan.ts';
+import { failWithIssues, readArtifact, runGrader } from './graderHarness.ts';
+
+runGrader('vscode-debug-plan.md satisfies the debug plan contract', () => {
+    const args = process.argv.slice(2);
+    const content = readArtifact('.azure/vscode-debug-plan.md');
+
+    const expectations: LocalDebugPlanExpectations = {
+        expectedStatus: valueOf(args, '--assert-status'),
+        expectedServiceCount: countOf(args, '--assert-service-count'),
+        expectedEmulators: valuesOf(args, '--assert-emulator'),
+        expectNoEmulators: args.includes('--assert-no-emulators'),
+        requireChecklist: args.includes('--assert-checklist'),
+    };
+
+    const result = validateLocalDebugPlanArtifact(content, expectations);
+    if (!result.valid) {
+        failWithIssues('debug plan validation errors:', result.issues);
+    }
+});
+
+function valueOf(args: string[], flag: string): string | undefined {
+    const match = args.find(arg => arg.startsWith(`${flag}=`));
+    return match?.slice(flag.length + 1) || undefined;
+}
+
+function valuesOf(args: string[], flag: string): string[] | undefined {
+    const values = args.filter(arg => arg.startsWith(`${flag}=`)).map(arg => arg.slice(flag.length + 1)).filter(Boolean);
+    return values.length ? values : undefined;
+}
+
+function countOf(args: string[], flag: string): number | undefined {
+    const raw = valueOf(args, flag);
+    if (raw === undefined) {
+        return undefined;
+    }
+    const parsed = Number(raw);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+        // A bad flag is a miswired eval spec, not a product defect. Throwing a plain
+        // Error routes it to exit 3 so the report blames the harness.
+        throw new Error(`Invalid ${flag}=${raw}: expected a non-negative integer`);
+    }
+    return parsed;
+}

--- a/evals/local-dev/eval.yaml
+++ b/evals/local-dev/eval.yaml
@@ -1,0 +1,104 @@
+name: azure-local-dev-contracts
+description: >
+  Verify the local development phase — azure-debug-plan scans a real scaffolded
+  workspace and produces a valid debug plan, stops at the approval gate, and
+  azure-debug-generate emits launch/tasks/compose artifacts that conform to it.
+type: capability
+
+defaults:
+  runs: 1
+  # Scaffolding a real project before the debug phase runs is slow; this is a
+  # chained multi-agent suite, not a single-turn one.
+  timeout: 45m
+  executor: azure-agent-executor
+
+# Chain the *real* scaffold agent so the debug agents analyse genuine generated
+# output rather than a hand-written fixture that can drift from what scaffold emits.
+# Only the approved plan is seeded: azure-project-scaffold requires
+# `.azure/project-plan.md` to exist and be Approved, but does not require the
+# azure-project-plan agent to have produced it — so we skip the cost and flakiness
+# of the requirements phase without giving up scaffold fidelity.
+environment:
+  files:
+    - src: ${REPO_ROOT=../..}/evals/local-dev/fixtures/functions-postgres/.azure/project-plan.md
+      dest: .azure/project-plan.md
+  env:
+    # The executor loads every agent named here, so skill activation is chosen by
+    # the model from the shipped descriptions, exactly as it is in VS Code.
+    AZURE_EVAL_AGENTS: azure-project-scaffold,azure-debug-plan,azure-debug-generate
+
+stimuli:
+  # ─── 2.1 Debug plan stops at the approval gate ────────────────────────────
+  - name: debug-plan-approval-gate
+    turns:
+      - |
+        The project plan has been approved. Execute the approved
+        `.azure/project-plan.md` and scaffold the project.
+      - |
+        Now set up local debugging for this project so I can hit F5 in VS Code.
+    graders:
+      - type: file-exists
+        name: debug-plan-exists
+        config:
+          path: .azure/vscode-debug-plan.md
+      - type: program
+        name: debug-plan-contract-valid
+        config:
+          program: node
+          args: [--disable-warning=MODULE_TYPELESS_PACKAGE_JSON, ${REPO_ROOT=../..}/evals/graders/validate-debug-plan.ts]
+      - type: program
+        name: stops-at-approval-gate
+        config:
+          program: node
+          args: [--disable-warning=MODULE_TYPELESS_PACKAGE_JSON, ${REPO_ROOT=../..}/evals/graders/validate-debug-gate.ts]
+      - type: tool-calls
+        name: opens-local-plan-view
+        config:
+          required: [workflow-tools-open_local_plan_view]
+      - type: tool-calls
+        name: no-premature-generate-handoff
+        config:
+          disallowed: [workflow-tools-start_azure_debug_generate]
+    constraints:
+      reject_tools: [vscode_askQuestions]
+
+  # ─── 2.2 Approved plan generates conforming artifacts ─────────────────────
+  - name: debug-generate-artifacts
+    turns:
+      - |
+        The project plan has been approved. Execute the approved
+        `.azure/project-plan.md` and scaffold the project.
+      - |
+        Now set up local debugging for this project so I can hit F5 in VS Code.
+      - "The debug plan looks good, approved. Generate the configuration."
+      # azure-debug-plan is contracted to call start_azure_debug_generate and STOP
+      # (azure-debug-plan.agent.md step 4). In VS Code that tool call spawns the
+      # generate agent; the harness MCP tool is a stub, so this turn carries the
+      # exact hand-off prompt the tool would have sent, verbatim from that step.
+      - "The local debugging plan has been approved. Now generate the artifacts as specified by `.azure/vscode-debug-plan.md`."
+    graders:
+      - type: file-exists
+        name: launch-json-exists
+        config:
+          path: .vscode/launch.json
+      - type: program
+        name: debug-plan-implemented
+        config:
+          program: node
+          args: [--disable-warning=MODULE_TYPELESS_PACKAGE_JSON, ${REPO_ROOT=../..}/evals/graders/validate-debug-plan.ts, --assert-status=Implemented, --assert-checklist]
+      - type: program
+        name: debug-config-structurally-sound
+        config:
+          program: node
+          args: [--disable-warning=MODULE_TYPELESS_PACKAGE_JSON, ${REPO_ROOT=../..}/evals/graders/validate-debug-config.ts]
+      - type: program
+        name: artifacts-conform-to-plan
+        config:
+          program: node
+          args: [--disable-warning=MODULE_TYPELESS_PACKAGE_JSON, ${REPO_ROOT=../..}/evals/graders/validate-debug-artifacts.ts]
+      - type: tool-calls
+        name: generate-handoff
+        config:
+          required: [workflow-tools-start_azure_debug_generate]
+    constraints:
+      reject_tools: [vscode_askQuestions]

--- a/evals/local-dev/fixtures/functions-postgres/.azure/project-plan.md
+++ b/evals/local-dev/fixtures/functions-postgres/.azure/project-plan.md
@@ -1,0 +1,70 @@
+# Project Plan
+
+**Status**: Approved
+**Created**: 2026-08-24
+**Mode**: New Project
+
+## 1. Project Overview
+
+**App Type**: Web Application
+
+Build a task tracker with a React frontend, an Azure Functions HTTP backend, and a
+PostgreSQL database for durable storage. Uploaded attachments are held in Blob Storage.
+
+### User Flow
+
+A user opens the tracker, creates a task with an optional attachment, and sees the
+task persist across restarts.
+
+### Architecture
+
+- A React single-page app calls the Functions API.
+- An Azure Functions (Node.js) app exposes the task routes.
+- PostgreSQL stores task records; Blob Storage holds attachments.
+
+## 2. Services Required
+
+| Name | Responsibility |
+|---|---|
+| web | React frontend for creating and listing tasks |
+| api | Azure Functions HTTP API for task CRUD |
+| database | PostgreSQL store for task records |
+| storage | Blob Storage for task attachments |
+
+## 3. Prerequisites
+
+- Node.js 22
+- npm
+- Docker (for the local PostgreSQL and Azurite containers)
+- Azure Functions Core Tools v4
+
+## 4. Project Structure
+
+```text
+web/src/App.tsx
+web/package.json
+api/src/functions/tasks.js
+api/host.json
+api/package.json
+```
+
+## 5. Route Definitions
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | /api/health | Liveness probe |
+| GET | /api/tasks | List tasks |
+| POST | /api/tasks | Create a task |
+
+## 6. Azure Dependencies
+
+| Dependency | Service | Local Emulator |
+|---|---|---|
+| PostgreSQL | database | `postgres:16` container |
+| Blob Storage | storage | Azurite container |
+
+## 7. Acceptance Criteria
+
+- `GET /api/health` returns 200.
+- A created task survives an API restart.
+- The frontend lists tasks returned by the API.

--- a/evals/msbench/SUITES.md
+++ b/evals/msbench/SUITES.md
@@ -1,0 +1,188 @@
+# MSBench suites
+
+Each subdirectory is one suite: a `user-overrides.yaml` staged as the last of the
+three config layers described in [`README.md`](./README.md).
+
+```bash
+./stage.sh --list          # local-dev, project-plan
+./stage.sh local-dev       # assemble assets/
+./preflight.sh local-dev   # verify offline, before spending a run
+./run.sh --skip-build      # submit
+```
+
+`stage.sh` copies the chosen suite's config to `assets/user-overrides.yaml`, which
+is what `run.sh` already reads — so `run.sh` needs no changes and no `--suite` flag.
+
+## `preflight.sh`
+
+An MSBench run is ~15 minutes and costs model calls, so it is worth catching the
+cheap mistakes first. `preflight.sh` stages the suite and then checks:
+
+- the config parses, and every `/agent/assets/...` path it references was staged
+- every `query:` is valid SQLite against the real assertion schema
+- every `exec:` **fails** against the workspace as the agent first sees it
+- every `exec:` **passes** against a workspace in the expected state for its step
+
+The third check is the important one: an assertion that passes against an untouched
+workspace is worse than no assertion, because it reports green. The fourth is its
+mirror — it catches an assertion so strict that even a correct agent fails it.
+
+Note that the reference for the fourth check is **step-dependent**. A gate assertion
+is phase-scoped (it requires the plan to still be at `Planning`), so validating it
+against a completed project would wrongly report it broken. Step 0 is checked against
+a synthesized planning-state workspace, later steps against the completed fixture.
+
+Preflight cannot check agent behaviour, the extension host, tool-call names as VS Code
+reports them, or whether the hand-off is observed. Those need a real run.
+
+## Why `exec:` instead of hand-translated SQL
+
+The original port turned each Vally grader into a SQL assertion by hand. That works
+for existence and tool-call checks, but it creates a **second copy of every contract**
+that has to be mirrored whenever the first changes — the risk the top-level README
+calls out.
+
+`stage-graders.sh` removes the need. It stages a self-contained bundle so the *real*
+graders run in-container:
+
+```
+assets/graders/
+  evals/graders/*.ts                       grader entry points
+  evals/src/artifacts/*.ts                 the validators
+  src/webviews/.../views/utils/            the product parsers they import
+  node_modules/jsonc-parser/               vendored; zero dependencies
+```
+
+The layout mirrors the repo, so every relative import resolves unchanged and no file
+needs editing. `jsonc-parser` is vendored rather than dropped because the extension
+itself ships and uses it — a file the grader accepts should be one the product can read.
+
+This is what the top-level README anticipated when it said the full contract check
+"lands next as an `exec:` assertion". `project-plan`'s requirements check is now the
+real `validate-requirements.ts` rather than a JSON-shape approximation.
+
+### What SQL is still better at
+
+`exec:` collapses the graders' three-way exit code (0 pass / 1 product failure /
+3 grader fault) into pass/fail, so SQL is kept for the things a filesystem grader
+genuinely cannot see:
+
+- **tool calls** — `toolCalls` has no filesystem equivalent
+- **chat prose** — `llm_responses` likewise
+- **per-step provenance** — `stepIndex` is auto-appended to every query, so an
+  assertion sees only its own turn
+
+That last one is a capability Vally lacks. `validate-debug-gate.ts` had to *drop* its
+docker-compose check, because a scaffolded project may legitimately ship a compose file
+and a post-hoc grader cannot distinguish that from a premature write. In `local-dev`
+the check is restored as a step-scoped query.
+
+## Suites
+
+### `project-plan`
+The `photo-app-requirements` stimulus. Ported from `evals/project-plan/eval.yaml`.
+
+### `local-dev`
+The local development phase — `azure-debug-plan` → `azure-debug-generate` — carrying
+all four debug graders from `evals/local-dev/eval.yaml`.
+
+It starts **mid-workflow**, because the debug agents analyse an existing project rather
+than create one. `stage-workspace.sh` seeds one from
+`evals/grader-certification/reference-node-fullstack`, reusing the grader certification
+fixture so the seed cannot rot independently of the graders.
+
+The seed deliberately **excludes** `.vscode/`, `.azure/vscode-debug-plan.md`,
+`api-test-collections/` and `docker-compose.yml`. Those are the artifacts under test;
+seeding them would let every assertion pass without the agent doing anything. The
+stager asserts their absence, and all four graders exit 1 against the bare seed and 0
+against the completed fixture — so the assertions are falsifiable in both directions.
+
+#### Known limitation: the hand-off
+
+`start_azure_debug_generate` calls `openChatWithAgent`, which runs
+`workbench.action.chat.newChat` — fire-and-forget, with no session handle. `promptSteps`
+drive a *single* session, so whether MSBench observes the spawned agent is **unverified**.
+
+Step 2 covers the case where it does not: it repeats the hand-off prompt verbatim from
+`startAzureDebugGenerateCommand`, so it is the exact query the product sends. If the
+native hand-off is observed, that step is a harmless restatement.
+
+`promptSteps[].handoff: { id }` is the schema-native alternative and would be cleaner,
+but the ids come from `workbench.action.chat.getHandoffs` and can only be discovered
+from a live run. Worth revisiting once one has been captured.
+
+## Relationship to PR #1689
+
+#1689 merged into `feat/CoR` on 2026-08-25 and is what provides `run.sh`, the README,
+and the CI workflow. It tracked `assets/user-overrides.yaml` (renamed from
+`cor-requirements.vscode.agent.yaml`).
+
+Under this layout that path is **generated**, so this branch completes the migration:
+
+1. the tracked `assets/user-overrides.yaml` is deleted — `project-plan/user-overrides.yaml`
+   supersedes it and carries the `exec:` upgrade, replacing the SQL stand-in that
+   #1689's README flagged as partial
+2. `evals/msbench/assets/user-overrides.yaml` is `.gitignore`d alongside the other
+   generated asset paths
+3. `msbench-evals.yml` runs `./stage.sh project-plan && ./preflight.sh project-plan`
+   before `run.sh --skip-build`
+
+The consequence: **`run.sh` now requires `./stage.sh <suite>` first.** It no longer
+works straight from a clean checkout, because the config it reads is no longer
+committed. `stage.sh` does not touch `assets/extensions/`, so it is safe to run
+either side of the vsix download.
+
+## Unverified in-container
+
+- **Docker** — unknown, which is why no assertion boots an emulator.
+
+## Runtime graders (planned)
+
+Everything today is **structural**: the graders import only `node:fs` and `node:path`,
+so they check that artifacts are well-formed and mutually consistent, never that the
+project runs. A `launch.json` referencing a port nothing binds passes.
+
+The weakest link is the checklist assertion — the agent *self-reports* having validated
+its work and the grader only confirms the checklist is filled in, not that its evidence
+is real. A plausible fabricated checklist passes.
+
+MSBench makes the next rung possible, gated on the capability probe in `local-dev`'s
+`script:` block (read `customScript/output.log` from an extracted run):
+
+| Rung | Check | Needs |
+| --- | --- | --- |
+| Cheap | `docker compose config` parses and resolves | compose file only |
+| Cheap | generated watch/build task actually compiles | toolchain |
+| **Medium** | `docker compose up -d`, poll healthchecks, then run the generated `api-test-collections/**/invoke.sh` | **Docker daemon** |
+| Expensive | drive F5 via the debug API, assert a breakpoint binds | VS Code automation |
+
+The medium rung is the first that proves local debug *works*, and is the one worth
+building if the probe reports a usable daemon. It also turns the checklist assertion
+from self-report into corroboration: the invoke scripts either return the documented
+status codes or they do not.
+
+
+## Trap: the container's Node is older than yours
+
+The container runs **Node 22.22**; a current dev machine runs **Node 24**. Node 24
+treats a bare `.ts` file as ESM, Node 22 treats it as CommonJS. So a bundle without
+a `package.json` declaring `"type": "module"` works perfectly locally and dies
+in-container on the first `import` with *"Cannot use import statement outside a
+module"*.
+
+Locally that marker is supplied by `evals/package.json`, which Node finds by walking
+up — but the bundle is extracted to `/agent/assets`, where there is no ancestor
+`package.json` at all. `stage-graders.sh` therefore writes one into the bundle and
+asserts it **statically**, because no local run can catch this behaviourally.
+
+This cost run [`2026082568864133`](https://msbenchapp.azurewebsites.net/run-analysis/2026082568864133),
+where all five `exec:` assertions failed with exit 1 — indistinguishable from a real
+product failure, which is the sharp edge of `exec:` noted above. When an `exec:`
+assertion fails, **read `exec.output` from `session.sqlite` before believing it**:
+
+```bash
+msbench-cli extract --run_id <id> --output ./out
+sqlite3 ./out/*-output/output/vsc-output/session.sqlite \
+  "SELECT stepIndex, exitCode, output FROM exec ORDER BY id;"
+```
+

--- a/evals/msbench/local-dev/user-overrides.yaml
+++ b/evals/msbench/local-dev/user-overrides.yaml
@@ -1,0 +1,163 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/vscode-copilot-evaluation/main/doc/references/TestConfig.schema.json
+
+# The local development phase (azure-debug-plan -> azure-debug-generate) run
+# against real VS Code on MSBench, with the SAME graders the Vally
+# `evals/local-dev/eval.yaml` suite uses — not hand-translated SQL.
+#
+# Every artifact assertion here is an `exec:` that runs the real validator, so
+# there is no second copy of the contract to keep in sync. The SQL assertions
+# are reserved for the things SQL does better than a file-system grader:
+# tool calls, per-step provenance, and chat prose.
+#
+# Prepare the assets, then run:
+#   ../stage-graders.sh   ./assets
+#   ../stage-workspace.sh ./assets
+#   (then submit with the msbench run script, --agent-assets ./assets)
+
+modelSelector:
+  id: claude-sonnet-4.5
+  vendor: copilot
+
+installExtensions:
+  - id: ms-azuretools.vscode-azureresourcegroups
+    mode: vsix
+    # Container path. Everything under ./assets is copied to /agent/assets and,
+    # unlike a benchmark config, this path is NOT rewritten — so it is hardcoded.
+    path: /agent/assets/extensions/vscode-azureresourcegroups.vsix
+
+# The debug planning agent. Unlike the project-plan eval this session starts
+# mid-workflow, because the debug agents analyse an existing project rather than
+# create one. The hand-off to azure-debug-generate is driven by promptSteps below.
+chatMode: azure-debug-plan
+
+# The webview gate tools (open_local_plan_view, start_azure_debug_generate) block
+# on a confirmation that nothing can answer in an unattended run.
+dangerouslyAutoApproveAllToolCalls: true
+
+script: |
+  set -eux
+
+  # Agent definitions come out of the VSIX under test rather than a git clone, so
+  # the instructions cannot drift from the build being graded.
+  VSIX=/agent/assets/extensions/vscode-azureresourcegroups.vsix
+  rm -rf /tmp/corext && mkdir -p /tmp/corext
+  unzip -q -o "$VSIX" 'extension/resources/agents/*' -d /tmp/corext
+  mkdir -p /workspace/.github/agents
+  cp -r /tmp/corext/extension/resources/agents/. /workspace/.github/agents/
+
+  # Seed the scaffolded project the debug agents analyse. Staged by
+  # stage-workspace.sh from the grader certification fixture, with the debug
+  # artifacts stripped out so no assertion can pass without the agent working.
+  cp -R /agent/assets/workspace-seed/. /workspace/
+
+  # Fail the run here rather than at assertion time if the seed is wrong.
+  test -f /workspace/.azure/project-plan.md
+  test ! -e /workspace/.azure/vscode-debug-plan.md
+  test ! -e /workspace/.vscode/launch.json
+
+  # The graders are Node scripts using type stripping, which needs Node 22+.
+  node --version
+  node -e 'const [maj]=process.versions.node.split(".").map(Number); if (maj < 22) { console.error("Graders need Node 22+ for type stripping; found "+process.versions.node); process.exit(1); }'
+
+  # ─── Capability probe ────────────────────────────────────────────────────
+  # Non-fatal on purpose: this records what the container can actually do, so
+  # runtime graders (boot the emulators, hit the endpoints) can be scoped from
+  # evidence rather than assumption. Read the results afterwards from
+  # customScript/output.log in the extracted run.
+  #
+  # `set +e` because every probe below is expected to fail on some image, and a
+  # failed probe must not abort setup.
+  set +e
+  echo "───── CAPABILITY PROBE ─────"
+  echo "PROBE docker-cli:     $(command -v docker || echo ABSENT)"
+  echo "PROBE docker-daemon:  $(docker info --format '{{.ServerVersion}}' 2>&1 | head -1)"
+  echo "PROBE docker-compose: $(docker compose version 2>&1 | head -1)"
+  echo "PROBE can-run-container: $(docker run --rm hello-world >/dev/null 2>&1 && echo YES || echo NO)"
+  echo "PROBE user:           $(id)"
+  echo "PROBE network-egress: $(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 https://mcr.microsoft.com/v2/ 2>&1 | tail -1)"
+  echo "PROBE func-tools:     $(func --version 2>&1 | head -1)"
+  echo "PROBE dotnet:         $(dotnet --version 2>&1 | head -1)"
+  echo "PROBE python:         $(python3 --version 2>&1 | head -1)"
+  echo "PROBE free-mem-mb:    $(free -m 2>/dev/null | awk '/Mem:/{print $2}' || echo unknown)"
+  echo "───── END PROBE ─────"
+  set -e
+
+promptSteps:
+  # ─── Step 0: plan, and stop at the approval gate ──────────────────────────
+  - text: |
+      Set up local debugging for this project so I can hit F5 in VS Code.
+    assertions:
+      - comment: The debug plan satisfies the full plan contract (real validator)
+        exec: >-
+          EVALUATE_WORKSPACE=/workspace node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON
+          /agent/assets/graders/evals/graders/validate-debug-plan.ts
+        timeoutMs: 60000
+
+      - comment: Planning stopped at the approval gate without generating (real validator)
+        exec: >-
+          EVALUATE_WORKSPACE=/workspace node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON
+          /agent/assets/graders/evals/graders/validate-debug-gate.ts
+        timeoutMs: 60000
+
+      # vally: tool-calls required [open_local_plan_view]
+      - comment: Agent should open the local plan webview for review
+        query: SELECT COUNT(*) > 0 FROM toolCalls WHERE tool LIKE '%open_local_plan_view%'
+
+      # vally: tool-calls disallowed [start_azure_debug_generate]
+      - comment: Agent should not hand off to generation before approval
+        query: SELECT COUNT(*) = 0 FROM toolCalls WHERE tool LIKE '%start_azure_debug_generate%'
+
+      # Stronger than the Vally equivalent. `validate-debug-gate.ts` had to drop
+      # its compose check entirely, because a scaffolded project may legitimately
+      # ship docker-compose.yml and a post-hoc grader cannot tell that apart from
+      # a premature write. The implied stepIndex filter scopes this to files
+      # written by THIS step, which is exactly the provenance the grader lacks.
+      - comment: This step should not have written a compose file
+        query: >-
+          SELECT COUNT(*) = 0 FROM files
+          WHERE path LIKE '%docker-compose.yml' OR path LIKE '%compose.yaml'
+
+      - comment: Agent should not fall back to the chat question tool
+        query: SELECT COUNT(*) = 0 FROM toolCalls WHERE tool LIKE '%askQuestion%'
+
+  # ─── Step 1: approve, which triggers the hand-off to generation ───────────
+  #
+  # In VS Code, start_azure_debug_generate runs openChatWithAgent, which calls
+  # workbench.action.chat.newChat — a fire-and-forget new session with no handle
+  # (see projectSession.ts). promptSteps drive a single session, so whether the
+  # spawned agent is observed here is UNVERIFIED. Step 2 exists to cover the case
+  # where it is not.
+  - text: "The debug plan looks good, approved. Generate the configuration."
+    assertions:
+      - comment: Agent should hand off to the generation agent after approval
+        query: SELECT COUNT(*) > 0 FROM toolCalls WHERE tool LIKE '%start_azure_debug_generate%'
+
+  # ─── Step 2: generation ───────────────────────────────────────────────────
+  #
+  # Carries the hand-off prompt verbatim from startAzureDebugGenerateCommand in
+  # registerCopilotOnRailsCommands.ts, so this is the exact query the product
+  # sends when it opens the generate agent. If step 1's hand-off is observed
+  # natively this turn is a harmless no-op restatement.
+  - text: "The local debugging plan has been approved. Now generate the artifacts as specified by `.azure/vscode-debug-plan.md`."
+    assertions:
+      - comment: launch.json and tasks.json are structurally sound (real validator)
+        exec: >-
+          EVALUATE_WORKSPACE=/workspace node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON
+          /agent/assets/graders/evals/graders/validate-debug-config.ts
+        timeoutMs: 60000
+
+      - comment: Generated artifacts conform to the approved plan (real validator)
+        exec: >-
+          EVALUATE_WORKSPACE=/workspace node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON
+          /agent/assets/graders/evals/graders/validate-debug-artifacts.ts
+        timeoutMs: 60000
+
+      # The failure mode azure-debug-generate/instructions.md calls "the single
+      # most common": stopping at Executing without running validation. Both live
+      # Vally runs hit exactly this.
+      - comment: Plan reaches Implemented with a completed validation checklist (real validator)
+        exec: >-
+          EVALUATE_WORKSPACE=/workspace node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON
+          /agent/assets/graders/evals/graders/validate-debug-plan.ts
+          --assert-status=Implemented --assert-checklist
+        timeoutMs: 60000

--- a/evals/msbench/preflight.sh
+++ b/evals/msbench/preflight.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# Verify a suite offline, before spending an MSBench run on it.
+#
+# An MSBench run is ~15 minutes and costs model calls, so the failures worth
+# catching here are the dumb ones: an `exec:` pointing at a path that is not in
+# the bundle, a SQL typo, or — the dangerous one — an assertion that would have
+# passed no matter what the agent did.
+#
+# What this CAN check, without a container:
+#   * the config parses, and every referenced /agent/assets path was staged
+#   * every `query:` is valid SQLite against the real assertion schema
+#   * every `exec:` FAILS against the bare workspace seed  (no vacuous passes)
+#   * every `exec:` PASSES against the completed reference fixture (not just broken)
+#
+# What it CANNOT check: the agent's behaviour, the extension host, tool call
+# names as VS Code reports them, or whether the hand-off is observed. Those need
+# a real run.
+#
+# Usage: ./preflight.sh <suite>
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/../.." && pwd)"
+ASSETS="${HERE}/assets"
+FIXTURE="${REPO_ROOT}/evals/grader-certification/reference-node-fullstack"
+
+SUITE="${1:-}"
+[ -n "$SUITE" ] || { echo "usage: $0 <suite>" >&2; exit 2; }
+CONFIG="${HERE}/${SUITE}/user-overrides.yaml"
+[ -f "$CONFIG" ] || { echo "no suite '${SUITE}'" >&2; exit 2; }
+
+bold() { printf '\033[1m%s\033[0m\n' "$*"; }
+pass() { printf '  \033[1;32mPASS\033[0m %s\n' "$*"; }
+fail() { printf '  \033[1;31mFAIL\033[0m %s\n' "$*"; FAILED=$((FAILED+1)); }
+FAILED=0
+
+bold "Staging ${SUITE}"
+"${HERE}/stage.sh" "$SUITE" >/dev/null
+pass "assets staged"
+
+# Pull the assertions out of the YAML once; everything below reads this.
+PLAN="$(mktemp)"; trap 'rm -f "$PLAN"' EXIT
+node -e '
+const yaml = require(process.argv[1] + "/evals/node_modules/yaml");
+const fs = require("fs");
+const doc = yaml.parse(fs.readFileSync(process.argv[2], "utf8"));
+const out = [];
+(doc.promptSteps || []).forEach((step, i) => {
+    (step.assertions || []).forEach((a) => {
+        if (a.exec)  out.push(JSON.stringify({ kind: "exec",  step: i, comment: a.comment, value: a.exec }));
+        if (a.query) out.push(JSON.stringify({ kind: "query", step: i, comment: a.comment, value: a.query }));
+    });
+});
+fs.writeFileSync(process.argv[3], out.join("\n") + "\n");
+' "$REPO_ROOT" "$CONFIG" "$PLAN"
+
+read_field() { node -e 'process.stdout.write(String(JSON.parse(process.argv[1])[process.argv[2]] ?? ""))' "$1" "$2"; }
+
+bold "Referenced container paths exist in assets/"
+while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    value="$(read_field "$row" value)"
+    for path in $(printf '%s' "$value" | grep -oE '/agent/assets/[^ ]+' || true); do
+        local_path="${ASSETS}/${path#/agent/assets/}"
+        if [ -e "$local_path" ]; then pass "${path}"; else fail "${path} — not staged (would be a missing file in-container)"; fi
+    done
+done < "$PLAN"
+
+# Also check paths referenced from the `script:` block, which runs before the agent.
+for path in $(grep -oE '/agent/assets/[a-zA-Z0-9_./-]+' "$CONFIG" | sort -u); do
+    case "$path" in
+        */extensions/*) continue ;;   # the VSIX is built by run.sh, not stage.sh
+    esac
+    local_path="${ASSETS}/${path#/agent/assets/}"
+    [ -e "$local_path" ] || fail "${path} — referenced but not staged"
+done
+
+bold "SQL assertions are valid SQLite"
+# The real schema, per the assertion tables MSBench exposes.
+SCHEMA="CREATE TABLE files(path TEXT, content TEXT, stepIndex INT);
+CREATE TABLE toolCalls(tool TEXT, stepIndex INT);
+CREATE TABLE llm_responses(response TEXT, stepIndex INT);"
+while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    [ "$(read_field "$row" kind)" = "query" ] || continue
+    q="$(read_field "$row" value)"
+    c="$(read_field "$row" comment)"
+    if err=$(printf '%s\nSELECT 1 FROM (%s) LIMIT 0;\n' "$SCHEMA" "$q" | sqlite3 :memory: 2>&1 >/dev/null); then
+        pass "${c}"
+    else
+        fail "${c} — ${err}"
+    fi
+done < "$PLAN"
+
+# The check that matters most. An assertion which passes against a workspace the
+# agent has not touched is worse than no assertion, because it reports green.
+# The check that matters most. An assertion which passes against a workspace the
+# agent has not touched is worse than no assertion, because it reports green.
+#
+# The baseline is the workspace as the agent first sees it: the seed for a suite
+# that has one, otherwise an empty directory — which is exactly what a suite like
+# project-plan starts from.
+PROBE="$(mktemp -d)"
+if [ -d "${ASSETS}/workspace-seed" ]; then
+    cp -R "${ASSETS}/workspace-seed/." "$PROBE/"
+    bold "exec assertions FAIL against the bare seed (no vacuous passes)"
+else
+    bold "exec assertions FAIL against an empty workspace (no vacuous passes)"
+fi
+while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    [ "$(read_field "$row" kind)" = "exec" ] || continue
+    cmd="$(read_field "$row" value)"; c="$(read_field "$row" comment)"
+    # Rewrite container paths to their local equivalents.
+    local_cmd="${cmd//\/agent\/assets/${ASSETS}}"
+    local_cmd="${local_cmd//EVALUATE_WORKSPACE=\/workspace/EVALUATE_WORKSPACE=$PROBE}"
+    set +e; out="$(eval "$local_cmd" 2>&1)"; st=$?; set -e
+    if [ "$st" -eq 1 ]; then pass "${c}"
+    elif [ "$st" -eq 0 ]; then fail "${c} — PASSED on an untouched workspace; this assertion proves nothing"
+    else fail "${c} — exit ${st} (grader fault, not a product failure): $(printf '%s' "$out" | head -2 | tr '\n' ' ')"; fi
+done < "$PLAN"
+rm -rf "$PROBE"
+
+bold "exec assertions PASS against a workspace in the expected state for their step"
+# The reference workspace is step-dependent. A gate assertion is *phase-scoped*
+# — it asserts the plan is still at "Planning" and generation has not started —
+# so validating it against the completed fixture would wrongly report it broken.
+# Step 0 therefore gets a synthesized planning-state workspace; later steps get
+# the completed fixture.
+PLANNING="$(mktemp -d)"; cp -R "${FIXTURE}/." "$PLANNING/"
+rm -rf "${PLANNING}/.vscode" "${PLANNING}/api-test-collections"
+sed -i '' 's/^> \*\*Status:\*\* .*/> **Status:** Planning/' "${PLANNING}/.azure/vscode-debug-plan.md"
+grep -q '^> \*\*Status:\*\* Planning' "${PLANNING}/.azure/vscode-debug-plan.md" \
+    || { echo "could not synthesize a planning-state fixture" >&2; exit 3; }
+
+while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    [ "$(read_field "$row" kind)" = "exec" ] || continue
+    cmd="$(read_field "$row" value)"; c="$(read_field "$row" comment)"
+    if [ "$(read_field "$row" step)" = "0" ]; then ref="$PLANNING"; label="planning-state"; else ref="$FIXTURE"; label="completed"; fi
+    local_cmd="${cmd//\/agent\/assets/${ASSETS}}"
+    local_cmd="${local_cmd//EVALUATE_WORKSPACE=\/workspace/EVALUATE_WORKSPACE=$ref}"
+    set +e; out="$(eval "$local_cmd" 2>&1)"; st=$?; set -e
+    if [ "$st" -eq 0 ]; then pass "${c} [${label}]"
+    else fail "${c} — exit ${st} against a KNOWN-GOOD ${label} workspace, so it would fail a correct agent: $(printf '%s' "$out" | grep -E 'FAIL|•' | head -3 | tr '\n' ' ')"; fi
+done < "$PLAN"
+rm -rf "$PLANNING"
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+    bold "Preflight clean — safe to submit ${SUITE} to MSBench."
+else
+    printf '\033[1;31m%s preflight check(s) failed.\033[0m Fix before spending an MSBench run.\n' "$FAILED"
+    exit 1
+fi

--- a/evals/msbench/project-plan/user-overrides.yaml
+++ b/evals/msbench/project-plan/user-overrides.yaml
@@ -48,6 +48,11 @@ script: |
   cp -r /tmp/corext/extension/resources/agents/. /workspace/.github/agents/
   ls -la /workspace/.github/agents/
 
+  # The `exec:` graders are Node scripts relying on type stripping (Node 22+).
+  # Fail here rather than letting every exec assertion fail as a "product" bug.
+  node --version
+  node -e 'const [maj]=process.versions.node.split(".").map(Number); if (maj < 22) { console.error("Graders need Node 22+ for type stripping; found "+process.versions.node); process.exit(1); }'
+
 promptSteps:
   - text: |
       I'd like to create an app where you can upload photos and they get stored
@@ -59,15 +64,17 @@ promptSteps:
       - comment: Agent should have written the requirements artifact
         query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'
 
-      # Partial stand-in for the `requirements-schema-valid` program grader, which
-      # needs a repo checkout in the container. Catches a malformed artifact; the
-      # full contract check lands next as an `exec:` assertion.
-      - comment: requirements.json should be valid JSON carrying a questions array
-        query: >-
-          SELECT COUNT(*) > 0 FROM files
-          WHERE path LIKE '%.azure/requirements.json'
-            AND json_valid(content)
-            AND json_array_length(json_extract(content, '$.questions')) > 0
+      # vally: program requirements-schema-valid
+      # The real grader, not a SQL approximation. The README previously noted this
+      # "needs a repo checkout in the container"; stage-graders.sh removes that
+      # constraint by staging a self-contained bundle under /agent/assets/graders,
+      # so the exact contract the Vally suite enforces runs here unchanged and
+      # there is no second copy of it to keep in sync.
+      - comment: requirements.json satisfies the full requirements contract (real grader)
+        exec: >-
+          EVALUATE_WORKSPACE=/workspace node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON
+          /agent/assets/graders/evals/graders/validate-requirements.ts
+        timeoutMs: 60000
 
       # vally: file-not-exists (no-dotfile-requirements)
       - comment: Agent should not have written the dotfile variant

--- a/evals/msbench/stage-graders.sh
+++ b/evals/msbench/stage-graders.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Stage a self-contained grader bundle for MSBench `exec:` assertions.
+#
+# The Vally graders import two things that do not exist inside the MSBench
+# container: the product's plan parser (reached by relative path out of evals/)
+# and `jsonc-parser`. Rather than clone the repo in-container — which would let
+# the graders drift from the build under test — we copy the exact files, keeping
+# the same relative layout so every import resolves unchanged:
+#
+#   <assets>/graders/
+#     evals/graders/*.ts                                the grader entry points
+#     evals/src/artifacts/*.ts                          the validators
+#     src/webviews/.../views/utils/                     the product parsers
+#     node_modules/jsonc-parser/                        vendored, zero-dependency
+#
+# `jsonc-parser` is vendored rather than dropped because the extension itself
+# ships it (root package.json) and uses it in TagFileSystem.ts — a file the
+# grader accepts should be a file the product can read. Node resolves the bare
+# specifier by walking up from evals/graders/ to <bundle>/node_modules.
+#
+# Usage: ./stage-graders.sh <assets-dir>
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/../.." && pwd)"
+
+ASSETS="${1:-}"
+[ -n "$ASSETS" ] || { echo "usage: $0 <assets-dir>" >&2; exit 2; }
+
+BUNDLE="${ASSETS}/graders"
+# The whole parser directory, not just the files today's graders import — the
+# parsers cross-reference each other, and enumerating them invites a bundle that
+# breaks the next time a grader picks up a new one.
+PARSER_DIR="src/webviews/copilotOnRails/views/utils"
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+rm -rf "$BUNDLE"
+mkdir -p "$BUNDLE/evals/graders" "$BUNDLE/evals/src/artifacts" \
+         "$BUNDLE/${PARSER_DIR}" "$BUNDLE/node_modules"
+
+cp "${REPO_ROOT}"/evals/graders/*.ts            "$BUNDLE/evals/graders/"
+cp "${REPO_ROOT}"/evals/src/artifacts/*.ts      "$BUNDLE/evals/src/artifacts/"
+cp -R "${REPO_ROOT}/${PARSER_DIR}/." "$BUNDLE/${PARSER_DIR}/"
+
+[ -d "${REPO_ROOT}/node_modules/jsonc-parser" ] \
+    || die "node_modules/jsonc-parser missing — run 'npm install' in the repo root first."
+cp -R "${REPO_ROOT}/node_modules/jsonc-parser"  "$BUNDLE/node_modules/"
+
+[ -f "$BUNDLE/node_modules/jsonc-parser/package.json" ] || die "jsonc-parser did not copy"
+
+# The graders are ESM. Locally that is supplied by evals/package.json, which Node
+# finds by walking up from the grader — but the bundle is extracted to
+# /agent/assets in the container, where there is no ancestor package.json at all,
+# so Node falls back to CommonJS and every grader dies on its first `import` with
+# "Cannot use import statement outside a module".
+#
+# That failure exits 1, which is indistinguishable from a real product failure —
+# so without this marker the suite reports the product as broken when the bundle
+# is at fault. This is exactly what happened on run 2026082568864133.
+cat > "$BUNDLE/package.json" <<'JSON'
+{
+  "name": "msbench-grader-bundle",
+  "private": true,
+  "type": "module"
+}
+JSON
+
+# Verify the marker statically, because no local run can verify it behaviourally:
+# Node 24 (a typical dev machine) treats a bare .ts file as ESM, while the
+# container's Node 22.22 treats it as CommonJS. The bug this guards against is
+# therefore INVISIBLE locally and only ever appears in-container — which is why
+# it survived a passing smoke test and reached run 2026082568864133.
+node -e '
+const p = require(process.argv[1] + "/package.json");
+if (p.type !== "module") process.exit(1);
+' "$BUNDLE" || die "bundle package.json must set \"type\": \"module\""
+
+# Smoke-test EVERY grader, not just one. Each is run against an empty directory,
+# where the correct behaviour is to report missing artifacts and exit 1. An
+# unresolved import also exits non-zero, so exit code alone proves nothing —
+# what distinguishes them is that a grader which actually ran prints its own
+# "FAIL:" line, and one that could not load prints a module-resolution error.
+#
+# Checking only a single grader previously let a missing product parser reach the
+# bundle, so the loop is the point.
+#
+# CRITICAL: the bundle is copied OUT of the repo before being tested. Run in
+# place, it inherits evals/package.json and node_modules/ from its ancestors and
+# passes even when it is not self-contained — which is precisely how the missing
+# "type": "module" above reached a live run. A temp dir has no such ancestors, so
+# this reproduces the container.
+PROBE="$(mktemp -d)"
+ISOLATED="$(mktemp -d)"
+trap 'rm -rf "$PROBE" "$ISOLATED"' EXIT
+cp -R "$BUNDLE/." "$ISOLATED/"
+
+BROKEN=""
+for grader in "$ISOLATED"/evals/graders/validate-*.ts; do
+    name="$(basename "$grader")"
+    set +e
+    output="$(EVALUATE_WORKSPACE="$PROBE" node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON "$grader" 2>&1)"
+    status=$?
+    set -e
+
+    case "$output" in
+        *ERR_MODULE_NOT_FOUND*|*"Cannot find module"*|*ERR_UNKNOWN_FILE_EXTENSION*)
+            BROKEN="${BROKEN}\n  ${name}: unresolved import — $(printf '%s' "$output" | grep -oE "Cannot find module '[^']*'" | head -1)"
+            continue ;;
+        *"Cannot use import statement outside a module"*|*"Failed to load the ES module"*)
+            BROKEN="${BROKEN}\n  ${name}: loaded as CommonJS — the bundle's package.json \"type\": \"module\" is missing or not being found"
+            continue ;;
+    esac
+    if [ "$status" -eq 0 ]; then
+        BROKEN="${BROKEN}\n  ${name}: passed against an EMPTY workspace — it cannot be failing for the right reasons"
+    elif [ "$status" -ne 1 ]; then
+        BROKEN="${BROKEN}\n  ${name}: exited ${status} (expected 1); grader fault, not a product failure"
+    elif ! printf '%s' "$output" | grep -q "FAIL:"; then
+        BROKEN="${BROKEN}\n  ${name}: exited 1 without printing a FAIL line — body may not have run"
+    fi
+done
+
+[ -z "$BROKEN" ] || die "grader bundle is not self-contained:$(printf '%b' "$BROKEN")"
+
+COUNT="$(find "$BUNDLE/evals/graders" -name 'validate-*.ts' | wc -l | tr -d ' ')"
+
+log "Staged ${COUNT} graders at ${BUNDLE} ($(du -sh "$BUNDLE" | cut -f1)) — all self-contained"

--- a/evals/msbench/stage-workspace.sh
+++ b/evals/msbench/stage-workspace.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Stage the local-dev workspace seed for MSBench.
+#
+# The debug agents analyse an existing project, so the workspace must already
+# contain one. We reuse `evals/grader-certification/reference-node-fullstack`
+# — a real scaffolded Node full-stack project that is already maintained as the
+# grader certification fixture, so it cannot rot independently of the graders.
+#
+# Its `.azure/vscode-debug-plan.md` and `.vscode/` are deliberately EXCLUDED:
+# those are the artifacts under test, and seeding them would let every assertion
+# pass without the agent doing anything.
+#
+# Usage: ./stage-workspace.sh <assets-dir>
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/../.." && pwd)"
+FIXTURE="${REPO_ROOT}/evals/grader-certification/reference-node-fullstack"
+
+ASSETS="${1:-}"
+[ -n "$ASSETS" ] || { echo "usage: $0 <assets-dir>" >&2; exit 2; }
+SEED="${ASSETS}/workspace-seed"
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+[ -d "$FIXTURE" ] || die "fixture not found at ${FIXTURE}"
+
+rm -rf "$SEED"
+mkdir -p "$SEED"
+cp -R "${FIXTURE}/." "$SEED/"
+
+# Remove the artifacts under test. A seeded plan or launch.json would make the
+# assertions pass vacuously — the single most dangerous failure mode here.
+rm -rf "${SEED}/.vscode" "${SEED}/.azure/vscode-debug-plan.md" \
+       "${SEED}/api-test-collections" "${SEED}/docker-compose.yml"
+
+for forbidden in .vscode/launch.json .vscode/tasks.json .azure/vscode-debug-plan.md; do
+    if [ -e "${SEED}/${forbidden}" ]; then
+        die "seed still contains ${forbidden}; assertions would pass vacuously"
+    fi
+done
+
+# The project plan must survive: azure-debug-plan reads it to classify services.
+[ -f "${SEED}/.azure/project-plan.md" ] || die "seed lost .azure/project-plan.md"
+
+log "Staged workspace seed at ${SEED} ($(du -sh "$SEED" | cut -f1))"

--- a/evals/msbench/stage.sh
+++ b/evals/msbench/stage.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Assemble evals/msbench/assets/ for one suite.
+#
+# run.sh hardcodes ASSETS="${HERE}/assets" and stages assets/user-overrides.yaml
+# as the last config layer. Rather than teach it about suites — which would
+# conflict with PR #1689 — each suite keeps its config in its own directory and
+# this script copies the selected one into place. `run.sh --skip-build` then
+# works unchanged.
+#
+# Usage: ./stage.sh <suite>        # e.g. ./stage.sh local-dev
+#        ./stage.sh --list
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ASSETS="${HERE}/assets"
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# `assets/` is excluded: it holds the *staged* copy of a suite's config, so
+# listing it would offer the last-staged suite back under a bogus name.
+suites() { find "$HERE" -mindepth 2 -maxdepth 2 -name user-overrides.yaml \
+             -not -path "${HERE}/assets/*" \
+             -exec dirname {} \; | xargs -n1 basename | sort; }
+
+SUITE="${1:-}"
+if [ "$SUITE" = "--list" ]; then suites; exit 0; fi
+[ -n "$SUITE" ] || die "usage: $0 <suite>   (available: $(suites | tr '\n' ' '))"
+
+CONFIG="${HERE}/${SUITE}/user-overrides.yaml"
+[ -f "$CONFIG" ] || die "no suite '${SUITE}' (available: $(suites | tr '\n' ' '))"
+
+mkdir -p "$ASSETS"
+cp "$CONFIG" "${ASSETS}/user-overrides.yaml"
+log "Staged ${SUITE}/user-overrides.yaml"
+
+# Only stage what the suite actually references. Checking the config keeps a
+# suite that needs neither from paying for a bundle it will not use.
+if grep -q '/agent/assets/graders' "$CONFIG"; then
+    "${HERE}/stage-graders.sh" "$ASSETS"
+fi
+if grep -q '/agent/assets/workspace-seed' "$CONFIG"; then
+    "${HERE}/stage-workspace.sh" "$ASSETS"
+else
+    # Clear a seed left by a previously staged suite. Leaving it would ship an
+    # unreferenced 80K into the container, and — worse — let preflight validate
+    # this suite against the *other* suite's baseline.
+    rm -rf "${ASSETS}/workspace-seed"
+fi
+
+log "Assets ready at ${ASSETS} — now run: ./run.sh --skip-build"

--- a/evals/package-lock.json
+++ b/evals/package-lock.json
@@ -10,7 +10,8 @@
             "license": "MIT",
             "dependencies": {
                 "@github/copilot-sdk": "^1.0.9-preview.2",
-                "@microsoft/vally": "0.13.0"
+                "@microsoft/vally": "0.13.0",
+                "jsonc-parser": "^2.3.1"
             },
             "devDependencies": {
                 "@microsoft/vally-cli": "0.13.0",
@@ -1200,6 +1201,12 @@
             "dependencies": {
                 "base64-js": "^1.5.1"
             }
+        },
+        "node_modules/jsonc-parser": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+            "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+            "license": "MIT"
         },
         "node_modules/jsonfile": {
             "version": "6.2.1",

--- a/evals/package.json
+++ b/evals/package.json
@@ -7,8 +7,11 @@
     "scripts": {
         "eval": "node run-eval.cjs",
         "eval:plan": "node run-eval.cjs --suite project-plan",
+        "eval:local-dev": "node run-eval.cjs --suite local-dev",
         "drift": "node check-agent-drift.mjs",
-        "lint": "vally lint --eval-spec project-plan/eval.yaml",
+        "lint": "npm run lint:plan && npm run lint:local-dev",
+        "lint:plan": "vally lint --eval-spec project-plan/eval.yaml",
+        "lint:local-dev": "vally lint --eval-spec local-dev/eval.yaml",
         "typecheck": "tsc --noEmit -p tsconfig.json",
         "certify": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON src/graderCertification.ts",
         "gate-tools": "node check-gate-tools.mjs",
@@ -17,7 +20,8 @@
     "license": "MIT",
     "dependencies": {
         "@github/copilot-sdk": "^1.0.9-preview.2",
-        "@microsoft/vally": "0.13.0"
+        "@microsoft/vally": "0.13.0",
+        "jsonc-parser": "^2.3.1"
     },
     "devDependencies": {
         "@microsoft/vally-cli": "0.13.0",

--- a/evals/results/grader-certification/offline/report.json
+++ b/evals/results/grader-certification/offline/report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-19T18:41:01.315Z",
+  "generatedAt": "2026-08-25T21:15:53.734Z",
   "mode": "offline",
   "fixture": "reference-node-fullstack",
   "outcome": "passed",
@@ -36,6 +36,33 @@
       "id": "golden-preview",
       "tier": "offline",
       "validator": "preview",
+      "expected": "passed",
+      "actual": [],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "golden-debug-plan",
+      "tier": "offline",
+      "validator": "debug-plan",
+      "expected": "passed",
+      "actual": [],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "golden-debug-config",
+      "tier": "offline",
+      "validator": "debug-config",
+      "expected": "passed",
+      "actual": [],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "golden-debug-artifacts",
+      "tier": "offline",
+      "validator": "debug-artifacts",
       "expected": "passed",
       "actual": [],
       "passed": true,
@@ -93,6 +120,163 @@
       "expected": "previewNotReady",
       "actual": [
         "previewNotReady"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-plan-table-concatenated",
+      "tier": "offline",
+      "validator": "debug-plan",
+      "expected": "tableRowConcatenated",
+      "actual": [
+        "tableRowConcatenated",
+        "invalidGenerateMarker"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-plan-checklist-stub",
+      "tier": "offline",
+      "validator": "debug-plan",
+      "expected": "checklistStub",
+      "actual": [
+        "checklistStub"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-plan-diagram-dropped",
+      "tier": "offline",
+      "validator": "debug-plan",
+      "expected": "missingSection",
+      "actual": [
+        "missingSection"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-plan-status-regressed",
+      "tier": "offline",
+      "validator": "debug-plan",
+      "expected": "unexpectedStatus",
+      "actual": [
+        "unexpectedStatus"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-config-prelaunch-dangling",
+      "tier": "offline",
+      "validator": "debug-config",
+      "expected": "preLaunchTaskUnresolved",
+      "actual": [
+        "preLaunchTaskUnresolved"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-config-dependson-dangling",
+      "tier": "offline",
+      "validator": "debug-config",
+      "expected": "dependsOnUnresolved",
+      "actual": [
+        "dependsOnUnresolved"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-config-dependson-cycle",
+      "tier": "offline",
+      "validator": "debug-config",
+      "expected": "dependsOnCycle",
+      "actual": [
+        "dependsOnCycle"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-artifacts-unchecked-config-generated",
+      "tier": "offline",
+      "validator": "debug-artifacts",
+      "expected": "uncheckedConfigGenerated",
+      "actual": [
+        "uncheckedConfigGenerated"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-artifacts-script-not-registered",
+      "tier": "offline",
+      "validator": "debug-artifacts",
+      "expected": "scriptNotRegistered",
+      "actual": [
+        "scriptNotRegistered"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-artifacts-api-collection-empty",
+      "tier": "offline",
+      "validator": "debug-artifacts",
+      "expected": "apiCollectionEmpty",
+      "actual": [
+        "apiCollectionEmpty"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-config-task-run-options",
+      "tier": "offline",
+      "validator": "debug-config",
+      "expected": "invalidTaskRunOptions",
+      "actual": [
+        "invalidTaskRunOptions"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-config-duplicate-task-label",
+      "tier": "offline",
+      "validator": "debug-config",
+      "expected": "duplicateTaskLabels",
+      "actual": [
+        "duplicateTaskLabels",
+        "dependsOnUnresolved",
+        "dependsOnCycle"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-artifacts-extension-recommendations",
+      "tier": "offline",
+      "validator": "debug-artifacts",
+      "expected": "invalidExtensionRecommendations",
+      "actual": [
+        "invalidExtensionRecommendations"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-artifacts-redacted-secret",
+      "tier": "offline",
+      "validator": "debug-artifacts",
+      "expected": "redactedSecretPlaceholder",
+      "actual": [
+        "redactedSecretPlaceholder"
       ],
       "passed": true,
       "durationMs": 0

--- a/evals/results/grader-certification/offline/report.md
+++ b/evals/results/grader-certification/offline/report.md
@@ -3,7 +3,7 @@
 - Mode: `offline`
 - Fixture: `reference-node-fullstack`
 - Outcome: **PASSED**
-- Cases: 9/9 passed
+- Cases: 26/26 passed
 
 | Case | Validator | Expected | Actual | Result |
 |---|---|---|---|---|
@@ -11,9 +11,26 @@
 | `golden-project-plan` | `project-plan` | `passed` | `passed` | PASS |
 | `golden-plan-gate` | `plan-gate` | `passed` | `passed` | PASS |
 | `golden-preview` | `preview` | `passed` | `passed` | PASS |
+| `golden-debug-plan` | `debug-plan` | `passed` | `passed` | PASS |
+| `golden-debug-config` | `debug-config` | `passed` | `passed` | PASS |
+| `golden-debug-artifacts` | `debug-artifacts` | `passed` | `passed` | PASS |
 | `requirements-schema-version` | `requirements` | `schemaVersion` | `schemaVersion` | PASS |
 | `project-plan-numbering` | `project-plan` | `nonSequentialHeading` | `nonSequentialHeading, nonSequentialHeading` | PASS |
 | `plan-gate-frontend-dropped` | `plan-gate` | `frontendIntentMismatch` | `frontendIntentMismatch` | PASS |
 | `plan-gate-preview-manifest-missing` | `plan-gate` | `previewManifestMissingAtGate` | `previewManifestMissingAtGate` | PASS |
 | `preview-not-ready` | `preview` | `previewNotReady` | `previewNotReady` | PASS |
+| `debug-plan-table-concatenated` | `debug-plan` | `tableRowConcatenated` | `tableRowConcatenated, invalidGenerateMarker` | PASS |
+| `debug-plan-checklist-stub` | `debug-plan` | `checklistStub` | `checklistStub` | PASS |
+| `debug-plan-diagram-dropped` | `debug-plan` | `missingSection` | `missingSection` | PASS |
+| `debug-plan-status-regressed` | `debug-plan` | `unexpectedStatus` | `unexpectedStatus` | PASS |
+| `debug-config-prelaunch-dangling` | `debug-config` | `preLaunchTaskUnresolved` | `preLaunchTaskUnresolved` | PASS |
+| `debug-config-dependson-dangling` | `debug-config` | `dependsOnUnresolved` | `dependsOnUnresolved` | PASS |
+| `debug-config-dependson-cycle` | `debug-config` | `dependsOnCycle` | `dependsOnCycle` | PASS |
+| `debug-artifacts-unchecked-config-generated` | `debug-artifacts` | `uncheckedConfigGenerated` | `uncheckedConfigGenerated` | PASS |
+| `debug-artifacts-script-not-registered` | `debug-artifacts` | `scriptNotRegistered` | `scriptNotRegistered` | PASS |
+| `debug-artifacts-api-collection-empty` | `debug-artifacts` | `apiCollectionEmpty` | `apiCollectionEmpty` | PASS |
+| `debug-config-task-run-options` | `debug-config` | `invalidTaskRunOptions` | `invalidTaskRunOptions` | PASS |
+| `debug-config-duplicate-task-label` | `debug-config` | `duplicateTaskLabels` | `duplicateTaskLabels, dependsOnUnresolved, dependsOnCycle` | PASS |
+| `debug-artifacts-extension-recommendations` | `debug-artifacts` | `invalidExtensionRecommendations` | `invalidExtensionRecommendations` | PASS |
+| `debug-artifacts-redacted-secret` | `debug-artifacts` | `redactedSecretPlaceholder` | `redactedSecretPlaceholder` | PASS |
 

--- a/evals/run-debug-graders.sh
+++ b/evals/run-debug-graders.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#---------------------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+#---------------------------------------------------------------------------------------------
+#
+# Run the local development graders against a workspace on disk.
+#
+# Usage:
+#   ./run-debug-graders.sh "/path/to/project" [extra --assert-* flags]
+#
+# Which graders apply depends on where the project is in the workflow, so this picks
+# them by inspecting the workspace: a plan with no .vscode/launch.json is still at the
+# approval gate, and anything past that is graded for generated artifacts instead.
+#
+# Exit codes mirror the grader contract: 0 all passed, 1 a grader reported a product
+# failure, 3 a grader itself could not run.
+
+set -uo pipefail
+
+WORKSPACE="${1:-}"
+if [[ -z "${WORKSPACE}" ]]; then
+    echo "usage: $0 <workspace-path> [extra grader flags]" >&2
+    exit 2
+fi
+shift || true
+
+if [[ ! -d "${WORKSPACE}" ]]; then
+    echo "error: '${WORKSPACE}' is not a directory." >&2
+    exit 2
+fi
+
+# Resolve to an absolute path so the graders are not affected by this script's cwd.
+WORKSPACE="$(cd "${WORKSPACE}" && pwd)"
+GRADERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/graders"
+PLAN="${WORKSPACE}/.azure/vscode-debug-plan.md"
+
+echo "workspace: ${WORKSPACE}"
+
+if [[ ! -f "${PLAN}" ]]; then
+    echo "error: no .azure/vscode-debug-plan.md found — nothing for the local dev graders to check." >&2
+    echo "       Run the azure-debug-plan agent against this project first." >&2
+    exit 2
+fi
+
+if [[ -f "${WORKSPACE}/.vscode/launch.json" ]]; then
+    echo "phase:     generated (.vscode/launch.json present)"
+    GRADERS=(validate-debug-plan validate-debug-config validate-debug-artifacts)
+else
+    echo "phase:     approval gate (no .vscode/launch.json yet)"
+    GRADERS=(validate-debug-gate validate-debug-plan)
+fi
+echo
+
+worst=0
+for grader in "${GRADERS[@]}"; do
+    EVALUATE_WORKSPACE="${WORKSPACE}" \
+        node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON "${GRADERS_DIR}/${grader}.ts" "$@"
+    status=$?
+    # Exit 3 means the grader is broken, which outranks a product failure.
+    if [[ ${status} -eq 3 || ${worst} -eq 0 && ${status} -ne 0 ]]; then
+        worst=${status}
+    fi
+    echo
+done
+
+exit ${worst}

--- a/evals/src/artifacts/debugArtifacts.ts
+++ b/evals/src/artifacts/debugArtifacts.ts
@@ -1,0 +1,354 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Conformance between `.azure/vscode-debug-plan.md` and the artifacts the generation
+ * phase produced from it.
+ *
+ * The generation contract is "the plan specifies WHAT to generate" and "only generate
+ * artifacts for rows where Generate is checked (`[x]`)". So every checked row must
+ * yield exactly one artifact, and every unchecked row must yield none — a plan that
+ * silently disagrees with the workspace is the failure this catches.
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import type { ParsedDebugPlan } from './localDebugPlan.ts';
+import { parseDebugPlan } from './localDebugPlan.ts';
+import { validateDebugEnvironment } from './debugEnvironment.ts';
+import { parseJsonc, readLaunchDocument, readTasksDocument, validateDebugLaunchConfiguration } from './launchConfig.ts';
+import type { ArtifactValidationIssue, ArtifactValidationResult } from './validationTypes.ts';
+import { createValidationResult } from './validationTypes.ts';
+
+const PLAN_PATH = path.join('.azure', 'vscode-debug-plan.md');
+const LAUNCH_PATH = path.join('.vscode', 'launch.json');
+const TASKS_PATH = path.join('.vscode', 'tasks.json');
+const EXTENSIONS_PATH = path.join('.vscode', 'extensions.json');
+const API_COLLECTIONS_DIR = 'api-test-collections';
+
+/** Compose file names the orchestrator may emit, in the order the plan prefers them. */
+const COMPOSE_FILES = ['docker-compose.yml', 'docker-compose.yaml', 'compose.yml', 'compose.yaml'];
+
+export async function validateDebugArtifacts(workspace: string): Promise<ArtifactValidationResult> {
+    const issues: ArtifactValidationIssue[] = [];
+
+    const planText = await readIfExists(path.join(workspace, PLAN_PATH));
+    if (planText === undefined) {
+        return createValidationResult([issue('planMissing', '$', `${path.join(workspace, PLAN_PATH)} does not exist, so no artifact can be checked against it.`)]);
+    }
+    const plan = parseDebugPlan(planText);
+
+    const launchText = await readIfExists(path.join(workspace, LAUNCH_PATH));
+    const tasksText = await readIfExists(path.join(workspace, TASKS_PATH));
+    if (launchText === undefined) {
+        issues.push(issue('launchJsonMissing', '$.launch', `${LAUNCH_PATH} was never generated.`));
+    }
+
+    if (launchText !== undefined) {
+        // Structural problems make the conformance comparison meaningless, so report
+        // them and skip the name matching rather than emitting cascading noise.
+        const structural = validateDebugLaunchConfiguration(launchText, tasksText);
+        const fatal = structural.issues.filter(entry => entry.code.endsWith('Unparseable'));
+        if (fatal.length > 0) {
+            return createValidationResult([...issues, ...fatal]);
+        }
+        validateConfigConformance(plan, launchText, issues);
+    }
+
+    await validateEmulatorArtifacts(workspace, plan, issues);
+    await validateExtensionRecommendations(workspace, issues);
+    await validateConvenienceScripts(workspace, plan, issues);
+    await validateApiTestCollections(workspace, plan, issues);
+
+    await validateDebugEnvironment(workspace, {
+        hasEmulators: plan.emulators.length > 0,
+        taskLabels: readTaskLabels(tasksText),
+        planText,
+    }, issues);
+
+    return createValidationResult(issues);
+}
+
+function readTaskLabels(tasksText: string | undefined): Set<string> {
+    if (tasksText === undefined) {
+        return new Set();
+    }
+    try {
+        return new Set(readTasksDocument(tasksText)
+            .tasks
+            .flatMap(task => (typeof task.label === 'string' ? [task.label] : [])));
+    } catch {
+        // A malformed tasks.json is already reported by the structural validator.
+        return new Set();
+    }
+}
+
+/**
+ * Without a recommendation for the debugger the scenario needs, the user is asked to
+ * install nothing and F5 fails with an unresolved debug type.
+ */
+async function validateExtensionRecommendations(workspace: string, issues: ArtifactValidationIssue[]): Promise<void> {
+    const raw = await readIfExists(path.join(workspace, EXTENSIONS_PATH));
+    if (raw === undefined) {
+        issues.push(issue('extensionRecommendationsMissing', '$.extensions', `${EXTENSIONS_PATH} was never generated.`));
+        return;
+    }
+    let recommendations: unknown;
+    try {
+        recommendations = (parseJsonc(raw) as { recommendations?: unknown } | null)?.recommendations;
+    } catch (error) {
+        issues.push(issue('extensionsJsonUnparseable', '$.extensions', describeError(error)));
+        return;
+    }
+    const entries = Array.isArray(recommendations) ? recommendations : [];
+    // A marketplace id is always `publisher.extension`; anything else will not resolve.
+    if (entries.length === 0 || entries.some(entry => typeof entry !== 'string' || !entry.includes('.'))) {
+        issues.push(issue('invalidExtensionRecommendations', '$.extensions', `${EXTENSIONS_PATH} must list at least one "publisher.extension" recommendation.`));
+    }
+}
+
+function validateConfigConformance(
+    plan: ParsedDebugPlan,
+    launchText: string,
+    issues: ArtifactValidationIssue[],
+): void {
+    const launch = readLaunchDocument(launchText);
+    const configNames = new Set(
+        launch.configurations
+            .map(config => (typeof config.name === 'string' ? config.name.trim().toLowerCase() : ''))
+            .filter(Boolean),
+    );
+    const compoundNames = new Set(
+        launch.compounds
+            .map(compound => (typeof compound.name === 'string' ? compound.name.trim().toLowerCase() : ''))
+            .filter(Boolean),
+    );
+
+    for (const row of plan.debugConfigs) {
+        if (!row.name) {
+            continue;
+        }
+        const key = row.name.toLowerCase();
+        const present = row.isCompound ? compoundNames.has(key) : configNames.has(key);
+
+        if (row.generate && !present) {
+            issues.push(issue(
+                row.isCompound ? 'compoundConfigMissing' : 'debugConfigMissing',
+                '$.launch',
+                `Plan row "${row.name}" is marked [x] but no matching ${row.isCompound ? 'compound' : 'launch configuration'} exists in launch.json.`,
+            ));
+        }
+        if (!row.generate && present) {
+            issues.push(issue(
+                'uncheckedConfigGenerated',
+                '$.launch',
+                `Plan row "${row.name}" is marked [ ] but launch.json generated it anyway.`,
+            ));
+        }
+    }
+
+    // A configuration nobody planned means the workspace drifted from the plan.
+    const plannedNames = new Set(plan.debugConfigs.map(row => row.name.toLowerCase()).filter(Boolean));
+    if (plannedNames.size > 0) {
+        for (const name of [...configNames, ...compoundNames]) {
+            if (!plannedNames.has(name)) {
+                issues.push(issue('unplannedConfigGenerated', '$.launch', `launch.json declares "${name}", which no plan row describes.`));
+            }
+        }
+    }
+}
+
+async function validateEmulatorArtifacts(
+    workspace: string,
+    plan: ParsedDebugPlan,
+    issues: ArtifactValidationIssue[],
+): Promise<void> {
+    const composeFile = await findFirstExisting(workspace, COMPOSE_FILES);
+    const emulatorCount = plan.emulators.length;
+
+    if (emulatorCount > 0 && !composeFile) {
+        issues.push(issue('composeMissing', '$.compose', `The plan lists ${emulatorCount} emulator(s) but no compose file was generated.`));
+        return;
+    }
+    if (emulatorCount === 0 && composeFile) {
+        issues.push(issue('unexpectedCompose', '$.compose', `The plan lists no emulators but ${composeFile} was generated.`));
+        return;
+    }
+    if (!composeFile) {
+        return;
+    }
+
+    // The agent picks its own compose service names, and plan labels are prose that
+    // often carry the image in a parenthetical — e.g.
+    // "SQL Server 2022 Container (`mcr.microsoft.com/mssql/server:2022-latest`)".
+    // Match on any recognisable token from the label rather than the whole string.
+    const compose = (await fs.readFile(path.join(workspace, composeFile), 'utf8')).toLowerCase();
+    for (const row of plan.emulators) {
+        const label = (row[1] ?? row[0] ?? '').trim();
+        const candidates = emulatorTokens(label);
+        if (candidates.length > 0 && !candidates.some(candidate => compose.includes(candidate))) {
+            issues.push(issue('emulatorNotInCompose', '$.compose', `Planned emulator "${label}" does not appear in ${composeFile} (looked for ${candidates.map(value => `"${value}"`).join(', ')}).`));
+        }
+    }
+}
+
+/**
+ * Tokens that would identify an emulator inside a compose file: the image reference
+ * the plan quotes, the image's own name, and the descriptive label stripped of its
+ * parenthetical and the word "container".
+ */
+function emulatorTokens(label: string): string[] {
+    const tokens = new Set<string>();
+    const add = (value: string): void => {
+        const cleaned = value.trim().toLowerCase();
+        // Very short fragments ("db", "sql") match almost any compose file, which
+        // would make the check unfalsifiable.
+        if (cleaned.length >= 4) {
+            tokens.add(cleaned);
+        }
+    };
+
+    for (const match of label.matchAll(/`([^`]+)`/g)) {
+        const image = match[1].trim();
+        add(image);
+        // `mcr.microsoft.com/mssql/server:2022-latest` also identifies as `mssql/server`.
+        const withoutTag = image.replace(/:[^/:]*$/, '');
+        add(withoutTag);
+        add(withoutTag.split('/').slice(-2).join('/'));
+        add(withoutTag.split('/').pop() ?? '');
+    }
+
+    const prose = label
+        .replace(/\([^)]*\)/g, '')
+        .replace(/`[^`]*`/g, '')
+        .replace(/\bcontainer\b/gi, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    add(prose);
+    // "PostgreSQL 16" and "Azurite" both reduce to a product name the compose file
+    // almost certainly mentions, in an image, a service key, or both.
+    add(prose.split(/\s+/)[0] ?? '');
+
+    return [...tokens];
+}
+
+async function validateConvenienceScripts(
+    workspace: string,
+    plan: ParsedDebugPlan,
+    issues: ArtifactValidationIssue[],
+): Promise<void> {
+    for (const row of plan.convenienceScripts) {
+        if (!row.generate || !row.script) {
+            continue;
+        }
+        const manifestPath = row.registeredIn || './package.json';
+        const absolute = path.join(workspace, manifestPath);
+        const raw = await readIfExists(absolute);
+        if (raw === undefined) {
+            issues.push(issue('scriptManifestMissing', '$.scripts', `Convenience script "${row.script}" is registered in ${manifestPath}, which does not exist.`));
+            continue;
+        }
+        let scripts: Record<string, unknown>;
+        try {
+            scripts = ((parseJsonc(raw) as { scripts?: Record<string, unknown> } | null)?.scripts) ?? {};
+        } catch (error) {
+            issues.push(issue('scriptManifestUnparseable', '$.scripts', `${manifestPath} could not be parsed: ${error instanceof Error ? error.message : String(error)}`));
+            continue;
+        }
+        if (!(row.script in scripts)) {
+            issues.push(issue('scriptNotRegistered', '$.scripts', `Convenience script "${row.script}" is marked [x] but is not registered in ${manifestPath}.`));
+        }
+    }
+}
+
+async function validateApiTestCollections(
+    workspace: string,
+    plan: ParsedDebugPlan,
+    issues: ArtifactValidationIssue[],
+): Promise<void> {
+    const checked = plan.apiTestCollections.filter(row => row.generate);
+    const root = path.join(workspace, API_COLLECTIONS_DIR);
+    const directories = await listDirectories(root);
+
+    if (checked.length === 0) {
+        if (directories.length > 0) {
+            issues.push(issue('unexpectedApiCollections', '$.apiTestCollections', `${API_COLLECTIONS_DIR}/ was generated but no plan row requests it.`));
+        }
+        return;
+    }
+    if (directories.length === 0) {
+        issues.push(issue('apiCollectionsMissing', '$.apiTestCollections', `${checked.length} service(s) request API test collections but ${API_COLLECTIONS_DIR}/ is empty or absent.`));
+        return;
+    }
+    // The plan names services by label while the directories use service ids, so
+    // compare counts rather than inventing a label-to-id mapping.
+    if (directories.length < checked.length) {
+        issues.push(issue('apiCollectionsIncomplete', '$.apiTestCollections', `${checked.length} service(s) request API test collections but only ${directories.length} directory/directories exist under ${API_COLLECTIONS_DIR}/.`));
+    }
+
+    for (const directory of directories) {
+        const invocations = await findInvokeScripts(path.join(root, directory));
+        if (invocations === 0) {
+            issues.push(issue('apiCollectionEmpty', '$.apiTestCollections', `${API_COLLECTIONS_DIR}/${directory} contains no invoke script.`));
+        }
+    }
+}
+
+async function findInvokeScripts(directory: string): Promise<number> {
+    let count = 0;
+    for (const child of await listDirectories(directory)) {
+        const entries = await listFiles(path.join(directory, child));
+        if (entries.some(name => /^invoke\.(sh|ps1)$/i.test(name))) {
+            count++;
+        }
+    }
+    return count;
+}
+
+async function readIfExists(target: string): Promise<string | undefined> {
+    try {
+        return await fs.readFile(target, 'utf8');
+    } catch {
+        return undefined;
+    }
+}
+
+async function findFirstExisting(workspace: string, candidates: string[]): Promise<string | undefined> {
+    for (const candidate of candidates) {
+        try {
+            await fs.access(path.join(workspace, candidate));
+            return candidate;
+        } catch {
+            continue;
+        }
+    }
+    return undefined;
+}
+
+async function listDirectories(target: string): Promise<string[]> {
+    try {
+        const entries = await fs.readdir(target, { withFileTypes: true });
+        return entries.filter(entry => entry.isDirectory()).map(entry => entry.name);
+    } catch {
+        return [];
+    }
+}
+
+async function listFiles(target: string): Promise<string[]> {
+    try {
+        const entries = await fs.readdir(target, { withFileTypes: true });
+        return entries.filter(entry => entry.isFile()).map(entry => entry.name);
+    } catch {
+        return [];
+    }
+}
+
+function issue(code: string, path: string, message: string): ArtifactValidationIssue {
+    return { code, path, message };
+}
+
+function describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/evals/src/artifacts/debugEnvironment.ts
+++ b/evals/src/artifacts/debugEnvironment.ts
@@ -1,0 +1,199 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Environment-level checks on the generated local development setup.
+ *
+ * Everything here catches a defect that a purely structural read of `launch.json`
+ * cannot see: a config file that looks well-formed but hands the service a masked
+ * credential, an empty interpolated variable, or an emulator that rejects the SDK
+ * the app actually uses. Each rule was learned from a real failed run, so they are
+ * kept together and applied to whatever generated files exist.
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import type { ArtifactValidationIssue } from './validationTypes.ts';
+
+/** Generated files that carry credentials and connection strings. */
+const CONFIG_FILE_PATTERN = /(^|[/\\])(docker-compose\.ya?ml|compose\.ya?ml|local\.settings\.json|\.env(\..+)?)$/i;
+
+/** A run of asterisks where a value belongs — the fingerprint of a redaction filter. */
+const REDACTION_MASK_PATTERN = /\*{3,}/;
+
+const COMPOSE_FILES = ['docker-compose.yml', 'docker-compose.yaml', 'compose.yml', 'compose.yaml'];
+
+const SKIP_DIRECTORIES = new Set(['node_modules', '.git', 'dist', 'out', '.venv', '__pycache__']);
+
+export interface DebugEnvironmentContext {
+    /** Whether the plan asked for emulators, which is what makes compose mandatory. */
+    hasEmulators: boolean;
+    /** Task labels declared in `tasks.json`. */
+    taskLabels: Set<string>;
+    /** Raw plan text, used to tell which emulator images were requested. */
+    planText: string;
+}
+
+export async function validateDebugEnvironment(
+    workspace: string,
+    context: DebugEnvironmentContext,
+    issues: ArtifactValidationIssue[],
+): Promise<void> {
+    await validateRedactedSecrets(workspace, issues);
+    await validateComposeInterpolation(workspace, issues);
+    await validateEmulatorSetup(workspace, context, issues);
+}
+
+/**
+ * A secret-redaction filter rewrites a concrete credential to `***` before the text
+ * reaches disk. The resulting file parses fine and then fails at runtime with an
+ * authentication error that looks like a misconfigured service.
+ */
+async function validateRedactedSecrets(workspace: string, issues: ArtifactValidationIssue[]): Promise<void> {
+    for (const filePath of await listFiles(workspace)) {
+        if (!CONFIG_FILE_PATTERN.test(filePath)) {
+            continue;
+        }
+        const content = await readIfExists(filePath);
+        if (content === undefined) {
+            continue;
+        }
+        const relative = path.relative(workspace, filePath) || path.basename(filePath);
+        content.split('\n').forEach((line, index) => {
+            const match = REDACTION_MASK_PATTERN.exec(line);
+            // Glob patterns such as `**/*` legitimately contain adjacent asterisks.
+            if (!match || line.includes('*/') || line.includes('/*')) {
+                return;
+            }
+            issues.push({
+                code: 'redactedSecretPlaceholder',
+                path: `$.generatedConfig["${relative}"].line[${index + 1}]`,
+                message: `${relative} line ${index + 1} contains a redaction mask ("${match[0]}") where a value is expected. `
+                    + 'Build connection strings from discrete variables instead of inlining user:password@host.',
+            });
+        });
+    }
+}
+
+/**
+ * `${VAR}` in a compose file interpolates from `.env` or the shell, never from a
+ * service's own `environment:` block. With nothing to resolve it, compose substitutes
+ * an empty string and the dependency starts with blank credentials instead of
+ * failing fast.
+ */
+async function validateComposeInterpolation(workspace: string, issues: ArtifactValidationIssue[]): Promise<void> {
+    const composeFile = await findFirstExisting(workspace, COMPOSE_FILES);
+    if (!composeFile) {
+        return;
+    }
+    const compose = await readIfExists(path.join(workspace, composeFile));
+    if (compose === undefined) {
+        return;
+    }
+
+    const referenced = new Set<string>();
+    for (const match of compose.matchAll(/\$\{([A-Za-z_][A-Za-z0-9_]*)(:?-[^}]*)?\}/g)) {
+        // A default (`${VAR:-fallback}`) makes the reference safe on its own.
+        if (!match[2]) {
+            referenced.add(match[1]);
+        }
+    }
+    if (referenced.size === 0) {
+        return;
+    }
+
+    const envText = await readIfExists(path.join(workspace, '.env'));
+    const declared = envText === undefined ? new Set<string>() : parseEnvKeys(envText);
+    const missing = [...referenced].filter(name => !declared.has(name)).sort();
+    if (missing.length > 0) {
+        issues.push({
+            code: 'missingComposeEnvValues',
+            path: '$.compose.interpolation',
+            message: `${composeFile} interpolates ${missing.map(name => `\${${name}}`).join(', ')} but `
+                + `${envText === undefined ? 'no .env file exists' : `.env does not declare ${missing.length === 1 ? 'it' : 'them'}`}. `
+                + 'Compose resolves undeclared variables to an empty string, so services start with blank credentials.',
+        });
+    }
+}
+
+async function validateEmulatorSetup(
+    workspace: string,
+    context: DebugEnvironmentContext,
+    issues: ArtifactValidationIssue[],
+): Promise<void> {
+    if (!context.hasEmulators) {
+        return;
+    }
+    if (!context.taskLabels.has('Start Emulators')) {
+        issues.push({
+            code: 'missingEmulatorTask',
+            path: '$.tasks',
+            message: 'A plan with emulators requires a "Start Emulators" task so the dependencies come up before the debugger attaches.',
+        });
+    }
+
+    const composeFile = await findFirstExisting(workspace, COMPOSE_FILES);
+    if (!composeFile || !/\bazurite\b/i.test(context.planText)) {
+        return;
+    }
+    const compose = await readIfExists(path.join(workspace, composeFile));
+    // Azurite rejects API versions newer than the ones it knows about, so a current
+    // Azure Storage SDK fails against it unless the check is disabled.
+    if (compose !== undefined && !/skipApiVersionCheck/i.test(compose)) {
+        issues.push({
+            code: 'azuriteApiVersionCheckEnabled',
+            path: '$.compose.services.azurite',
+            message: 'Azurite must start with --skipApiVersionCheck, otherwise newer Azure Storage SDK API versions are rejected locally.',
+        });
+    }
+}
+
+function parseEnvKeys(content: string): Set<string> {
+    return new Set(content.split('\n').flatMap(line => {
+        const parsed = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/.exec(line);
+        return parsed ? [parsed[1]] : [];
+    }));
+}
+
+async function listFiles(directory: string): Promise<string[]> {
+    const found: string[] = [];
+    let entries;
+    try {
+        entries = await fs.readdir(directory, { withFileTypes: true });
+    } catch {
+        return found;
+    }
+    for (const entry of entries) {
+        const absolute = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+            if (!SKIP_DIRECTORIES.has(entry.name)) {
+                found.push(...await listFiles(absolute));
+            }
+            continue;
+        }
+        found.push(absolute);
+    }
+    return found;
+}
+
+async function findFirstExisting(workspace: string, candidates: string[]): Promise<string | undefined> {
+    for (const candidate of candidates) {
+        try {
+            await fs.access(path.join(workspace, candidate));
+            return candidate;
+        } catch {
+            continue;
+        }
+    }
+    return undefined;
+}
+
+async function readIfExists(target: string): Promise<string | undefined> {
+    try {
+        return await fs.readFile(target, 'utf8');
+    } catch {
+        return undefined;
+    }
+}

--- a/evals/src/artifacts/launchConfig.ts
+++ b/evals/src/artifacts/launchConfig.ts
@@ -1,0 +1,281 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Structural contract for the VS Code debug configuration the generation phase emits.
+ *
+ * This validator never launches anything — it answers the question a user hits on the
+ * first F5: does `launch.json` reference tasks that exist, do the `dependsOn` chains
+ * terminate, and can the compound start every service exactly once? Those are the
+ * defects that make a generated setup unusable, and they are all visible statically.
+ *
+ * Rules come from `resources/agents/azure-debug-generate/references/multi-service.md`
+ * and `validation.md`.
+ */
+
+import { parse, printParseErrorCode } from 'jsonc-parser';
+import type { ParseError } from 'jsonc-parser';
+import type { ArtifactValidationIssue, ArtifactValidationResult } from './validationTypes.ts';
+import { createValidationResult } from './validationTypes.ts';
+
+export interface LaunchConfiguration {
+    name?: unknown;
+    preLaunchTask?: unknown;
+    type?: unknown;
+}
+
+export interface CompoundConfiguration {
+    name?: unknown;
+    configurations?: unknown;
+    preLaunchTask?: unknown;
+}
+
+export interface TaskDefinition {
+    label?: unknown;
+    dependsOn?: unknown;
+    dependsOrder?: unknown;
+    isBackground?: unknown;
+    problemMatcher?: unknown;
+    runOptions?: { instancePolicy?: unknown; instanceLimit?: unknown };
+}
+
+export interface LaunchDocument {
+    configurations: LaunchConfiguration[];
+    compounds: CompoundConfiguration[];
+}
+
+export interface TasksDocument {
+    tasks: TaskDefinition[];
+}
+
+/**
+ * Parse JSONC — `launch.json` and `tasks.json` are commented by design, and the
+ * generation phase leans on that to explain each configuration.
+ *
+ * Uses the same `jsonc-parser` the extension itself ships with, so a file the
+ * grader accepts is a file the product can read.
+ */
+export function parseJsonc(text: string): unknown {
+    const errors: ParseError[] = [];
+    const value = parse(text, errors, { allowTrailingComma: true, disallowComments: false });
+    if (errors.length > 0) {
+        const [first] = errors;
+        throw new SyntaxError(`${printParseErrorCode(first.error)} at offset ${first.offset}`);
+    }
+    return value;
+}
+
+export function readLaunchDocument(text: string): LaunchDocument {
+    const parsed = parseJsonc(text) as { configurations?: unknown; compounds?: unknown } | null;
+    return {
+        configurations: Array.isArray(parsed?.configurations) ? parsed.configurations as LaunchConfiguration[] : [],
+        compounds: Array.isArray(parsed?.compounds) ? parsed.compounds as CompoundConfiguration[] : [],
+    };
+}
+
+export function readTasksDocument(text: string): TasksDocument {
+    const parsed = parseJsonc(text) as { tasks?: unknown } | null;
+    return { tasks: Array.isArray(parsed?.tasks) ? parsed.tasks as TaskDefinition[] : [] };
+}
+
+/**
+ * Validate `launch.json` against `tasks.json`.
+ *
+ * `tasksText` may be undefined — a workspace whose configs declare no `preLaunchTask`
+ * legitimately has no tasks file, but one that references tasks must have it.
+ */
+export function validateDebugLaunchConfiguration(
+    launchText: string,
+    tasksText: string | undefined,
+): ArtifactValidationResult {
+    const issues: ArtifactValidationIssue[] = [];
+
+    let launch: LaunchDocument;
+    try {
+        launch = readLaunchDocument(launchText);
+    } catch (error) {
+        return createValidationResult([issue('launchJsonUnparseable', '$.launch', describeError(error))]);
+    }
+
+    let tasks: TasksDocument = { tasks: [] };
+    if (tasksText !== undefined) {
+        try {
+            tasks = readTasksDocument(tasksText);
+        } catch (error) {
+            return createValidationResult([issue('tasksJsonUnparseable', '$.tasks', describeError(error))]);
+        }
+    }
+
+    if (launch.configurations.length === 0) {
+        issues.push(issue('noLaunchConfigurations', '$.launch', 'launch.json declares no configurations.'));
+    }
+
+    const taskByLabel = new Map<string, TaskDefinition>();
+    for (const task of tasks.tasks) {
+        if (typeof task.label !== 'string' || !task.label.trim()) {
+            issues.push(issue('unlabeledTask', '$.tasks', 'A task has no label.'));
+            continue;
+        }
+        if (taskByLabel.has(task.label)) {
+            // VS Code resolves a `dependsOn` by label, so a duplicate makes the
+            // startup graph ambiguous.
+            issues.push(issue('duplicateTaskLabels', '$.tasks', `Task label "${task.label}" is declared more than once.`));
+        }
+        taskByLabel.set(task.label, task);
+
+        // Re-running F5, or a compound whose members share a chain, invokes the same
+        // task again. Without a silent single-instance policy VS Code either prompts
+        // the user or starts the service a second time.
+        if (task.runOptions?.instanceLimit !== 1 || task.runOptions?.instancePolicy !== 'silent') {
+            issues.push(issue(
+                'invalidTaskRunOptions',
+                '$.tasks',
+                `Task "${task.label}" must set runOptions.instanceLimit to 1 and runOptions.instancePolicy to "silent" so a repeated invocation is a no-op.`,
+            ));
+        }
+        // A background task with an empty problem matcher never signals "ready", so
+        // the debugger attaches before the service is listening.
+        if (task.isBackground === true && isEmptyProblemMatcher(task.problemMatcher)) {
+            issues.push(issue(
+                'missingBackgroundProblemMatcher',
+                '$.tasks',
+                `Background task "${task.label}" has no problem matcher, so nothing detects when the service is ready.`,
+            ));
+        }
+    }
+
+    const configByName = new Map<string, LaunchConfiguration>();
+    for (const config of launch.configurations) {
+        if (typeof config.name !== 'string' || !config.name.trim()) {
+            issues.push(issue('unnamedLaunchConfig', '$.launch', 'A launch configuration has no name.'));
+            continue;
+        }
+        if (configByName.has(config.name)) {
+            issues.push(issue('duplicateLaunchConfig', '$.launch', `Launch configuration "${config.name}" is declared more than once.`));
+        }
+        configByName.set(config.name, config);
+        if (typeof config.type !== 'string' || !config.type.trim()) {
+            issues.push(issue('missingDebuggerType', '$.launch', `Launch configuration "${config.name}" has no debugger "type".`));
+        }
+    }
+
+    // Every referenced task must exist, and the chains it pulls in must terminate.
+    for (const [name, config] of configByName) {
+        const preLaunchTask = config.preLaunchTask;
+        if (preLaunchTask === undefined) {
+            continue;
+        }
+        if (typeof preLaunchTask !== 'string') {
+            issues.push(issue('invalidPreLaunchTask', '$.launch', `Launch configuration "${name}" has a non-string preLaunchTask.`));
+            continue;
+        }
+        if (!taskByLabel.has(preLaunchTask)) {
+            issues.push(issue('preLaunchTaskUnresolved', '$.launch', `Launch configuration "${name}" references task "${preLaunchTask}", which is not defined in tasks.json.`));
+        }
+    }
+
+    validateTaskGraph(taskByLabel, issues);
+    validateCompounds(launch, configByName, issues);
+
+    return createValidationResult(issues);
+}
+
+function validateTaskGraph(taskByLabel: Map<string, TaskDefinition>, issues: ArtifactValidationIssue[]): void {
+    for (const [label, task] of taskByLabel) {
+        for (const dependency of dependsOnLabels(task)) {
+            if (!taskByLabel.has(dependency)) {
+                issues.push(issue('dependsOnUnresolved', '$.tasks', `Task "${label}" depends on "${dependency}", which is not defined.`));
+            }
+        }
+    }
+
+    // A cycle makes the chain never terminate, so VS Code would hang on F5.
+    const visiting = new Set<string>();
+    const settled = new Set<string>();
+    const reported = new Set<string>();
+
+    const visit = (label: string, trail: string[]): void => {
+        if (settled.has(label)) {
+            return;
+        }
+        if (visiting.has(label)) {
+            const cycle = [...trail.slice(trail.indexOf(label)), label].join(' -> ');
+            if (!reported.has(cycle)) {
+                reported.add(cycle);
+                issues.push(issue('dependsOnCycle', '$.tasks', `Task dependency cycle: ${cycle}.`));
+            }
+            return;
+        }
+        visiting.add(label);
+        for (const dependency of dependsOnLabels(taskByLabel.get(label))) {
+            if (taskByLabel.has(dependency)) {
+                visit(dependency, [...trail, label]);
+            }
+        }
+        visiting.delete(label);
+        settled.add(label);
+    };
+
+    for (const label of taskByLabel.keys()) {
+        visit(label, []);
+    }
+}
+
+/**
+ * The compound is where a broken startup graph shows up: a member that names a
+ * configuration nobody defined simply never starts, leaving the user with a
+ * partially-running stack and no error.
+ */
+function validateCompounds(
+    launch: LaunchDocument,
+    configByName: Map<string, LaunchConfiguration>,
+    issues: ArtifactValidationIssue[],
+): void {
+    for (const compound of launch.compounds) {
+        const name = typeof compound.name === 'string' ? compound.name : '(unnamed)';
+        const members = Array.isArray(compound.configurations) ? compound.configurations : [];
+        if (members.length === 0) {
+            issues.push(issue('emptyCompound', '$.launch', `Compound "${name}" lists no member configurations.`));
+            continue;
+        }
+
+        for (const member of members) {
+            if (typeof member !== 'string') {
+                issues.push(issue('compoundMemberUnresolved', '$.launch', `Compound "${name}" has a non-string member.`));
+                continue;
+            }
+            if (!configByName.has(member)) {
+                issues.push(issue('compoundMemberUnresolved', '$.launch', `Compound "${name}" references configuration "${member}", which is not defined.`));
+            }
+        }
+    }
+}
+
+/** A missing or `[]` problem matcher gives VS Code no ready signal to wait on. */
+function isEmptyProblemMatcher(problemMatcher: unknown): boolean {
+    if (problemMatcher === undefined || problemMatcher === null) {
+        return true;
+    }
+    return Array.isArray(problemMatcher) && problemMatcher.length === 0;
+}
+
+function dependsOnLabels(task: TaskDefinition | undefined): string[] {
+    const dependsOn = task?.dependsOn;
+    if (typeof dependsOn === 'string') {
+        return [dependsOn];
+    }
+    if (Array.isArray(dependsOn)) {
+        return dependsOn.filter((entry): entry is string => typeof entry === 'string');
+    }
+    return [];
+}
+
+function describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function issue(code: string, path: string, message: string): ArtifactValidationIssue {
+    return { code, path, message };
+}

--- a/evals/src/artifacts/localDebugPlan.ts
+++ b/evals/src/artifacts/localDebugPlan.ts
@@ -1,0 +1,554 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Contract for `.azure/vscode-debug-plan.md` — the artifact the local development
+ * phase produces and the generation phase then treats as its single source of truth.
+ *
+ * Parsing goes through the shipped `parseLocalDebugPlanMarkdown`, so a plan this
+ * validator accepts is by construction a plan the product webview can render. The
+ * rules encoded here come from `resources/agents/azure-debug-plan/references/plan-template.md`
+ * and the generation contract in `resources/agents/azure-debug-generate/`.
+ */
+
+import type { LocalPlanContent, LocalPlanData, LocalPlanSection, LocalPlanTableContent } from '../../../src/webviews/copilotOnRails/views/utils/parseLocalDebugPlanMarkdown.ts';
+import {
+    LocalDebugPlanStatus,
+    findColumnIndex,
+    findSection,
+    firstTable,
+    flattenContent,
+    isChecked,
+    parseLocalDebugPlanMarkdown,
+} from '../../../src/webviews/copilotOnRails/views/utils/parseLocalDebugPlanMarkdown.ts';
+import type { ArtifactValidationIssue, ArtifactValidationResult } from './validationTypes.ts';
+import { createValidationResult } from './validationTypes.ts';
+
+/** Marks the compound row in the Debug Configurations table. */
+export const COMPOUND_PROJECT_TYPE = '*Compound Config*';
+
+const requiredSections = [
+    'prerequisites',
+    'debug configurations',
+    'orchestrator',
+    'emulators',
+    'architecture diagram',
+] as const;
+
+const executionModes = ['auto', 'guided'] as const;
+
+export interface LocalDebugPlanExpectations {
+    /** Status the plan must record, e.g. `Planning` at the approval gate. */
+    expectedStatus?: string;
+    /** Number of generated, non-compound services the scan should have found. */
+    expectedServiceCount?: number;
+    /** Substrings that must each match an Emulators row (e.g. `Azurite`, `PostgreSQL`). */
+    expectedEmulators?: string[];
+    /** The scenario has no Azure dependencies, so no emulator may be planned. */
+    expectNoEmulators?: boolean;
+    /** Require the Debug Configuration Checklist to be present and free of stubs. */
+    requireChecklist?: boolean;
+}
+
+export interface DebugConfigRow {
+    generate: boolean;
+    name: string;
+    serviceRoot: string;
+    projectType: string;
+    runtime: string;
+    isCompound: boolean;
+}
+
+export interface ParsedDebugPlan {
+    data: LocalPlanData;
+    debugConfigs: DebugConfigRow[];
+    emulators: string[][];
+    migrations: PlanChecklistRow[];
+    apiTestCollections: PlanChecklistRow[];
+    convenienceScripts: ConvenienceScriptRow[];
+}
+
+export interface PlanChecklistRow {
+    generate: boolean;
+    service: string;
+}
+
+export interface ConvenienceScriptRow {
+    generate: boolean;
+    script: string;
+    registeredIn: string;
+}
+
+export function validateLocalDebugPlanArtifact(
+    content: string,
+    expectations: LocalDebugPlanExpectations = {},
+): ArtifactValidationResult {
+    const issues: ArtifactValidationIssue[] = [];
+    const data = parseLocalDebugPlanMarkdown(content);
+    if (data.parseError) {
+        issues.push(issue('productionParserFailure', '$', data.parseError.message));
+    }
+
+    validateHeader(data, expectations, issues);
+    validateTableIntegrity(data, issues);
+    validatePlaceholders(data, issues);
+
+    for (const sectionName of requiredSections) {
+        if (!findSection(data, sectionName)) {
+            issues.push(issue('missingSection', '$', `Missing required "${sectionName}" section.`));
+        }
+    }
+
+    validatePrerequisites(data, issues);
+    const debugConfigs = validateDebugConfigurations(data, expectations, issues);
+    validateEmulators(data, expectations, issues);
+    validateArchitectureDiagram(data, issues);
+    validateChecklist(data, debugConfigs, expectations, issues);
+
+    return createValidationResult(issues);
+}
+
+/**
+ * Pull the plan's structured tables out once so both this validator and the
+ * artifact-conformance validator read the plan the same way.
+ */
+export function parseDebugPlan(content: string): ParsedDebugPlan {
+    const data = parseLocalDebugPlanMarkdown(content);
+    return {
+        data,
+        debugConfigs: readDebugConfigRows(data),
+        emulators: findTable(data, 'emulators')?.rows ?? [],
+        migrations: readChecklistRows(data, 'migrations'),
+        apiTestCollections: readChecklistRows(data, 'api test collections'),
+        convenienceScripts: readConvenienceScriptRows(data),
+    };
+}
+
+function validateHeader(
+    data: LocalPlanData,
+    expectations: LocalDebugPlanExpectations,
+    issues: ArtifactValidationIssue[],
+): void {
+    // plan-template.md mandates `# Azure Debug Plan`. Nothing in the product reads the
+    // title, so this is a drift signal rather than a functional break — but the plan is
+    // the generation phase's only input, and a renamed document means the agent has
+    // stopped following the template it is supposed to fill in.
+    if (data.title.trim() !== 'Azure Debug Plan') {
+        issues.push(issue('invalidTitle', '$.title', `Plan title must be "Azure Debug Plan", found "${data.title.trim()}".`));
+    }
+
+    const status = data.status.trim();
+    if (!status || status === 'Unknown') {
+        issues.push(issue('missingStatus', '$.Status', 'Plan header must record a **Status**.'));
+    } else if (!Object.values(LocalDebugPlanStatus).includes(status.toLowerCase() as LocalDebugPlanStatus)) {
+        issues.push(issue('unknownStatus', '$.Status', `Status "${status}" is not one of ${Object.values(LocalDebugPlanStatus).join(', ')}.`));
+    }
+
+    if (expectations.expectedStatus && status.toLowerCase() !== expectations.expectedStatus.toLowerCase()) {
+        issues.push(issue('unexpectedStatus', '$.Status', `Expected status "${expectations.expectedStatus}", found "${status || 'missing'}".`));
+    }
+
+    const mode = data.executionMode.trim();
+    if (!mode || mode === 'Unknown') {
+        issues.push(issue('missingExecutionMode', '$.ExecutionMode', 'Plan header must record an **Execution Mode**.'));
+    } else if (!executionModes.includes(mode.toLowerCase() as typeof executionModes[number])) {
+        issues.push(issue('unknownExecutionMode', '$.ExecutionMode', `Execution Mode "${mode}" is not one of Auto, Guided.`));
+    }
+}
+
+/**
+ * `plan-template.md` calls out concatenated table rows as the failure that "breaks
+ * parsing completely" — a row merged onto the separator line loses its cells, so the
+ * generation phase silently reads the wrong plan. A row whose cell count disagrees
+ * with the header, or that still carries separator dashes, is that failure.
+ */
+function validateTableIntegrity(data: LocalPlanData, issues: ArtifactValidationIssue[]): void {
+    for (const { section, content } of walkContent(data)) {
+        if (content.type !== 'table') {
+            continue;
+        }
+        for (const [index, row] of content.rows.entries()) {
+            if (row.some(cell => /^:?-{3,}:?$/.test(cell.trim()))) {
+                issues.push(issue(
+                    'tableRowConcatenated',
+                    `$.${section}`,
+                    `Row ${index + 1} still contains separator dashes — a table row was merged onto the "|---|" line.`,
+                ));
+                continue;
+            }
+            // Trailing empty cells are cosmetic (the shipped compound row writes `||||`),
+            // so only extra cells that actually carry content indicate merged rows.
+            const overflow = row.slice(content.headers.length).filter(cell => cell.trim().length > 0);
+            if (overflow.length > 0) {
+                issues.push(issue(
+                    'tableRowConcatenated',
+                    `$.${section}`,
+                    `Row ${index + 1} has ${overflow.length} cell(s) beyond the ${content.headers.length} the header declares: ${overflow.join(', ')}.`,
+                ));
+            }
+        }
+    }
+}
+
+/**
+ * A `{placeholder}` left in means the agent copied the template without filling it.
+ *
+ * Route parameters (`/api/photos/{id}`) and inline JSON payloads are legitimate plan
+ * content, so a brace only counts when it names a template field — either a known
+ * single-word token or a multi-word prompt like `{ISO-8601 datetime}`.
+ */
+const templateTokens = new Set([
+    'name', 'path', 'type', 'runtime', 'version', 'label', 'service', 'services',
+    'status', 'description', 'tool', 'emulator', 'orchestrator', 'category',
+]);
+
+function validatePlaceholders(data: LocalPlanData, issues: ArtifactValidationIssue[]): void {
+    for (const { section, content } of walkContent(data)) {
+        const text = contentText(content);
+        for (const match of text.matchAll(/(.?)\{([^}\n]+)\}/g)) {
+            const [, preceding, body] = match;
+            // `/api/pairs/{id}` — a route parameter, not an unfilled field.
+            if (preceding === '/' || preceding === '"') {
+                continue;
+            }
+            const inner = body.trim();
+            const isTemplatePrompt = /[\s|/]/.test(inner) || templateTokens.has(inner.toLowerCase());
+            if (isTemplatePrompt && !/^["\d]/.test(inner)) {
+                issues.push(issue('unfilledPlaceholder', `$.${section}`, `Template placeholder "{${inner}}" was never filled in.`));
+                break;
+            }
+        }
+    }
+}
+
+function validatePrerequisites(data: LocalPlanData, issues: ArtifactValidationIssue[]): void {
+    const table = findTable(data, 'prerequisites');
+    if (!table) {
+        return;
+    }
+    const installed = findColumnIndex(table.headers, 'installed');
+    if (installed === -1) {
+        issues.push(issue('missingPrerequisiteColumn', '$.prerequisites', 'Prerequisites table must have an "Installed" column.'));
+        return;
+    }
+    let hasUnconfirmed = false;
+    for (const row of table.rows) {
+        const marker = row[installed]?.trim() ?? '';
+        if (marker === '❓') {
+            hasUnconfirmed = true;
+        } else if (marker !== '✅') {
+            issues.push(issue('invalidInstalledMarker', '$.prerequisites', `Installed must be ✅ or ❓, found "${marker || 'empty'}".`));
+        }
+    }
+    // The template pairs any ❓ with an explicit call to action, because that marker is
+    // the user's only cue to check a tool before approving.
+    if (hasUnconfirmed && !hasActionRequiredCallout(data)) {
+        issues.push(issue('missingActionRequiredCallout', '$.prerequisites', 'A ❓ prerequisite requires the "Action required" callout.'));
+    }
+}
+
+function validateDebugConfigurations(
+    data: LocalPlanData,
+    expectations: LocalDebugPlanExpectations,
+    issues: ArtifactValidationIssue[],
+): DebugConfigRow[] {
+    const table = findTable(data, 'debug configurations');
+    if (!table) {
+        return [];
+    }
+    for (const column of ['generate', 'debug config name']) {
+        if (findColumnIndex(table.headers, column) === -1) {
+            issues.push(issue('missingDebugConfigColumn', '$.debugConfigurations', `Debug Configurations table must have a "${column}" column.`));
+        }
+    }
+
+    const rows = readDebugConfigRows(data);
+    if (rows.length === 0) {
+        issues.push(issue('noDebugConfigRows', '$.debugConfigurations', 'Debug Configurations table has no rows.'));
+        return rows;
+    }
+
+    const generateColumn = findColumnIndex(table.headers, 'generate');
+    if (generateColumn !== -1) {
+        for (const row of table.rows) {
+            const marker = row[generateColumn]?.trim() ?? '';
+            if (!/^\[[ xX]\]$/.test(marker)) {
+                issues.push(issue('invalidGenerateMarker', '$.debugConfigurations', `Generate must be [x] or [ ], found "${marker || 'empty'}".`));
+            }
+        }
+    }
+
+    const generated = rows.filter(row => row.generate);
+    const services = generated.filter(row => !row.isCompound);
+    if (generated.length === 0) {
+        issues.push(issue('noGeneratedConfigs', '$.debugConfigurations', 'No Debug Configurations row is marked [x], so generation would produce nothing.'));
+    }
+
+    for (const row of services) {
+        if (!row.name) {
+            issues.push(issue('incompleteDebugConfigRow', '$.debugConfigurations', 'A generated row has no Debug Config Name.'));
+        }
+        for (const [label, value] of [['Service Root', row.serviceRoot], ['Project Type', row.projectType], ['Runtime', row.runtime]] as const) {
+            if (!value || value === '—') {
+                issues.push(issue('incompleteDebugConfigRow', '$.debugConfigurations', `Generated config "${row.name || '(unnamed)'}" is missing ${label}.`));
+            }
+        }
+    }
+
+    const duplicates = findDuplicates(services.map(row => row.name.toLowerCase()));
+    for (const duplicate of duplicates) {
+        issues.push(issue('duplicateDebugConfigName', '$.debugConfigurations', `Debug Config Name "${duplicate}" is used more than once.`));
+    }
+
+    // A workspace with two or more debuggable services needs a single entry point,
+    // otherwise the user has to start each service by hand.
+    const hasCompound = generated.some(row => row.isCompound);
+    if (services.length > 1 && !hasCompound) {
+        issues.push(issue('missingCompoundConfig', '$.debugConfigurations', `${services.length} services are generated but no "${COMPOUND_PROJECT_TYPE}" row is present.`));
+    }
+    if (services.length <= 1 && hasCompound) {
+        issues.push(issue('unexpectedCompoundConfig', '$.debugConfigurations', 'A compound config row is present but there is fewer than two services to compose.'));
+    }
+
+    if (expectations.expectedServiceCount !== undefined && services.length !== expectations.expectedServiceCount) {
+        issues.push(issue('unexpectedServiceCount', '$.debugConfigurations', `Expected ${expectations.expectedServiceCount} generated services, found ${services.length}.`));
+    }
+
+    return rows;
+}
+
+function validateEmulators(
+    data: LocalPlanData,
+    expectations: LocalDebugPlanExpectations,
+    issues: ArtifactValidationIssue[],
+): void {
+    const rows = findTable(data, 'emulators')?.rows ?? [];
+    const text = rows.map(row => row.join(' ')).join('\n');
+
+    if (expectations.expectNoEmulators && rows.length > 0) {
+        issues.push(issue('unexpectedEmulator', '$.emulators', `Expected no emulators, found ${rows.length}.`));
+    }
+    for (const expected of expectations.expectedEmulators ?? []) {
+        if (!text.toLowerCase().includes(expected.toLowerCase())) {
+            issues.push(issue('missingEmulator', '$.emulators', `Expected an emulator matching "${expected}", found: ${rows.length ? text.replace(/\n/g, '; ') : '(none)'}.`));
+        }
+    }
+}
+
+function validateArchitectureDiagram(data: LocalPlanData, issues: ArtifactValidationIssue[]): void {
+    const section = findSection(data, 'architecture diagram');
+    if (!section) {
+        return;
+    }
+    const mermaid = flattenContent(section.content).find(
+        content => content.type === 'codeBlock' && content.language.toLowerCase() === 'mermaid',
+    );
+    if (!mermaid) {
+        issues.push(issue('missingMermaidDiagram', '$.architectureDiagram', 'Architecture Diagram section must contain a ```mermaid code block.'));
+        return;
+    }
+    if (mermaid.type === 'codeBlock' && mermaid.code.trim().length === 0) {
+        issues.push(issue('emptyMermaidDiagram', '$.architectureDiagram', 'The mermaid diagram is empty.'));
+    }
+}
+
+/**
+ * The checklist is the generation phase's evidence that it really validated each
+ * configuration. `validation.md` names a stubbed or missing checklist the single most
+ * common failure mode, so an `Implemented` plan must carry a real result per config.
+ */
+function validateChecklist(
+    data: LocalPlanData,
+    debugConfigs: DebugConfigRow[],
+    expectations: LocalDebugPlanExpectations,
+    issues: ArtifactValidationIssue[],
+): void {
+    const implemented = data.status.trim().toLowerCase() === LocalDebugPlanStatus.Implemented;
+    if (!expectations.requireChecklist && !implemented) {
+        return;
+    }
+
+    const section = findSection(data, 'debug configuration checklist');
+    if (!section) {
+        issues.push(issue('missingChecklist', '$.debugConfigurationChecklist', 'A plan reporting validation results must include a "Debug Configuration Checklist" section.'));
+        return;
+    }
+
+    const entries = checklistEntries(section);
+    if (entries.length === 0) {
+        issues.push(issue('missingChecklist', '$.debugConfigurationChecklist', 'The Debug Configuration Checklist has no entries.'));
+        return;
+    }
+
+    for (const entry of entries) {
+        if (!/^[✅❌]/.test(entry)) {
+            issues.push(issue('checklistStub', '$.debugConfigurationChecklist', `Checklist entry "${truncate(entry)}" has no ✅ or ❌ result.`));
+            continue;
+        }
+        // An entry reads `✅ <Config Name> — <evidence>`; only the evidence half tells
+        // us whether validation actually happened, so isolate it before judging.
+        const body = entry.slice(1).trim();
+        const separator = /\s+(?:—|–|-{1,2}|:)\s+/.exec(body);
+        const detail = separator ? body.slice(separator.index + separator[0].length).trim() : '';
+        // A stub is the *absence* of evidence: no evidence half at all, or the
+        // template's own `<ready signal + curl result>` placeholder. Real entries
+        // legitimately quote JSON payloads and words like "pending", so never match
+        // on those.
+        if (!detail || /^<[^>]*>$/.test(detail) || /^(TBD|TODO|pending|N\/A)\.?$/i.test(detail)) {
+            issues.push(issue('checklistStub', '$.debugConfigurationChecklist', `Checklist entry "${truncate(entry)}" is still a stub.`));
+        }
+    }
+
+    const joined = entries.join('\n').toLowerCase();
+    for (const row of debugConfigs.filter(config => config.generate && config.name)) {
+        if (!joined.includes(row.name.toLowerCase())) {
+            issues.push(issue('checklistMissingEntry', '$.debugConfigurationChecklist', `No checklist entry for generated config "${row.name}".`));
+        }
+    }
+}
+
+function checklistEntries(section: LocalPlanSection): string[] {
+    const entries: string[] = [];
+    for (const content of flattenContent(section.content)) {
+        if (content.type === 'bulletList') {
+            entries.push(...content.items.map(item => item.trim()));
+            continue;
+        }
+        const text = contentText(content);
+        for (const line of text.split('\n').map(value => value.trim())) {
+            // Skip the section's own lead-in line ("Debug Configuration Checklist:").
+            if (!line || /^debug configuration checklist:?$/i.test(line)) {
+                continue;
+            }
+            entries.push(line);
+        }
+    }
+    return entries;
+}
+
+function readDebugConfigRows(data: LocalPlanData): DebugConfigRow[] {
+    const table = findTable(data, 'debug configurations');
+    if (!table) {
+        return [];
+    }
+    const generate = findColumnIndex(table.headers, 'generate');
+    const name = findColumnIndex(table.headers, 'debug config name');
+    const serviceRoot = findColumnIndex(table.headers, 'service root');
+    const projectType = findColumnIndex(table.headers, 'project type');
+    const runtime = findColumnIndex(table.headers, 'runtime');
+
+    return table.rows
+        .filter(row => row.some(cell => cell.trim().length > 0))
+        .map(row => {
+            const type = cell(row, projectType);
+            return {
+                generate: isChecked(cell(row, generate)),
+                name: cell(row, name),
+                serviceRoot: cell(row, serviceRoot),
+                projectType: type,
+                runtime: cell(row, runtime),
+                isCompound: type.toLowerCase().includes('compound'),
+            };
+        });
+}
+
+function readChecklistRows(data: LocalPlanData, sectionName: string): PlanChecklistRow[] {
+    const table = findTable(data, sectionName);
+    if (!table) {
+        return [];
+    }
+    const generate = findColumnIndex(table.headers, 'generate');
+    const service = findColumnIndex(table.headers, 'service');
+    return table.rows
+        .filter(row => row.some(value => value.trim().length > 0))
+        .map(row => ({
+            generate: isChecked(cell(row, generate)),
+            service: cell(row, service),
+        }));
+}
+
+function readConvenienceScriptRows(data: LocalPlanData): ConvenienceScriptRow[] {
+    const table = findTable(data, 'convenience scripts');
+    if (!table) {
+        return [];
+    }
+    const generate = findColumnIndex(table.headers, 'generate');
+    const script = findColumnIndex(table.headers, 'script');
+    const registeredIn = findColumnIndex(table.headers, 'registered in');
+    return table.rows
+        .filter(row => row.some(value => value.trim().length > 0))
+        .map(row => ({
+            generate: isChecked(cell(row, generate)),
+            script: cell(row, script).replace(/`/g, ''),
+            registeredIn: cell(row, registeredIn).replace(/`/g, ''),
+        }));
+}
+
+/** The first table inside the section whose title contains `sectionTitle`. */
+function findTable(data: LocalPlanData, sectionTitle: string): LocalPlanTableContent | undefined {
+    const section = findSection(data, sectionTitle);
+    return section && firstTable(section);
+}
+
+/** Section titles carry emoji and punctuation; key on letters and digits only. */
+function sectionKey(title: string): string {
+    return title.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function cell(row: string[], index: number): string {
+    return index === -1 ? '' : (row[index] ?? '').trim();
+}
+
+function walkContent(data: LocalPlanData): Array<{ section: string; content: LocalPlanContent }> {
+    return data.sections.flatMap(section =>
+        flattenContent(section.content).map(content => ({ section: sectionKey(section.title), content })),
+    );
+}
+
+function contentText(content: LocalPlanContent): string {
+    switch (content.type) {
+        case 'table':
+            return [content.headers.join(' '), ...content.rows.map(row => row.join(' '))].join('\n');
+        case 'blockquote':
+        case 'paragraph':
+            return content.text;
+        case 'bulletList':
+            return content.items.join('\n');
+        case 'codeBlock':
+        case 'subsection':
+            // Diagram bodies legitimately use braces, and subsection children are
+            // visited separately by `flatten`.
+            return '';
+    }
+}
+
+function hasActionRequiredCallout(data: LocalPlanData): boolean {
+    return walkContent(data).some(({ content }) =>
+        content.type === 'blockquote' && /action required/i.test(content.text),
+    );
+}
+
+function findDuplicates(values: string[]): string[] {
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+    for (const value of values) {
+        if (!value) {
+            continue;
+        }
+        if (seen.has(value)) {
+            duplicates.add(value);
+        }
+        seen.add(value);
+    }
+    return [...duplicates];
+}
+
+function truncate(value: string): string {
+    return value.length > 60 ? `${value.slice(0, 57)}...` : value;
+}
+
+function issue(code: string, path: string, message: string): ArtifactValidationIssue {
+    return { code, path, message };
+}

--- a/evals/src/graderCertification.ts
+++ b/evals/src/graderCertification.ts
@@ -7,6 +7,9 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { PlanGateState } from './artifacts/planEvaluation.ts';
+import { validateDebugArtifacts } from './artifacts/debugArtifacts.ts';
+import { validateDebugLaunchConfiguration } from './artifacts/launchConfig.ts';
+import { validateLocalDebugPlanArtifact } from './artifacts/localDebugPlan.ts';
 import { validatePlanEvaluationContract } from './artifacts/planEvaluation.ts';
 import { validatePreviewArtifacts } from './artifacts/preview.ts';
 import { validateProjectPlanArtifact } from './artifacts/projectPlan.ts';
@@ -66,17 +69,20 @@ async function main(): Promise<void> {
         throw new Error('ACA certification is not available in the planning-only subset. Add scaffold/build/runtime graders first.');
     }
     const outputIndex = process.argv.indexOf('--output');
-    const outputDirectory = outputIndex >= 0
-        ? path.resolve(process.argv[outputIndex + 1])
-        : path.join(repoRoot, 'evals', 'results', 'grader-certification', 'offline');
     const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8')) as CertificationManifest;
     if (manifest.schemaVersion !== 1) {
         throw new Error(`Unsupported grader certification manifest version ${manifest.schemaVersion}.`);
     }
+    const only = readValidatorFilter(manifest);
+    const outputDirectory = outputIndex >= 0
+        ? path.resolve(process.argv[outputIndex + 1])
+        // A filtered run is not a certification of the grader set, so it must not
+        // overwrite the report a full run produced.
+        : path.join(repoRoot, 'evals', 'results', 'grader-certification', only ? 'offline-filtered' : 'offline');
     const fixture = path.join(repoRoot, manifest.fixture.path);
     const scenarioPath = path.join(fixture, 'scenario.json');
     const scenario = validateScenario(JSON.parse(await fs.readFile(scenarioPath, 'utf8')), scenarioPath);
-    const cases = await runOfflineCertification(manifest, fixture, scenario);
+    const cases = await runOfflineCertification(manifest, fixture, scenario, only);
     const report: CertificationReport = {
         schemaVersion: 1,
         generatedAt: new Date().toISOString(),
@@ -90,24 +96,46 @@ async function main(): Promise<void> {
         fs.writeFile(path.join(outputDirectory, 'report.json'), `${JSON.stringify(report, null, 2)}\n`),
         fs.writeFile(path.join(outputDirectory, 'report.md'), renderMarkdown(report)),
     ]);
-    console.log(`${report.outcome.toUpperCase()}: ${cases.filter(value => value.passed).length}/${cases.length} grader certification cases passed.`);
+    console.log(`${report.outcome.toUpperCase()}: ${cases.filter(value => value.passed).length}/${cases.length} grader certification cases passed${only ? ` (filtered to ${[...only].join(', ')})` : ''}.`);
     if (report.outcome !== 'passed') {
         process.exitCode = 1;
     }
+}
+
+/**
+ * `--validator <id>` (repeatable) narrows certification to one grader while you are
+ * iterating on it. The full set still runs in CI, so a filter can only make a local
+ * run smaller — never make a failing grader look certified.
+ */
+function readValidatorFilter(manifest: CertificationManifest): Set<string> | undefined {
+    const requested = process.argv.flatMap((argument, index) =>
+        argument === '--validator' && process.argv[index + 1] ? [process.argv[index + 1]] : []);
+    if (requested.length === 0) {
+        return undefined;
+    }
+    const known = new Set(manifest.fixture.offlineValidators);
+    const unknown = requested.filter(id => !known.has(id));
+    if (unknown.length > 0) {
+        throw new Error(`Unknown validator ${unknown.join(', ')}. Known validators: ${[...known].join(', ')}.`);
+    }
+    return new Set(requested);
 }
 
 async function runOfflineCertification(
     manifest: CertificationManifest,
     fixture: string,
     scenario: CorEvaluationScenario,
+    only: Set<string> | undefined,
 ): Promise<CertificationCase[]> {
     const cases: CertificationCase[] = [];
     const golden = await runOfflineValidators(fixture, scenario);
-    for (const validator of manifest.fixture.offlineValidators) {
+    for (const validator of manifest.fixture.offlineValidators.filter(id => !only || only.has(id))) {
         const result = golden.get(validator) ?? ['validatorNotExecuted'];
         cases.push(createCase(`golden-${validator}`, 'offline', validator, 'passed', result));
     }
-    for (const mutation of manifest.mutations.filter(value => value.tier === 'offline')) {
+    const mutations = manifest.mutations.filter(value =>
+        value.tier === 'offline' && (!only || only.has(value.validator)));
+    for (const mutation of mutations) {
         cases.push(await withMutatedFixture(fixture, mutation, async workspace => {
             const results = await runOfflineValidators(workspace, scenario);
             const actual = results.get(mutation.validator) ?? ['validatorNotExecuted'];
@@ -132,10 +160,13 @@ async function runOfflineValidators(
     scenario: CorEvaluationScenario,
 ): Promise<Map<string, string[]>> {
     const azure = path.join(workspace, '.azure');
-    const [requirements, projectPlan] = await Promise.all([
+    const [requirements, projectPlan, debugPlan] = await Promise.all([
         fs.readFile(path.join(azure, 'requirements.json'), 'utf8'),
         fs.readFile(path.join(azure, 'project-plan.md'), 'utf8'),
+        fs.readFile(path.join(azure, 'vscode-debug-plan.md'), 'utf8'),
     ]);
+    const launchText = await fs.readFile(path.join(workspace, '.vscode', 'launch.json'), 'utf8');
+    const tasksText = await fs.readFile(path.join(workspace, '.vscode', 'tasks.json'), 'utf8');
     const validations: Array<readonly [string, ArtifactValidationResult]> = await Promise.all([
         Promise.resolve(['requirements', validateRequirementsArtifact(requirements, { requireConfirmed: true })] as const),
         Promise.resolve(['project-plan', validateProjectPlanArtifact(projectPlan, { expectedStatus: 'Integrated' })] as const),
@@ -144,6 +175,14 @@ async function runOfflineValidators(
             validatePlanEvaluationContract(state.expectedFrontend, state.generatedFrontend, state.gate),
         ] as const),
         validatePreviewArtifacts(path.join(azure, '.preview-temp')).then(result => ['preview', result] as const),
+        Promise.resolve(['debug-plan', validateLocalDebugPlanArtifact(debugPlan, {
+            expectedStatus: 'Implemented',
+            expectedServiceCount: 1,
+            expectNoEmulators: true,
+            requireChecklist: true,
+        })] as const),
+        Promise.resolve(['debug-config', validateDebugLaunchConfiguration(launchText, tasksText)] as const),
+        validateDebugArtifacts(workspace).then(result => ['debug-artifacts', result] as const),
     ]);
     const results = new Map(validations.map(([id, result]) => [id, issueCodes(result)]));
     return results;

--- a/src/webviews/copilotOnRails/views/utils/parseLocalDebugPlanMarkdown.ts
+++ b/src/webviews/copilotOnRails/views/utils/parseLocalDebugPlanMarkdown.ts
@@ -52,12 +52,20 @@ export function parseLocalDebugPlanMarkdown(markdown: string): LocalPlanData {
     };
 }
 
-export enum LocalDebugPlanStatus {
-    Planning = 'planning',
-    Approved = 'approved',
-    Executing = 'executing',
-    Implemented = 'implemented',
-}
+/**
+ * Declared as a const object rather than a TS `enum` so the module stays
+ * erasable: the eval graders load this parser directly through Node's
+ * type-stripping, which rejects `enum`. Call sites are unaffected — both the
+ * value (`LocalDebugPlanStatus.Implemented`) and the type still resolve.
+ */
+export const LocalDebugPlanStatus = {
+    Planning: 'planning',
+    Approved: 'approved',
+    Executing: 'executing',
+    Implemented: 'implemented',
+} as const;
+
+export type LocalDebugPlanStatus = typeof LocalDebugPlanStatus[keyof typeof LocalDebugPlanStatus];
 
 
 const STATUS_METADATA_REGEX = /^\s*>?\s*\**Status[:*]*:[:*]*\s*(.+)$/i;


### PR DESCRIPTION
## Add local-development phase evals


Extends the eval system to the phase after scaffold (`azure-debug-plan` → `azure-debug-generate`)


**Graders** — four validators (plan contract, `launch.json`/`tasks.json` structure, plan/artifact conformance, completed validation checklist) plus a gate check that planning doesn't generate early. Certification goes 9 → 26 cases.


**Real graders on MSBench** — `stage-graders.sh` bundles the actual grader sources into the container, so MSBench runs the same code Vally does. This replaces the SQL approximation of `requirements-schema-valid` that #1689 flagged as partial.


**`preflight.sh`** — verifies a suite offline before spending container time, checking each `exec:` assertion fails on a bare workspace *and* passes on a valid one so vacuous passes can't slip through.


⚠️ **`run.sh` now requires `./stage.sh <suite>` first** — `assets/user-overrides.yaml` is generated rather than tracked now that each suite owns its config. CI updated.


**Verification:** certify 26/26 · typecheck · eslint · lint · preflight clean on both suites.


**Known gaps:** checks are structural only — nothing boots an emulator yet (a Docker capability probe is included to scope that work). We would need to add a bit more within MSBench to test if the local development set up is working properly. 