### PR TITLE
Raise the MSBench run timeouts so long end-to-end runs aren't killed

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -134,6 +134,61 @@ The agent definition is unpacked from the VSIX itself rather than cloned from Gi
 so the instructions always match the build under test. Cloning a branch would let the
 two drift and silently grade the wrong version of the prompt.
 
+## Timeouts
+
+Two unrelated things are both called a timeout here, and conflating them is expensive.
+
+**`timeouts:` in [`config/base.yaml`](config/base.yaml) — the real ones.** Enforced by
+the agent and the platform runner. The schema's defaults are sized for a single-turn
+run, so they are set explicitly:
+
+| Key | Default | Ours | Why |
+| --- | --- | --- | --- |
+| `agentSeconds` | 6300 (1h45m) | 18000 (5h) | The E2E chain is describe → requirements → plan → scaffold → build → run → debug in **one** session. The default is a per-turn budget, not a chain budget. Sized to fit inside the job cap — see below. |
+| `stallSeconds` | 2700 (45m) | 5400 (90m) | See below. |
+| `runnerGraceSeconds` | 300 (5m) | 900 (15m) | A long session has far more to flush at the end (screen recording, trajectory, `session.sqlite`) than a 5-step run, and a truncated artifact is an unreadable result. |
+
+`stallSeconds` is the one that bites. It is **not** an agent-inactivity timeout — the
+schema defines it as time with *"no agent trace, CAPI proxy log, Copilot Chat log, or
+workspace file activity"*, so it fires only when all four signals are quiet at once. A
+long `npm install`, `azd provision`, build or test suite produces none of the four for
+minutes at a time. A healthy run doing exactly what we asked can therefore be killed for
+looking idle, and it reports as a product failure. Quiet is not the same as stuck.
+
+**These three are one budget, not three independent knobs, and the budget has to fit
+inside the platform job limit.** The job clock starts before the agent clock — container
+pull, VS Code and VSIX install, workspace setup and the `script:` preamble all happen
+before the agent's first turn. So if `agentSeconds` is set to the full job cap, the job
+is killed *first*, the agent timeout never fires, and because `runnerGraceSeconds` is
+time the runner takes **after** the agent timeout, the grace period never runs either.
+Nothing gets flushed — no screen recording, no trajectory, no `session.sqlite` — on
+precisely the runs you most need to diagnose. `agentSeconds` must therefore be the job
+cap minus setup minus grace, with margin:
+
+```
+6h job cap − ~15m setup − 15m grace ⇒ 5h agent
+```
+
+The schema gives all three a `maximum` of `9007199254740991`, so nothing above is
+schema-constrained. The real ceiling is the platform job limit. GitHub documents a 6-hour
+cap for hosted runners and 5 days for self-hosted; our runs report `dispatched to GitHub
+Actions` with `run_platform='linux_container'`, but **we could not verify which pool
+MSBench dispatches to** — that is decided by a server-side workflow not visible from the
+CLI or from `vscode-copilot-evaluation`. The 6h figure above is therefore an assumption,
+chosen because it is the safer of the two documented limits. If the cap is ever
+confirmed, re-derive `agentSeconds` from the arithmetic above rather than just raising
+it; raising it past 6h needs confirmation from the MSBench team
+(<CodeExService@microsoft.com>).
+
+**`msbench-cli run --timeout` — not the same thing, and don't add it.** It is a *local*
+wait. From `cli/arguments.py`: *"Max seconds to wait locally for completion. When
+reached, the CLI attempts to cancel the CES run, downloads partial results, and exits
+with a timeout error."* `_handle_timeout` in `execution/ces_client.py` confirms it —
+partial download, then `cancel_run`. So setting it does not give a run more time; it
+**ends a still-healthy run early** and leaves you with partial artifacts. It defaults to
+`None` (wait indefinitely), and `run.sh` deliberately does not pass it. Leave it that
+way.
+
 ## Layout
 
 Three things under `assets/` are **generated on every run and gitignored**, because a

--- a/evals/msbench/config/base.yaml
+++ b/evals/msbench/config/base.yaml
@@ -28,6 +28,44 @@ modelSelector:
   id: claude-sonnet-4.5
   vendor: copilot
 
+# Set explicitly because the defaults (6300 / 2700 / 300) are sized for a
+# single-turn run, and the end-to-end chain is not one.
+#
+# NOTE: these are the *in-config* timeouts, enforced by the agent and the
+# platform runner. They are unrelated to `msbench-cli run --timeout`, which is a
+# purely local wait — see README.md, "Timeouts". Do not add that flag.
+timeouts:
+  # describe -> requirements -> plan -> scaffold -> build -> run -> debug, all in
+  # ONE chat session. 1h45m is a per-turn budget, not a budget for the chain.
+  #
+  # Budget, NOT an independent knob. The agent clock starts *after* the job clock
+  # (container pull, VS Code + VSIX install, workspace setup, the `script:`
+  # preamble all precede the first turn), so agentSeconds must leave room for
+  # both that head start and the grace period below — otherwise the job is killed
+  # first, the agent timeout never fires, runnerGraceSeconds never runs, and
+  # nothing is flushed on exactly the runs that need diagnosing:
+  #
+  #   6h job cap - ~15m setup - 15m grace => 5h agent, with margin
+  #
+  # Re-derive this if the cap is ever confirmed. GitHub documents a 6h cap for
+  # hosted runners and 5 days for self-hosted; runs report `dispatched to GitHub
+  # Actions` with run_platform='linux_container', but we could NOT verify which
+  # pool MSBench uses — that is decided by a server-side workflow we cannot read.
+  # 6h is assumed because it is the safer of the two. Raising it needs
+  # confirmation from CodeExService@microsoft.com.
+  agentSeconds: 18000 # 5h
+  # The trap. This is not agent inactivity — it fires only when the agent trace,
+  # the CAPI proxy log, the Copilot Chat log AND workspace file activity are all
+  # quiet. `npm install`, `azd provision`, a build or a test suite produce none
+  # of those four for minutes at a time, so a perfectly healthy run gets killed
+  # for looking idle. Quiet is not the same as stuck.
+  stallSeconds: 5400 # 90m
+  # Time the outer runner allows for cleanup after the agent timeout. A long
+  # session has far more to flush than a 5-step one (screen recording,
+  # trajectory, session.sqlite), and a truncated artifact is an unreadable
+  # result — the run cost is paid either way, so buy the flush.
+  runnerGraceSeconds: 900 # 15m
+
 installExtensions:
   - id: ms-azuretools.vscode-azureresourcegroups
     mode: vsix


