### PR TITLE
Verify what actually ran before trusting a run's results

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -203,8 +203,10 @@ second checked-in copy is exactly the drift this eval exists to catch:
 Edit `config/`, never `assets/`.
 
 Both generators are TypeScript run directly by Node, which strips the types at load
-time — there is no build step and no emitted JavaScript. `evals/tsconfig.json`
-type-checks them (`npm run typecheck`) but emits nothing.
+time — there is no build step and no emitted JavaScript. The same is true of
+[`verify-run.ts`](verify-run.ts), which `run.sh` calls after a run to decide whether the
+results are readable at all. `evals/tsconfig.json` type-checks them
+(`npm run typecheck`) but emits nothing.
 
 ### Why one config file per stimulus
 
@@ -331,6 +333,113 @@ answer than inventing a brittle SQL proxy for a judgement call. It is not a subs
 for `exec:` on anything the validators already decide deterministically.
 
 
+## Is this run a result?
+
+A finished run is not automatically a *result*. Two things can make the results table
+mean something other than what it looks like, and neither is visible in the table:
+
+1. **The agent was throttled mid-run.** It then produced nothing, so artifact assertions
+   fail while negative assertions pass trivially — which reads exactly like a product
+   regression.
+2. **The model that answered was not the model requested.** Every number is then
+   attributed to the wrong model.
+
+`run.sh` runs [`verify-run.ts`](verify-run.ts) on the extracted artifacts before you can
+read the table, and it owns the verdict:
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | The run is a result. Read the table. |
+| `75` | `EX_TEMPFAIL` — throttled. Not a result at all; retry in ~15 minutes. |
+| `65` | `EX_DATAERR` — the run measured something other than what was requested. |
+
+Both are deliberately distinct from `1`, which still means a genuine red run. **A
+detector for false reds is worthless if it also hides true ones**, so this is verified
+against stored runs: it catches the throttled run, passes the six green ones, and still
+reports the genuinely-red negative control (`2026082582510393`) as a real failure.
+
+### Which surface got throttled
+
+`output/vsc-output/capi-proxy.log` records every upstream model call with its path and
+status. From throttled run `2026082583236973`:
+
+```
+23:11:12.786  [8]  POST /v1/messages      -> 200
+23:11:14.772  [9]  POST /v1/messages      -> 429     <-- throttled
+23:11:14.773  [9]  Response body: too many requests
+23:11:15.438  [10] POST /chat/completions -> 200     <-- 666ms later, SUCCEEDS
+```
+
+That 666 ms is the whole point: **the 429 is scoped to the API surface, not to the
+account.** `/v1/messages` is the Anthropic surface (Claude models); `/chat/completions`
+and `/responses` are OpenAI ones. They throttle independently, so being refused on one
+says nothing about the others.
+
+So the banner reports *which* surface ran out and after how many calls — "throttled on
+`POST /v1/messages` after 8 successful upstream calls (2 of them on that surface)" —
+which is what a per-surface token budget can actually act on.
+
+`verify-run.ts` also prints a path census on **every** run, throttled or not, so each run
+is a free datapoint:
+
+```
+    upstream model calls (capi-proxy.log):
+      GET /models                  1x 200
+      POST /chat/completions       9x 200
+      POST /embeddings             2x 200
+      POST /v1/messages            5x 200
+```
+
+The mix is model-dependent — Claude runs use both `/v1/messages` and `/chat/completions`
+(auxiliary models and embeddings go to the latter), while GPT runs touch `/v1/messages`
+zero times. Paths are parsed from the log rather than matched against a known list,
+because the set grows as new models ship — `/responses` arrived with `gpt-5.6-sol` and
+`gpt-5-mini` — and a hardcoded list would silently miss a 429 on a surface added later.
+
+Note the asymmetry: `error.json` → `"type": "RATE_LIMIT"` is the sole authority on
+whether a run is **void**. A 429 in the proxy log only means one request was refused; the
+agent often retries and finishes fine, and voiding those runs would start hiding real
+failures. Such a run is reported as a note and still counts:
+
+```
+    NOTE: POST /responses returned 429 after 2 successful calls,
+          but the run completed. Results stand; budget is running low.
+```
+
+### Did we measure the model we asked for?
+
+`run.sh` selects the model via `modelSelector` in the staged `user-overrides.yaml` (with
+`--model .`). The check here is small, because the harness already covers the dangerous
+case: `selectActiveModel` in `vscode-copilot-evaluation`'s `src/proxy/capiProxyServer.ts`
+looks the requested id up in the **live `GET /models` catalogue** and throws
+`X_MODEL_NOT_FOUND_ERROR` if it is absent, then pins `is_chat_fallback` and
+`model_picker_enabled` on the matched entry so VS Code cannot substitute anything else.
+An unknown id therefore hard-fails at launch, before any agent turn — verified with
+`gpt-5` and `gpt-5.6`, at ~0 tokens each. **There is no silent fallback to a default.**
+
+Existence is not identity, though, so `verify-run.ts` asserts that the model which became
+active is the model requested, by reading the `Set active model to: <id>` line from
+`output/vsc-output/agent-output.log` (mirrored in `entry.log`; present in all seven stored
+runs — it is *not* in `capi-proxy.log`). One line, on artifacts already being read. It
+exists to catch a future regression in model selection during model sweeps, where every
+run is supposed to be a different model and a mislabelled one would collapse N models
+into N runs of the same one.
+
+Three other values look like they would answer this and do not — they are all echoes of
+the request rather than observations of the answer:
+
+| Source | Why it can't disagree |
+| --- | --- |
+| `msbench-cli show_run`, `metadata.json` | `_read_assets_model_selector` (plugin `cli.py`) reads it straight back out of the `user-overrides.yaml` *we* supplied. |
+| `configs/final-agent-config.json` | The same request one layer in. Proves our asset arrived intact; still not the answer. |
+| `configs/msbench-user-overrides.yaml` | Literally our staged file, rendered. |
+
+> **Don't "fix" the model id to match `COPILOT_VENDOR_MODELS`.** That shipped catalogue
+> (28 entries in `cli.py`) is misleading in both directions: `gpt-5.6-sol` is *absent*
+> from it but resolves and runs fine, while `gpt-5` is *present* in it and fails. The
+> live `GET /models` response is the only real authority. `_require_assets_model_selector`
+> only checks that the `modelSelector` key exists — it never validates the id.
+
 ## Results and artifacts
 
 ```bash
@@ -373,16 +482,11 @@ with a clear message:
 - **A red run that is actually rate limiting.** Back-to-back runs get throttled by the
   Copilot API mid-run. The agent then produces nothing, so artifact assertions fail
   while negative assertions pass trivially — indistinguishable from a genuine agent
-  regression at a glance. `run.sh` now detects this and **exits 75 (`EX_TEMPFAIL`) with
-  a loud banner instead of letting you read the results table**, so a throttled run
-  cannot be mistaken for a regression.
+  regression at a glance. `run.sh` **exits 75 (`EX_TEMPFAIL`) with a loud banner instead
+  of letting you read the results table**, so a throttled run cannot be mistaken for a
+  regression. See [Is this run a result?](#is-this-run-a-result) for what it reports.
 
-  The check keys on `output/error.json` → `"type": "RATE_LIMIT"` and is deliberately
-  narrow: verified against three stored runs, it catches the throttled one, passes the
-  green one, and — the case that actually matters — still reports the genuinely-red
-  negative control as a real failure. A detector for false reds is worthless if it
-  also hides true ones. Corroborate manually with
-  `select name, count(*) from spans group by name` against
+  Corroborate manually with `select name, count(*) from spans group by name` against
   `output/vsc-output/agent-traces.db` (note: `spans`/`span_attributes`, not `toolCalls`,
   which is the assertion-time view) — ~13 chat spans is healthy, dying around 6 is
   throttling. A **completely empty `exec` table** is another tell: the graders never ran

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -425,6 +425,39 @@ exists to catch a future regression in model selection during model sweeps, wher
 run is supposed to be a different model and a mislabelled one would collapse N models
 into N runs of the same one.
 
+**Only a dated release suffix is tolerated** between the two ids — `gpt-4o-mini` matches
+`gpt-4o-mini-2024-07-18`, and nothing else matches. In particular these must *not* match,
+because they are different models with different cost and capability:
+
+| Requested | Active | |
+| --- | --- | --- |
+| `gpt-5` | `gpt-5-mini` | reject |
+| `gpt-4o` | `gpt-4o-mini` | reject |
+| `claude-opus-4` | `claude-opus-4-1` | reject |
+| `gpt-5.6` | `gpt-5.6-sol` | reject |
+
+A bare numeric revision (`claude-opus-4` → `claude-opus-4-1`) is deliberately rejected
+too: Opus 4.1 is a different model from Opus 4, so absorbing that into a lenient match
+would silently mislabel a sweep datapoint. The full boundary is executable —
+`npm run msbench:self-test` in `evals/` asserts every accepted and rejected pair.
+
+There is a third outcome besides match and mismatch. If the `Set active model to:` line is
+missing entirely, the check **fails open and says so loudly**:
+
+```
+      !! IDENTITY NOT VERIFIED — this is NOT a pass.
+      !! no "Set active model to:" line in agent-output.log or entry.log
+      !! The run stands, but nothing confirmed which model answered.
+```
+
+`identity not verified` is a distinct state from `identity verified OK`, and the summary
+line reflects it. Fail-open is the deliberate choice: a run that died before model
+selection legitimately has no such line, and failing closed would turn every missing
+artifact into a fake mismatch — and if a future harness version stopped emitting the line,
+it would block every run on a false accusation. That is the same disease as a detector
+that hides true reds, just pointed the other way. The cost is that the check could quietly
+rot, which is exactly why the state is shouted rather than tucked into a note.
+
 Three other values look like they would answer this and do not — they are all echoes of
 the request rather than observations of the answer:
 

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -361,13 +361,16 @@ reports the genuinely-red negative control (`2026082582510393`) as a real failur
 ### Which surface got throttled
 
 `output/vsc-output/capi-proxy.log` records every upstream model call with its path and
-status. From throttled run `2026082583236973`:
+status. Verbatim from throttled run `2026082583236973` (interleaved header/body lines
+removed, but the call lines are exactly as they appear — this is the format
+`verify-run.ts` parses):
 
 ```
