### PR TITLE
Stop run.sh from reporting throttled and raced runs as results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ evals/msbench/assets/graders/
 # Built from evals/msbench/config/{base,stimuli/*}.yaml by run.sh. run-agent.sh
 # only ever reads this one filename, so selecting a stimulus means writing it.
 evals/msbench/assets/user-overrides.yaml
+
+# Mutual-exclusion lock taken by run.sh while it owns assets/.
+evals/msbench/assets/.run.lock/

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -32,6 +32,9 @@ than being levelled up — only `photo-app-requirements` specifies
 `no-dotfile-requirements` and `transcript-not-contains`, and only it and
 `api-only-inventory` specify `no-premature-plan`.
 
+All four are verified by a real green run; ids are under
+[Verified result](#verified-result).
+
 ## Quick start
 
 ```bash
@@ -85,10 +88,35 @@ rather than being skipped — fingerprint `Linux x86_64 / cwd=/workspace / node=
 and the validator's own `PASS: requirements.json satisfies the requirements contract` on
 stderr.
 
-> **Flaky failure mode:** back-to-back runs can fail with `"type": "RATE_LIMIT"` in
-> `output/error.json` — the Copilot API rate-limits the agent mid-run, so the artifact
-> assertions fail simply because nothing was produced. This is not a product failure.
-> Leave a few minutes between runs, and check `error.json` before believing a red result.
+The other three stimuli are each verified by their own green run, with the validator
+genuinely executing under the flags that distinguish them:
+
+| Stimulus | Run | Result |
+| --- | --- | --- |
+| `api-only-inventory` | [`2026082582848923`](https://msbenchapp.azurewebsites.net/run-analysis/2026082582848923) | 5/5 |
+| `no-datastore-converter` | [`2026082585315961`](https://msbenchapp.azurewebsites.net/run-analysis/2026082585315961) | 4/4 |
+| `multi-service-order-processing` | [`2026082586199078`](https://msbenchapp.azurewebsites.net/run-analysis/2026082586199078) | 4/4 |
+
+### The negative control, in MSBench
+
+The validator's failure path was already verified locally, but that only proves the
+*grader* exits non-zero — not that MSBench notices. An assertion that cannot go red is
+worse than no assertion, so
+[`2026082582510393`](https://msbenchapp.azurewebsites.net/run-analysis/2026082582510393)
+ran the photo-app prompt (which asks for PostgreSQL) against the validator invoked with
+`--assert-no-datastore`, a contract it must fail.
+
+Result: **6/7, with only the `exec:` assertion red** and `resolved: false`. The failure
+was attributable rather than merely present — exit code **1**, a product failure rather
+than the exit 3 that means the grader itself broke:
+
+```
+FAIL: requirements.json satisfies the requirements contract
+  — Expected "No datastore required" in recommendedChoice, got: Blob Storage, PostgreSQL
+```
+
+So the assertion fails for the intended reason, and the failure stays isolated to the
+one assertion under test instead of collapsing the whole run.
 
 ## How it works
 
@@ -290,12 +318,34 @@ with a clear message:
 - **A red run that is actually rate limiting.** Back-to-back runs get throttled by the
   Copilot API mid-run. The agent then produces nothing, so artifact assertions fail
   while negative assertions pass trivially — indistinguishable from a genuine agent
-  regression at a glance. **Always check `output/error.json` for `"type": "RATE_LIMIT"`
-  before believing a red result.** Corroborate with
+  regression at a glance. `run.sh` now detects this and **exits 75 (`EX_TEMPFAIL`) with
+  a loud banner instead of letting you read the results table**, so a throttled run
+  cannot be mistaken for a regression.
+
+  The check keys on `output/error.json` → `"type": "RATE_LIMIT"` and is deliberately
+  narrow: verified against three stored runs, it catches the throttled one, passes the
+  green one, and — the case that actually matters — still reports the genuinely-red
+  negative control as a real failure. A detector for false reds is worthless if it
+  also hides true ones. Corroborate manually with
   `select name, count(*) from spans group by name` against
   `output/vsc-output/agent-traces.db` (note: `spans`/`span_attributes`, not `toolCalls`,
-  which is the assertion-time view). ~13 chat spans is healthy; dying around 6 is
-  throttling. Leave several minutes between runs.
+  which is the assertion-time view) — ~13 chat spans is healthy, dying around 6 is
+  throttling. A **completely empty `exec` table** is another tell: the graders never ran
+  at all, rather than running and failing.
+
+  Observed budget: **three runs inside 14 minutes succeeded and the fourth was
+  throttled**, at ~250k tokens each. So this is a rolling token allowance rather than a
+  minimum gap between runs; spacing runs ~15 minutes apart is the practical rule.
+
+- **Two `run.sh` invocations at once submit each other's stimulus.** `assets/` is shared
+  mutable state — every invocation rewrites `user-overrides.yaml` before uploading it —
+  so overlapping runs race and the loser submits the winner's prompt. That yields a run
+  which looks entirely normal while grading the wrong stimulus, the worst failure mode
+  here: it is confidently wrong rather than obviously broken. (This is exactly how run
+  `2026082584891952`, invoked with `--stimulus no-datastore-converter`, graded the
+  photo-app prompt.) `run.sh` now takes a lock (`assets/.run.lock`) and refuses to start
+  rather than racing, and echoes the prompt it is actually submitting so a mismatch
+  shows up in the log instead of only after unzipping the results.
 - **`HTTP 400 BadRequest` from `/api/ces/benchmark/startRun` at submit time.** Seen
   submitting ~90s after a previous run finished; no run id is allocated. The same
   config submitted cleanly after a cooldown, so treat it as transient submission

--- a/evals/msbench/run.sh
+++ b/evals/msbench/run.sh
@@ -176,11 +176,74 @@ fi
 
 # --- submit ------------------------------------------------------------------
 
-log "Submitting to MSBench (benchmark: ${BENCHMARK})"
+# assets/ is shared mutable state: every invocation rewrites user-overrides.yaml
+# before uploading it. Two overlapping runs therefore race, and the loser
+# silently submits the winner's stimulus -- a run that looks entirely normal but
+# grades the wrong prompt. Serialise instead.
+LOCK="${ASSETS}/.run.lock"
+if ! mkdir "$LOCK" 2>/dev/null; then
+    die "Another run.sh is using ${ASSETS} (lock: ${LOCK}).
+    Concurrent runs would submit each other's stimulus. Wait for it to finish,
+    or remove the lock if no run.sh is alive."
+fi
+trap 'rmdir "$LOCK" 2>/dev/null || true' EXIT
+
+log "Submitting to MSBench (benchmark: ${BENCHMARK}, stimulus: ${STIMULUS})"
+# Echo the prompt actually being submitted, so a stimulus/config mismatch is
+# visible in the log rather than only discoverable by unzipping the results.
+sed -n '/^promptSteps:/,/assertions:/p' "${ASSETS}/user-overrides.yaml" \
+    | sed -n '2,4p' | sed 's/^/    | /'
 echo
-exec "${VENV}/bin/msbench-cli" run \
+
+RUN_LOG="$(mktemp -t msbench-run)"
+trap 'rm -f "$RUN_LOG"; rmdir "$LOCK" 2>/dev/null || true' EXIT
+
+set +e
+"${VENV}/bin/msbench-cli" run \
     --agent vscode \
     --model . \
     --benchmark "$BENCHMARK" \
     --agent-assets "$ASSETS" \
-    ${PASSTHRU[@]+"${PASSTHRU[@]}"}
+    ${PASSTHRU[@]+"${PASSTHRU[@]}"} 2>&1 | tee "$RUN_LOG"
+CLI_STATUS=${PIPESTATUS[0]}
+set -e
+
+# A throttled run still prints a normal-looking red results table: the agent
+# produced nothing, so artifact assertions fail while negative assertions pass
+# trivially. That is indistinguishable from a real regression by eye, and was
+# twice mistaken for one while building this. Check before the reader can draw a
+# conclusion from the table.
+RUN_ID="$(grep -oE 'run_id=[0-9]+' "$RUN_LOG" | head -1 | cut -d= -f2 || true)"
+if [ -n "$RUN_ID" ]; then
+    RESULTS_ZIP="$(ls "${HOME}/Library/Application Support/msbench/runs/${RUN_ID}/results.zip" \
+                      "${HOME}/.local/share/msbench/runs/${RUN_ID}/results.zip" 2>/dev/null | head -1 || true)"
+    if [ -n "$RESULTS_ZIP" ]; then
+        SCRATCH="$(mktemp -d)"
+        unzip -oq "$RESULTS_ZIP" -d "$SCRATCH" 2>/dev/null || true
+        find "$SCRATCH" -name '*-output.zip' -exec unzip -oq {} -d "${SCRATCH}/out" \; 2>/dev/null || true
+        RATE_LIMITED=0
+        if [ -f "${SCRATCH}/out/output/error.json" ] \
+                && grep -q '"type": *"RATE_LIMIT"' "${SCRATCH}/out/output/error.json"; then
+            RATE_LIMITED=1
+        fi
+        rm -rf "$SCRATCH"
+        if [ "$RATE_LIMITED" -eq 1 ]; then
+            echo
+            echo "  ============================================================"
+            echo "  RATE_LIMIT — this run is NOT a result. Do not read the table."
+            echo "  ============================================================"
+            echo "  The Copilot API throttled the agent mid-run, so it produced"
+            echo "  nothing. Positive assertions fail and negative ones pass"
+            echo "  trivially, which looks exactly like an agent regression."
+            echo
+            echo "  Runs cost ~250k tokens each; roughly 3 in 15 minutes is the"
+            echo "  observed ceiling. Wait ~15 minutes and re-run."
+            echo
+            echo "  Run id: ${RUN_ID}"
+            echo
+            exit 75  # EX_TEMPFAIL: retry later, distinct from a genuine red run
+        fi
+    fi
+fi
+
+exit "$CLI_STATUS"


### PR DESCRIPTION
Follows #1695, which proved `exec:` graders work and ported the remaining single-turn stimuli.

This PR was originally the same work, developed in parallel. #1695 merged first, so I rebased and dropped everything now duplicated. What's left is the part that wasn't covered: two failure modes that produce a run which **looks completely normal while meaning nothing**, plus the run evidence that was still outstanding when #1695 merged.

## 1. Throttled runs are no longer readable as results

The Copilot API throttles the agent mid-run, so it produces nothing. Artifact assertions then fail while negative assertions pass trivially — which reads *exactly* like an agent regression. I misread it as one twice today.

`run.sh` now checks `output/error.json` and exits **75 (`EX_TEMPFAIL`)** behind a banner rather than letting the results table be read at all.

The check is deliberately narrow, keyed on `"type": "RATE_LIMIT"`, and I verified it in **both** directions against three stored runs:

| Run | Nature | Detector |
| --- | --- | --- |
| `2026082583236973` | throttled | ✅ caught |
| `2026082582848923` | genuinely green | ✅ passed through |
| `2026082582510393` | **genuinely red** | ✅ still reported as a real failure |

That third row is the one that matters. A detector for false reds is worthless if it also hides true ones, so it was worth testing explicitly rather than assuming.

**On the throttling itself:** three runs inside 14 minutes succeeded and the fourth was throttled, at ~250k tokens each. So it's a rolling token allowance, not a minimum gap between runs — spacing ~15 minutes apart is the practical rule, and that's now in the README.

## 2. Concurrent runs silently graded the wrong stimulus

`assets/` is shared mutable state — every invocation rewrites `user-overrides.yaml` before uploading it — so two overlapping `run.sh` calls race and the loser submits the winner's prompt.

This is not hypothetical: run `2026082584891952`, invoked with `--stimulus no-datastore-converter`, actually graded the **photo-app** prompt. I only caught it because the assertion count looked wrong. It's the worst failure mode available here — confidently wrong rather than obviously broken, and it would silently corrupt any future CI matrix.

Fixed two ways: `run.sh` takes a lock (`assets/.run.lock`) and refuses to start rather than racing, and it echoes the prompt it is actually submitting, so a mismatch appears in the log instead of only after unzipping results:

```
==> Submitting to MSBench (benchmark: vscbench.say_hello, stimulus: no-datastore-converter)
    |   - text: |
    |       I want a simple unit converter web app — you type in a value and pick the
    |       units and it converts. Nothing needs to be saved, no accounts, no backend.
```

## 3. The run evidence #1695 was missing

**Negative control, in MSBench.** #1695 verified the failure path *locally*, which proves the grader exits non-zero but not that MSBench notices — and an assertion that can't go red is worse than none. Run [`2026082582510393`](https://msbenchapp.azurewebsites.net/run-analysis/2026082582510393) closes that: **6/7 with only the `exec:` assertion red**, exit code **1** (a product failure, not the exit 3 meaning the grader broke), failing for the intended reason and staying isolated to the assertion under test:

```
FAIL: requirements.json satisfies the requirements contract
  — Expected "No datastore required" in recommendedChoice, got: Blob Storage, PostgreSQL
```

**Green runs for the three ported stimuli.** #1695 shipped them with only the photo-app run id. Each is now verified, with the validator genuinely executing under its distinguishing flags:

| Stimulus | Run | Result |
| --- | --- | --- |
| `api-only-inventory` | [`2026082582848923`](https://msbenchapp.azurewebsites.net/run-analysis/2026082582848923) | 5/5 |
| `no-datastore-converter` | [`2026082585315961`](https://msbenchapp.azurewebsites.net/run-analysis/2026082585315961) | 4/4 |
| `multi-service-order-processing` | [`2026082586199078`](https://msbenchapp.azurewebsites.net/run-analysis/2026082586199078) | 4/4 |

All four stimuli in `config/stimuli/` are now backed by a real green run.

## Verification

- `./run.sh` with no arguments still builds `photo-app-requirements`, unchanged.
- `--build-only` exits before the lock is taken, so it never blocks or leaks a lock.
- `drift`, `typecheck`, `certify` (9/9) and `lint` pass; the `certify` report rewrite was reverted rather than committed.
- Rebased onto current `feat/CoR`, so this sits cleanly on top of #1695 and the `.mjs` → `.ts` conversion in #1696.