### PR DESCRIPTION
## The failure this prevents

Every MSBench stimulus we have today is **single-turn**: ask for requirements, check the artifact, done. A few minutes, start to finish. We're about to start running the **whole chain in one session** — describe → requirements → plan → scaffold → build → run → debug — which includes long, quiet steps like `npm install`, `azd provision`, builds and test suites.

MSBench's default timeouts are tuned for the short case. The one that bites is **`stallSeconds`**, and it is not what its name suggests. It is *not* an inactivity timeout on the agent. Per the schema it fires when there is **"no agent trace, CAPI proxy log, Copilot Chat log, or workspace file activity"** — all four quiet at once. A five-minute `npm install` produces none of the four. So a perfectly healthy run, doing exactly what we asked it to do, gets killed for looking idle, and the result reads as a product failure rather than a harness one. **Quiet is not the same as stuck.**

## The change

Six lines of YAML in `evals/msbench/config/base.yaml`, plus comments and a README section.

| Key | Default | New | Why |
| --- | --- | --- | --- |
| `agentSeconds` | 6300 (1h45m) | **18000 (5h)** | 1h45m is a budget for **one turn**. The E2E chain is seven phases in a single session. Sized to fit *inside* the job cap — see below. |
| `stallSeconds` | 2700 (45m) | **5400 (90m)** | See above — headroom for the longest legitimately silent step. |
| `runnerGraceSeconds` | 300 (5m) | **900 (15m)** | A long session has far more state to flush at the end (screen recording, trajectory, `session.sqlite`) than a 5-step run. The run cost is paid either way; a truncated artifact just makes it unreadable. |

**These are one budget, not three independent knobs.** The job clock starts before the agent clock — container pull, VS Code and VSIX install, workspace setup and the `script:` preamble all precede the agent's first turn. Set `agentSeconds` to the full job cap and the job gets killed *first*: the agent timeout never fires, so `runnerGraceSeconds` (which only runs *after* the agent timeout) never runs either, and nothing is flushed on exactly the runs you most need to diagnose. Hence the arithmetic, which is in the config comment so the next person can re-derive it:

```
6h job cap − ~15m setup − 15m grace ⇒ 5h agent
```

## Verified vs. assumed

**Verified:**

- The schema (`TestConfig.schema.json` in `vscode-copilot-evaluation`, referenced at the top of `base.yaml`) gives all three keys a `maximum` of `9007199254740991`. Nothing here is schema-constrained. I validated the generated `user-overrides.yaml` against the real schema with `jsonschema` — it passes.
- **`msbench-cli run --timeout` is a completely different thing and must not be confused with these.** From `cli/arguments.py`: *"Max seconds to wait locally for completion. When reached, the CLI attempts to cancel the CES run, downloads partial results, and exits with a timeout error."* `_handle_timeout` in `execution/ces_client.py` confirms it — partial download, then `cancel_run`. It gives a run **less** time, not more: it ends a still-healthy run early. It defaults to `None`, `run.sh` does not pass it, and the README now says so explicitly so nobody "helpfully" adds it later.

**Assumed — flagged in both the code comment and here:**

- **I could not verify the job limit for MSBench's actual pool.** GitHub *documents* a 6h cap for hosted runners and 5 days for self-hosted. Our runs report `dispatched to GitHub Actions` with `run_platform='linux_container'`, but which runner pool that workflow targets is decided server-side and isn't visible from the CLI source or from `vscode-copilot-evaluation`. The 6h figure in the arithmetic above is an **assumption**, taken because it's the safer of the two documented limits. **Raising it past 6h needs confirmation from the MSBench team (CodeExService@microsoft.com)** — and if the cap is ever confirmed, re-derive `agentSeconds` from the arithmetic rather than just bumping it.

## Scope

Two files: `evals/msbench/config/base.yaml` and `evals/msbench/README.md`. No model, stimuli, `run.sh` or layout changes.

**No MSBench run was submitted**; this is verifiable by reading the schema and the CLI source, and runs cost real money on a shared, rate-limited resource.

> ⚠️ **CI note:** `Build / Build` is red here for an unrelated, pre-existing reason — `npm run lint` already fails on `feat/CoR` itself because #1696 converted `evals/` to TypeScript without updating the eslint glob. That is fixed separately in #1705; this PR goes green once #1705 merges. Nothing in this diff touches it.