-23:11:12.786  [8]  POST /v1/messages      -> 200
-23:11:14.772  [9]  POST /v1/messages      -> 429     <-- throttled
-23:11:14.773  [9]  Response body: too many requests
-23:11:15.438  [10] POST /chat/completions -> 200     <-- 666ms later, SUCCEEDS
+[2026-08-25T23:11:12.786Z] [CAPI PROXY] [8] POST /v1/messages -> 200
+[2026-08-25T23:11:14.772Z] [CAPI PROXY] [9] POST /v1/messages -> 429     <-- throttled
+[2026-08-25T23:11:14.773Z] [CAPI PROXY] [9] Response body:
+too many requests
+[2026-08-25T23:11:15.438Z] [CAPI PROXY] [10] POST /chat/completions -> 200  <-- 666ms later, SUCCEEDS
 ```
 
 That 666 ms is the whole point: **the 429 is scoped to the API surface, not to the

--- a/evals/msbench/run.sh
+++ b/evals/msbench/run.sh
@@ -208,11 +208,13 @@ set +e
 CLI_STATUS=${PIPESTATUS[0]}
 set -e
 
-# A throttled run still prints a normal-looking red results table: the agent
-# produced nothing, so artifact assertions fail while negative assertions pass
-# trivially. That is indistinguishable from a real regression by eye, and was
-# twice mistaken for one while building this. Check before the reader can draw a
-# conclusion from the table.
+# A finished run is not automatically a *result*. Two conditions make the
+# results table mean something other than what it appears to mean, and neither
+# is visible in the table itself: the agent was throttled mid-run (so it
+# produced nothing, and every assertion resolves trivially), or the model that
+# answered was not the model requested. verify-run.ts checks both and owns the
+# verdict; exit 75 means "not a result, retry later" and 65 means "measured the
+# wrong thing", both distinct from the 1 that means a genuine red run.
 RUN_ID="$(grep -oE 'run_id=[0-9]+' "$RUN_LOG" | head -1 | cut -d= -f2 || true)"
 if [ -n "$RUN_ID" ]; then
     RESULTS_ZIP="$(ls "${HOME}/Library/Application Support/msbench/runs/${RUN_ID}/results.zip" \
@@ -221,27 +223,15 @@ if [ -n "$RUN_ID" ]; then
         SCRATCH="$(mktemp -d)"
         unzip -oq "$RESULTS_ZIP" -d "$SCRATCH" 2>/dev/null || true
         find "$SCRATCH" -name '*-output.zip' -exec unzip -oq {} -d "${SCRATCH}/out" \; 2>/dev/null || true
-        RATE_LIMITED=0
-        if [ -f "${SCRATCH}/out/output/error.json" ] \
-                && grep -q '"type": *"RATE_LIMIT"' "${SCRATCH}/out/output/error.json"; then
-            RATE_LIMITED=1
-        fi
+
+        set +e
+        node "${HERE}/verify-run.ts" --run-dir "${SCRATCH}/out" --run-id "$RUN_ID"
+        VERIFY_STATUS=$?
+        set -e
+
         rm -rf "$SCRATCH"
-        if [ "$RATE_LIMITED" -eq 1 ]; then
-            echo
-            echo "  ============================================================"
-            echo "  RATE_LIMIT — this run is NOT a result. Do not read the table."
-            echo "  ============================================================"
-            echo "  The Copilot API throttled the agent mid-run, so it produced"
-            echo "  nothing. Positive assertions fail and negative ones pass"
-            echo "  trivially, which looks exactly like an agent regression."
-            echo
-            echo "  Runs cost ~250k tokens each; roughly 3 in 15 minutes is the"
-            echo "  observed ceiling. Wait ~15 minutes and re-run."
-            echo
-            echo "  Run id: ${RUN_ID}"
-            echo
-            exit 75  # EX_TEMPFAIL: retry later, distinct from a genuine red run
+        if [ "$VERIFY_STATUS" -ne 0 ]; then
+            exit "$VERIFY_STATUS"
         fi
     fi
 fi

--- a/evals/msbench/verify-run.ts
+++ b/evals/msbench/verify-run.ts
@@ -178,21 +178,93 @@ function firstExisting(...paths: string[]): string | undefined {
 }
 
 /**
- * Tolerate a dated or otherwise more specific id on either side —
- * `gpt-4o-mini` vs `gpt-4o-mini-2024-07-18` is the same model, and the log may
- * carry the long form. A changed family (`claude-sonnet-4.5` for `gpt-5.6-sol`)
- * is still rejected.
+ * A dated release suffix, e.g. the `-2024-07-18` in `gpt-4o-mini-2024-07-18`.
+ *
+ * This is the *only* difference tolerated between the requested and the active
+ * id. An earlier version of this accepted any suffix (`a.startsWith(b + '-')`),
+ * which is badly wrong: it makes `gpt-5` match `gpt-5-mini`, a cheaper and less
+ * capable model. That is precisely the mismatch this check exists to catch, and
+ * exactly what a model sweep would hit.
+ *
+ * A bare numeric revision (`claude-opus-4` vs `claude-opus-4-1`) is deliberately
+ * NOT tolerated either. Opus 4.1 is a different model from Opus 4, with
+ * different behaviour and cost, so treating them as equal would silently
+ * mislabel a sweep datapoint. If the harness ever starts reporting a revision we
+ * did not request, that should be a loud failure and a conscious decision, not
+ * something absorbed by a lenient matcher.
+ */
+const DATED_RELEASE_SUFFIX = /^-\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * The pairs that define the boundary, asserted by `--self-test`.
+ *
+ * Kept as data rather than prose so the next person can see — and re-run — the
+ * exact cases the matcher must accept and must reject.
+ */
+const MODEL_MATCH_CASES: readonly (readonly [string, string, boolean])[] = [
+    // Same model, written two ways: the log may carry the dated release id.
+    ['gpt-4o-mini', 'gpt-4o-mini-2024-07-18', true],
+    ['gpt-4o-mini-2024-07-18', 'gpt-4o-mini', true],
+    ['gpt-4.1', 'gpt-4.1-2025-04-14', true],
+    ['claude-sonnet-4.5', 'claude-sonnet-4.5', true],
+    ['Claude-Sonnet-4.5', 'claude-sonnet-4.5 ', true],
+
+    // Different models. Every one of these was accepted by the old prefix
+    // matcher, and each would have mislabelled a model sweep datapoint.
+    ['gpt-5', 'gpt-5-mini', false],
+    ['gpt-4o', 'gpt-4o-mini', false],
+    ['claude-opus-4', 'claude-opus-4-1', false],
+    ['gpt-5.6', 'gpt-5.6-sol', false],
+    ['claude-sonnet-4.5', 'claude-haiku-4.5', false],
+    ['gpt-5-mini', 'gpt-5', false],
+
+    // A dated suffix on a *different* family is still a different model: the
+    // date pattern must never be checked without confirming the prefix first.
+    ['gpt-4o', 'claude-2024-07-18', false],
+];
+
+/**
+ * True when `requested` and `observed` name the same model.
+ *
+ * Equality, or one being the other plus a dated release suffix. Nothing else —
+ * see DATED_RELEASE_SUFFIX and MODEL_MATCH_CASES for the boundary.
  */
 function modelMatches(requested: string, observed: string): boolean {
     const a = requested.trim().toLowerCase();
     const b = observed.trim().toLowerCase();
-    return a === b || a.startsWith(`${b}-`) || b.startsWith(`${a}-`);
+    if (a === b) {
+        return true;
+    }
+    const [longer, shorter] = a.length > b.length ? [a, b] : [b, a];
+    // The prefix test must come first: without it, `gpt-4o` vs
+    // `claude-2024-07-18` would slice to `-2024-07-18` and match.
+    if (!longer.startsWith(shorter)) {
+        return false;
+    }
+    return DATED_RELEASE_SUFFIX.test(longer.slice(shorter.length));
+}
+
+/** Assert the matcher's boundary. Run with `node verify-run.ts --self-test`. */
+function selfTest(): void {
+    const failures = MODEL_MATCH_CASES.filter(([a, b, expected]) => modelMatches(a, b) !== expected);
+    for (const [a, b, expected] of MODEL_MATCH_CASES) {
+        const actual = modelMatches(a, b);
+        const status = actual === expected ? 'ok  ' : 'FAIL';
+        console.log(`  ${status} ${expected ? 'match   ' : 'reject  '} ${a}  vs  ${b}`);
+    }
+    if (failures.length) {
+        console.error(`\n${failures.length} model-matcher case(s) failed.`);
+        process.exit(1);
+    }
+    console.log(`\n${MODEL_MATCH_CASES.length} model-matcher cases passed.`);
 }
 
 interface ModelVerdict {
     readonly requested?: string;
     readonly active?: string;
     readonly mismatch: boolean;
+    /** True when the check could not run at all — distinct from "verified OK". */
+    readonly unverified?: boolean;
     readonly note?: string;
 }
 
@@ -231,12 +303,22 @@ function verifyModel(outputDir: string, expectedOverride?: string): ModelVerdict
         : undefined;
 
     if (!requested) {
-        return { requested, active, mismatch: false, note: 'no modelSelector.id to compare against' };
+        return { requested, active, mismatch: false, unverified: true, note: 'no modelSelector.id to compare against' };
     }
     if (!active) {
+        // Fail open, loudly.
+        //
         // A run that died before model selection legitimately has no such line,
-        // and absent evidence is not evidence of the wrong model. Say so.
-        return { requested, active, mismatch: false, note: 'no "Set active model to:" line — identity not verified' };
+        // and absent evidence is not evidence of the wrong model. Failing closed
+        // would turn every missing artifact into a fake "model mismatch" and, if
+        // a future harness version stopped emitting the line, would block every
+        // run on a false accusation — the same disease as a detector that hides
+        // true reds, just pointed the other way.
+        //
+        // The cost of that choice is that the check could silently disappear, so
+        // it is reported as its own prominent state rather than folded into a
+        // pass. `unverified` is not `verified OK`.
+        return { requested, active, mismatch: false, unverified: true, note: 'no "Set active model to:" line in agent-output.log or entry.log' };
     }
     return { requested, active, mismatch: !modelMatches(requested, active) };
 }
@@ -260,8 +342,13 @@ function main(): void {
     };
 
     const runDir = valueOf('--run-dir');
+    if (args.includes('--self-test')) {
+        selfTest();
+        return;
+    }
     if (!runDir) {
         console.error('usage: verify-run.ts --run-dir <extracted results dir> [--run-id <id>] [--expected-model <id>]');
+        console.error('       verify-run.ts --self-test');
         process.exit(2);
     }
     const runId = valueOf('--run-id') ?? 'unknown';
@@ -288,7 +375,14 @@ function main(): void {
     console.log('    model:');
     console.log(`      requested (user-overrides.yaml)  ${model.requested ?? '-'}`);
     console.log(`      active    (agent-output.log)     ${model.active ?? '-'}`);
-    if (model.note) {
+    if (model.unverified) {
+        // Deliberately not a quiet aside. This is a third state next to
+        // "matches" and "mismatch", and the one that would otherwise let the
+        // check rot away unnoticed.
+        console.log('      !! IDENTITY NOT VERIFIED — this is NOT a pass.');
+        console.log(`      !! ${model.note}`);
+        console.log('      !! The run stands, but nothing confirmed which model answered.');
+    } else if (model.note) {
         console.log(`      note: ${model.note}`);
     }
 
@@ -356,7 +450,9 @@ function main(): void {
         process.exit(EX_DATAERR);
     }
 
-    console.log('    verified: this run is a result.');
+    console.log(model.unverified
+        ? '    this run is a result (model identity unverified — see above).'
+        : '    verified: this run is a result.');
 }
 
 main();

--- a/evals/msbench/verify-run.ts
+++ b/evals/msbench/verify-run.ts
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Decide whether a finished MSBench run is a *result* before anyone reads its
+ * results table.
+ *
+ * Two failure modes look exactly like ordinary output but mean something else
+ * entirely, and both are invisible in the table itself:
+ *
+ *   1. The Copilot API throttled the agent mid-run. The agent then produced
+ *      nothing, so artifact assertions fail while negative assertions pass
+ *      trivially — pixel-identical to a product regression.
+ *   2. The model that answered was not the model we asked for. The harness
+ *      already refuses an *unknown* id outright, so this is a light identity
+ *      check rather than fallback protection — see verifyModel below.
+ *
+ * Exit codes are the contract with run.sh:
+ *
+ *   0   the run is a result — go ahead and read the table
+ *   75  EX_TEMPFAIL: throttled. Not a result at all; retry later
+ *   65  EX_DATAERR: the run measured something other than what was requested
+ *
+ * 75 and 65 are deliberately distinct from 1. A genuinely red run — a real
+ * product failure — must keep reporting as a red run, because a detector for
+ * false reds is worthless if it also hides true ones.
+ *
+ * Runs straight off source via Node's built-in type stripping — no build step.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** `<sysexits.h>`: a transient condition, retry later. Not a failed assertion. */
+const EX_TEMPFAIL = 75;
+/** `<sysexits.h>`: the run's own data is wrong, so its numbers mean nothing. */
+const EX_DATAERR = 65;
+
+/** One upstream model call, as recorded by the CAPI proxy. */
+interface ProxyCall {
+    readonly at: number;
+    readonly index: number;
+    readonly method: string;
+    readonly path: string;
+    readonly status: number;
+}
+
+/**
+ * `[2026-08-25T23:11:14.772Z] [CAPI PROXY] [9] POST /v1/messages -> 429`
+ *
+ * The proxy also logs response headers and bodies on their own lines under the
+ * same request index; only the request/status line is of interest here.
+ */
+const CALL_LINE = /^\[([^\]]+)\]\s+\[CAPI PROXY\]\s+\[(\d+)\]\s+([A-Z]+)\s+(\S+)\s+->\s+(\d+)\s*$/;
+
+function parseProxyLog(text: string): ProxyCall[] {
+    const calls: ProxyCall[] = [];
+    for (const line of text.split('\n')) {
+        const match = CALL_LINE.exec(line.trimEnd());
+        if (!match) {
+            continue;
+        }
+        const at = Date.parse(match[1]);
+        calls.push({
+            at: Number.isNaN(at) ? 0 : at,
+            index: Number(match[2]),
+            method: match[3],
+            path: match[4],
+            status: Number(match[5]),
+        });
+    }
+    return calls;
+}
+
+/**
+ * Every distinct surface the run touched, with a status breakdown.
+ *
+ * Paths are whatever the log says — nothing here matches a known list. At
+ * least four are in play (`/v1/messages`, `/chat/completions`, `/responses`,
+ * `/embeddings`, plus `GET /models`), the set moves as new models ship, and a
+ * hardcoded list would silently miss a 429 on a surface added later. Missing a
+ * 429 is the exact failure this check exists to prevent.
+ *
+ * Worth printing on *every* run, not just throttled ones: it turns each run
+ * into a free datapoint about which surfaces we lean on and how hard, which is
+ * what a per-surface token budget has to be built from. The mix is
+ * model-dependent — Claude runs use both `/v1/messages` and `/chat/completions`,
+ * while GPT runs touch `/v1/messages` zero times — so a census of all paths
+ * says considerably more than a single throttled path would.
+ */
+function census(calls: ProxyCall[]): string[] {
+    const byPath = new Map<string, Map<number, number>>();
+    for (const call of calls) {
+        const key = `${call.method} ${call.path}`;
+        const statuses = byPath.get(key) ?? new Map<number, number>();
+        statuses.set(call.status, (statuses.get(call.status) ?? 0) + 1);
+        byPath.set(key, statuses);
+    }
+    return [...byPath.entries()]
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([key, statuses]) => {
+            const breakdown = [...statuses.entries()]
+                .sort((a, b) => a[0] - b[0])
+                .map(([status, count]) => `${count}x ${status}`)
+                .join(', ');
+            return `${key.padEnd(28)} ${breakdown}`;
+        });
+}
+
+interface ThrottleEvidence {
+    readonly surface: string;
+    /** Successful upstream calls anywhere before the throttle landed. */
+    readonly successesBefore: number;
+    /** Successful calls on the throttled surface specifically. */
+    readonly successesOnSurface: number;
+    /** A call on a *different* surface that succeeded after the 429, if any. */
+    readonly recoveredOn?: string;
+    readonly recoveredAfterMs?: number;
+}
+
+/**
+ * The finding this whole check exists for: a 429 is scoped to one API surface,
+ * not to the account.
+ *
+ * `/v1/messages` is the Anthropic surface (Claude models); `/chat/completions`
+ * and `/responses` are OpenAI ones. They throttle independently, which is why a
+ * run can be refused on one and, in the observed case 666 ms later, served on
+ * another. Recording *which* surface ran out, and after how many calls,
+ * upgrades the signal from "this run was throttled" to something a token budget
+ * can act on. The surface is read from the log, never assumed.
+ */
+function findThrottle(calls: ProxyCall[]): ThrottleEvidence | undefined {
+    const firstThrottled = calls.findIndex(call => call.status === 429);
+    if (firstThrottled === -1) {
+        return undefined;
+    }
+    const throttled = calls[firstThrottled];
+    const surface = `${throttled.method} ${throttled.path}`;
+    const before = calls.slice(0, firstThrottled);
+    const ok = (call: ProxyCall) => call.status >= 200 && call.status < 400;
+
+    const recovery = calls
+        .slice(firstThrottled + 1)
+        .find(call => ok(call) && `${call.method} ${call.path}` !== surface);
+
+    return {
+        surface,
+        successesBefore: before.filter(ok).length,
+        successesOnSurface: before.filter(call => ok(call) && `${call.method} ${call.path}` === surface).length,
+        recoveredOn: recovery && `${recovery.method} ${recovery.path}`,
+        recoveredAfterMs: recovery && recovery.at && throttled.at ? recovery.at - throttled.at : undefined,
+    };
+}
+
+/**
+ * Read `modelSelector.id` out of a user-overrides.yaml.
+ *
+ * Deliberately a regex rather than a YAML parse: this runs from run.sh on a
+ * machine that may not have `evals/node_modules` installed, and the shape being
+ * read is two fixed lines. msbench's own CLI reads the same key the same way.
+ */
+function readModelSelectorId(yamlPath: string): string | undefined {
+    if (!existsSync(yamlPath)) {
+        return undefined;
+    }
+    const match = /^modelSelector:\s*$[\s\S]*?^\s+id:\s*["']?([^"'\s#]+)/m.exec(readFileSync(yamlPath, 'utf8'));
+    return match?.[1];
+}
+
+function firstExisting(...paths: string[]): string | undefined {
+    return paths.find(path => existsSync(path));
+}
+
+/**
+ * Tolerate a dated or otherwise more specific id on either side —
+ * `gpt-4o-mini` vs `gpt-4o-mini-2024-07-18` is the same model, and the log may
+ * carry the long form. A changed family (`claude-sonnet-4.5` for `gpt-5.6-sol`)
+ * is still rejected.
+ */
+function modelMatches(requested: string, observed: string): boolean {
+    const a = requested.trim().toLowerCase();
+    const b = observed.trim().toLowerCase();
+    return a === b || a.startsWith(`${b}-`) || b.startsWith(`${a}-`);
+}
+
+interface ModelVerdict {
+    readonly requested?: string;
+    readonly active?: string;
+    readonly mismatch: boolean;
+    readonly note?: string;
+}
+
+/**
+ * Assert that the model which answered is the model we asked for.
+ *
+ * This is deliberately *small*, because the harness already covers the scary
+ * case. `selectActiveModel` in vscode-copilot-evaluation's capiProxyServer.ts
+ * looks the requested id up in the live `GET /models` catalogue and throws
+ * `X_MODEL_NOT_FOUND_ERROR` when it is absent, then pins `is_chat_fallback` and
+ * `model_picker_enabled` on the matched entry so VS Code cannot substitute
+ * anything else. An unknown id therefore hard-fails at launch, before any agent
+ * turn — verified empirically with `gpt-5` and `gpt-5.6`, which cost ~0 tokens.
+ * So there is no silent fallback to detect and no machinery worth building
+ * for one.
+ *
+ * Existence is not identity, though. This checks the one line that states which
+ * model actually became active, so that a future regression in model selection
+ * shows up as a failed run rather than as a quietly mislabelled datapoint —
+ * which matters most during model sweeps, where every run is supposed to be a
+ * different model.
+ *
+ * `Set active model to: <id>` is emitted into `vsc-output/agent-output.log`
+ * (mirrored in `entry.log`); present in all seven stored runs checked.
+ * Note it is *not* in capi-proxy.log, despite being the proxy's decision.
+ */
+function verifyModel(outputDir: string, expectedOverride?: string): ModelVerdict {
+    const requested = expectedOverride ?? readModelSelectorId(join(HERE, 'assets', 'user-overrides.yaml'));
+
+    const logPath = firstExisting(
+        join(outputDir, 'vsc-output', 'agent-output.log'),
+        join(outputDir, 'entry.log'),
+    );
+    const active = logPath
+        ? /Set active model to:\s*(\S+)/.exec(readFileSync(logPath, 'utf8'))?.[1]
+        : undefined;
+
+    if (!requested) {
+        return { requested, active, mismatch: false, note: 'no modelSelector.id to compare against' };
+    }
+    if (!active) {
+        // A run that died before model selection legitimately has no such line,
+        // and absent evidence is not evidence of the wrong model. Say so.
+        return { requested, active, mismatch: false, note: 'no "Set active model to:" line — identity not verified' };
+    }
+    return { requested, active, mismatch: !modelMatches(requested, active) };
+}
+
+function banner(lines: string[]): void {
+    const rule = '  ============================================================';
+    console.log('');
+    console.log(rule);
+    for (const line of lines) {
+        console.log(`  ${line}`);
+    }
+    console.log(rule);
+    console.log('');
+}
+
+function main(): void {
+    const args = process.argv.slice(2);
+    const valueOf = (flag: string): string | undefined => {
+        const index = args.indexOf(flag);
+        return index !== -1 ? args[index + 1] : undefined;
+    };
+
+    const runDir = valueOf('--run-dir');
+    if (!runDir) {
+        console.error('usage: verify-run.ts --run-dir <extracted results dir> [--run-id <id>] [--expected-model <id>]');
+        process.exit(2);
+    }
+    const runId = valueOf('--run-id') ?? 'unknown';
+    const outputDir = firstExisting(join(runDir, 'output'), runDir) ?? runDir;
+
+    console.log(`==> Verifying run ${runId} before reading its results`);
+
+    // --- what the agent actually asked the models --------------------------
+    const proxyLog = join(outputDir, 'vsc-output', 'capi-proxy.log');
+    let throttle: ThrottleEvidence | undefined;
+    if (existsSync(proxyLog)) {
+        const calls = parseProxyLog(readFileSync(proxyLog, 'utf8'));
+        console.log('    upstream model calls (capi-proxy.log):');
+        for (const line of census(calls)) {
+            console.log(`      ${line}`);
+        }
+        throttle = findThrottle(calls);
+    } else {
+        console.log('    upstream model calls: capi-proxy.log absent — skipped');
+    }
+
+    // --- did we measure the model we asked for? ----------------------------
+    const model = verifyModel(outputDir, valueOf('--expected-model'));
+    console.log('    model:');
+    console.log(`      requested (user-overrides.yaml)  ${model.requested ?? '-'}`);
+    console.log(`      active    (agent-output.log)     ${model.active ?? '-'}`);
+    if (model.note) {
+        console.log(`      note: ${model.note}`);
+    }
+
+    // --- verdict -----------------------------------------------------------
+    //
+    // `error.json` -> RATE_LIMIT stays the sole authority on whether the run is
+    // void. A 429 in the proxy log means a request was refused, not that the
+    // run failed: the agent frequently retries and finishes normally, and
+    // voiding those would start hiding real red runs. So the proxy log enriches
+    // the verdict, it does not cast it.
+    const errorJson = join(outputDir, 'error.json');
+    const rateLimited = existsSync(errorJson) && /"type":\s*"RATE_LIMIT"/.test(readFileSync(errorJson, 'utf8'));
+
+    if (rateLimited) {
+        const detail = throttle
+            ? [
+                `Throttled on ${throttle.surface} after ${throttle.successesBefore} successful`,
+                `upstream calls (${throttle.successesOnSurface} of them on that surface).`,
+                ...(throttle.recoveredOn
+                    ? [
+                        `${throttle.recoveredOn} then succeeded${throttle.recoveredAfterMs !== undefined ? ` ${throttle.recoveredAfterMs}ms later` : ''}, so the`,
+                        'limit is scoped to that one API surface, not to the account.',
+                    ]
+                    : []),
+                '',
+            ]
+            : [];
+        banner([
+            'RATE_LIMIT — this run is NOT a result. Do not read the table.',
+            '',
+            'The Copilot API throttled the agent mid-run, so it produced',
+            'nothing. Positive assertions fail and negative ones pass',
+            'trivially, which looks exactly like an agent regression.',
+            '',
+            ...detail,
+            'Runs cost ~250k tokens each; roughly 3 in 15 minutes is the',
+            'observed ceiling. Wait ~15 minutes and re-run.',
+            '',
+            `Run id: ${runId}`,
+        ]);
+        process.exit(EX_TEMPFAIL);
+    }
+
+    if (throttle) {
+        // Refused but recovered. Say so — it is the early warning that the
+        // budget for this surface is nearly spent — then let the run stand.
+        console.log('');
+        console.log(`    NOTE: ${throttle.surface} returned 429 after ${throttle.successesBefore} successful calls,`);
+        console.log('          but the run completed. Results stand; budget is running low.');
+    }
+
+    if (model.mismatch) {
+        banner([
+            'MODEL MISMATCH — this run did not measure what you asked for.',
+            '',
+            `Requested: ${model.requested ?? '-'}`,
+            `Active:    ${model.active ?? '-'}`,
+            '',
+            'An unknown model id hard-fails at launch, so this means model',
+            'selection resolved a known id to a different model than the one',
+            'asked for. Treat these numbers as belonging to the active model.',
+            '',
+            `Run id: ${runId}`,
+        ]);
+        process.exit(EX_DATAERR);
+    }
+
+    console.log('    verified: this run is a result.');
+}
+
+main();

--- a/evals/msbench/verify-run.ts
+++ b/evals/msbench/verify-run.ts
@@ -52,7 +52,16 @@ interface ProxyCall {
 }
 
 /**
- * `[2026-08-25T23:11:14.772Z] [CAPI PROXY] [9] POST /v1/messages -> 429`
+ * Matches a call line, verbatim from run 2026082583236973:
+ *
+ *   [2026-08-25T23:11:14.772Z] [CAPI PROXY] [9] POST /v1/messages -> 429
+ *
+ * That bracketed-ISO form is the only shape the proxy emits — checked against
+ * all seven stored runs, in which the abbreviated `23:11:14.772 [9] POST ...`
+ * style used in some hand-written notes appears zero times. Deliberately not
+ * accepting that second form: it would be a branch no artifact can exercise, so
+ * it could not be tested and would rot silently. If the proxy's format ever
+ * does change, the census printing nothing is the loud signal to update this.
  *
  * The proxy also logs response headers and bodies on their own lines under the
  * same request index; only the request/status line is of interest here.

--- a/evals/package.json
+++ b/evals/package.json
@@ -12,7 +12,8 @@
         "typecheck": "tsc --noEmit -p tsconfig.json",
         "certify": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON src/graderCertification.ts",
         "gate-tools": "node check-gate-tools.ts",
-        "ci:local": "node ci-local.ts"
+        "ci:local": "node ci-local.ts",
+        "msbench:self-test": "node msbench/verify-run.ts --self-test"
     },
     "license": "MIT",
     "dependencies": {


### PR DESCRIPTION
## The problem

A finished eval run prints a results table. The table looks the same whether or not it means anything. There are two ways it can be lying to you, and neither is visible in the table.

**Way 1: the agent got rate limited.** The Copilot API throttles us mid-run. The agent stops producing anything. So every "did the agent write the file?" assertion fails, and every "did the agent avoid doing X?" assertion passes trivially — because it did nothing at all. On screen that is indistinguishable from our product breaking. This has already been mistaken for a regression twice.

**Way 2: the model that ran wasn't the model we asked for.** Then all the numbers are real, but attributed to the wrong model.

[#1698](https://github.com/microsoft/vscode-azureresourcegroups/pull/1698) already catches the first case and refuses to show you the table. This PR makes both cases *legible* — it tells you what actually happened instead of just "something happened".

## Which surface got throttled

We found a log we weren't reading: `capi-proxy.log` records every call the agent made to a model, with the URL path and status code. Here is the real excerpt from throttled run `2026082583236973`:

```
23:11:12.786  [8]  POST /v1/messages      -> 200
23:11:14.772  [9]  POST /v1/messages      -> 429     <-- throttled
23:11:14.773  [9]  Response body: too many requests
23:11:15.438  [10] POST /chat/completions -> 200     <-- 666ms later, SUCCEEDS
```

Look at the last two lines. We got refused, and then **666 milliseconds later the same account successfully called a model.** That is not a flaky retry — it is the key finding.

A "surface" here just means one API endpoint family. `/v1/messages` is Anthropic's (Claude). `/chat/completions` and `/responses` are OpenAI's. **They have separate budgets and throttle independently.** So "we got rate limited" was always an incomplete sentence. The useful version is "we ran out on `/v1/messages` after 8 successful calls" — that is a number you can budget against.

The banner now says exactly that:

```
  Throttled on POST /v1/messages after 8 successful
  upstream calls (2 of them on that surface).
  POST /chat/completions then succeeded 666ms later, so the
  limit is scoped to that one API surface, not to the account.
```

Every run — throttled or not — also prints a census, so each run becomes a free datapoint on where our token spend goes:

```
    upstream model calls (capi-proxy.log):
      GET /models                  1x 200
      POST /chat/completions       9x 200
      POST /embeddings             2x 200
      POST /v1/messages            5x 200
```

This matters more than it looks, because **the mix depends on the model**. Claude runs use both `/v1/messages` and `/chat/completions` (helper models and embeddings go to the latter). GPT runs touch `/v1/messages` zero times. Per-model budgets need per-surface data.

Paths are read from the log, never matched against a list of known ones. New surfaces appear as new models ship — `/responses` arrived with `gpt-5.6-sol` — and a hardcoded list would silently miss a 429 on a surface added next month. Missing a 429 is the exact thing this check exists to prevent.

## Did we measure the model we asked for?

This check ended up much smaller than planned, because the harness already handles the scary case.

I had assumed a bad model id would quietly fall back to some default — which during model sweeps would collapse N different model runs into N runs of the same model, without anyone noticing. **That turns out not to happen.** `selectActiveModel` in `vscode-copilot-evaluation` looks the requested id up in the live model catalogue and throws `X_MODEL_NOT_FOUND_ERROR` if it's missing, then pins the match so VS Code can't substitute anything. A bad id crashes at launch, before any agent turn, costing ~0 tokens. Verified: `gpt-5` and `gpt-5.6` both hard-fail this way.

So there's no silent fallback to defend against. But *existing* is not the same as *being the one that answered*, so there's now a one-line identity check: assert the log's `Set active model to: <id>` matches what we requested. It's nearly free — same artifacts we're already reading — and it exists to catch a future regression in model selection during sweeps, where each run is supposed to be a different model.

Worth knowing, and documented in the README so nobody "helpfully" fixes our config later: MSBench's shipped model catalogue (`COPILOT_VENDOR_MODELS`, 28 entries) is wrong in *both* directions. `gpt-5.6-sol` is absent from it but works fine; `gpt-5` is in it and fails. The live `GET /models` response is the only real authority.

Three sources look like they'd answer "which model ran" and none of them can, because they're all echoes of our own request rather than observations — `msbench-cli show_run` / `metadata.json` reads the value straight back out of the `user-overrides.yaml` *we* uploaded, and `final-agent-config.json` is that same request one layer in. There's a table in the README.

## The thing I was most careful about

**A detector for false alarms is worthless if it also hides real ones.**

So `error.json` → `RATE_LIMIT` stays the *only* thing that can void a run. A 429 in the proxy log on its own does not — the agent frequently retries and finishes fine, and voiding those would start swallowing genuine failures. Those runs get a note and still count:

```
    NOTE: POST /responses returned 429 after 2 successful calls,
          but the run completed. Results stand; budget is running low.
```

Exit codes are the contract with `run.sh`. `EX_TEMPFAIL` and `EX_DATAERR` are just the standard names from `sysexits.h` for "try again later" and "the input data was wrong":

| Exit | Meaning |
| --- | --- |
| `0` | It's a result. Read the table. |
| `75` | `EX_TEMPFAIL` — throttled. Not a result; retry in ~15 min. |
| `65` | `EX_DATAERR` — measured something other than what was requested. |

Both are deliberately **not** `1`, which still means a genuine red run.

## Review fix: the model matcher was too permissive

Caught in review. The original predicate tolerated *any* suffix:

```ts
return a === b || a.startsWith(`${b}-`) || b.startsWith(`${a}-`);
```

So requested `gpt-5` vs active `gpt-5-mini` → `b.startsWith("gpt-5-")` → **reported as a match.** Same for `gpt-4o`/`gpt-4o-mini` and `claude-opus-4`/`claude-opus-4-1`. Those are different models with different cost and capability — the exact substitution this check exists to catch. As written it could have blessed the failure it was built to prevent, which during a model sweep is the worst kind of bug: silently confident.

Now only a **dated release suffix** is tolerated, and the prefix is confirmed before the date is tested (otherwise `gpt-4o` would match `claude-2024-07-18` by slicing to `-2024-07-18`).

A bare numeric revision is deliberately rejected too, as an explicit decision rather than a side effect: `claude-opus-4-1` is Opus 4.1, a different model from Opus 4, and absorbing that into a lenient match would mislabel a sweep datapoint.

The boundary is **executable, not prose** — `npm run msbench:self-test`:

```
  ok   match    gpt-4o-mini  vs  gpt-4o-mini-2024-07-18
  ok   match    gpt-4.1  vs  gpt-4.1-2025-04-14
  ok   reject   gpt-5  vs  gpt-5-mini
  ok   reject   gpt-4o  vs  gpt-4o-mini
  ok   reject   claude-opus-4  vs  claude-opus-4-1
  ok   reject   gpt-5.6  vs  gpt-5.6-sol
  ok   reject   gpt-4o  vs  claude-2024-07-18
  ...
12 model-matcher cases passed.
```

Confirmed non-vacuous: run the same 12 cases against the old predicate and 5 of them fail.

## "Identity not verified" is now its own state

Also from review. When the `Set active model to:` line is missing, the check fails open — but it now says so loudly instead of as a quiet note:

```
      !! IDENTITY NOT VERIFIED — this is NOT a pass.
      !! no "Set active model to:" line in agent-output.log or entry.log
      !! The run stands, but nothing confirmed which model answered.
```

The summary line changes to match, so this can't be mistaken for a pass.

**Why fail open rather than closed:** a run that died before model selection legitimately has no such line, and failing closed would turn every missing artifact into a fake "model mismatch". If a future harness version stopped emitting the line, fail-closed would block every run on a false accusation — the same disease as a detector that hides true reds, just pointed the other way. The real cost of failing open is that the check could quietly rot, which is precisely why the state is shouted rather than tucked away. Reasoning is recorded in both the code and the README.

## Verification — no runs submitted

**No MSBench run was submitted.** Everything was verified offline against 7 stored runs plus 4 constructed log fixtures.

Against the stored runs:

| Run | Expected | Result |
| --- | --- | --- |
| `2026082583236973` (throttled) | void | exit 75, names `/v1/messages`, 8 calls, 666ms recovery ✅ |
| `2026082582510393` (**genuinely red** negative control) | still red | exit 0 — reported as a real failure ✅ |
| 5 green runs | pass | exit 0 ✅ |

That second row is the one that matters: the genuinely-broken run is still reported as broken.

Constructed fixtures covered: a 429 on a **brand-new surface** (`/responses`) — picked up with zero code changes, proving the generic parsing works; a recovered 429 (note, exit 0); a model mismatch (exit 65); and a run with no proxy log at all (degrades gracefully, doesn't crash).

`npm run typecheck` passes in `evals/`. The new script is `.ts`, run directly by Node's type stripping, no build step.

## Branch base

PR #1698 has **not** merged, so per the brief this branch is based on its head (`alexweininger-msbench-exec-graders` — note the branch name in my brief was stale) and targets `feat/CoR`, since it directly extends that detector in the same block of `run.sh`.

**So the diff below includes #1698's commit until that one merges.** My own change is the single commit `Verify what actually ran before trusting a run's results` — review that one. Merging #1698 first will collapse this to just my commit.

## Scope

`run.sh`, `README.md`, one new `verify-run.ts`, and a one-line `evals/package.json` script for the self-test. No model change, no eval restructuring, no new stimuli, no grader changes.
