### PR TITLE
Ask the eval container what toolchains it actually has

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -244,6 +244,7 @@ so the probe reports one `name=value` per line:
 
 | Group | Probed |
 | --- | --- |
+| Staged assets | the graders tree at `/agent/assets/graders/evals/graders`, and the VSIX's byte size |
 | Language runtimes | `node`, `npm`, `npx`, `python3`, `pip`, `pip3`, `dotnet`, `java`, `go` |
 | Database clients | `psql`, `sqlcmd`, `mongosh`, `redis-cli` |
 | Cloud and containers | `az`, `azd`, `func`, `docker` |
@@ -251,11 +252,24 @@ so the probe reports one `name=value` per line:
 | Capacity | free disk, total memory, CPU count |
 | Egress | HTTP status against the npm, PyPI and NuGet endpoints, plus `HTTPS_PROXY` |
 
+The first row is the triage row, and it is why this predates the breadth question:
+`stage-graders.ts` copies the grader sources in at run time preserving repo-relative
+paths, so a tree staged to an unexpected path fails every `exec:` grader in a way that
+looks exactly like a product regression. A missing or truncated VSIX is the same kind of
+invisible failure — `run.sh` guards it locally, but not a staging failure in between, so
+the byte count is recorded (~7 MB is healthy, ~1 MB is a VSIX built without `npm run
+build`).
+
 Egress is the critical one, because it decides which of three answers we get:
 present (breadth is free), absent but installable in the `script:` preamble (breadth
 costs setup minutes per run, and only works if the container can reach the internet), or
 neither (breadth needs our own published image, forfeiting the cheapness of borrowing
 one). `net_*=200` means reachable; `net_*=000` means the request never completed.
+
+Read `net_*` narrowly: it proves the endpoint answered, not that `npm install` works. An
+intercepting proxy returns 200 too, and so does a registry that then refuses the actual
+package fetch. It is conclusive in the negative direction — a `000` means outcome (b) is
+off the table — and only suggestive in the positive one.
 
 Every probe is individually failure-tolerant — a missing binary prints `MISSING` and the
 script continues, so one absent tool cannot truncate the answer.

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -233,6 +233,42 @@ sqlite3 session.sqlite "SELECT output FROM exec WHERE command LIKE '%uname%'"
 sqlite3 session.sqlite "SELECT exitCode, stdErr FROM exec WHERE command LIKE '%validate-%'"
 ```
 
+### What the fingerprint reports, and why
+
+It answers a question the suite is about to depend on. We are expanding to many project
+stacks (React + Functions + Postgres, Python + FastAPI + Cosmos, C# + Functions + SQL,
+static sites, workers) and adding gates that actually **build and run** the generated
+project. All of that executes inside the borrowed `say_hello` image — an image nobody
+here chose the contents of. The stacks we can test are bounded by what it already has,
+so the probe reports one `name=value` per line:
+
+| Group | Probed |
+| --- | --- |
+| Language runtimes | `node`, `npm`, `npx`, `python3`, `pip`, `pip3`, `dotnet`, `java`, `go` |
+| Database clients | `psql`, `sqlcmd`, `mongosh`, `redis-cli` |
+| Cloud and containers | `az`, `azd`, `func`, `docker` |
+| Build essentials | `git`, `make`, `gcc`, `unzip`, `curl` |
+| Capacity | free disk, total memory, CPU count |
+| Egress | HTTP status against the npm, PyPI and NuGet endpoints, plus `HTTPS_PROXY` |
+
+Egress is the critical one, because it decides which of three answers we get:
+present (breadth is free), absent but installable in the `script:` preamble (breadth
+costs setup minutes per run, and only works if the container can reach the internet), or
+neither (breadth needs our own published image, forfeiting the cheapness of borrowing
+one). `net_*=200` means reachable; `net_*=000` means the request never completed.
+
+Every probe is individually failure-tolerant — a missing binary prints `MISSING` and the
+script continues, so one absent tool cannot truncate the answer.
+
+The probe is **defined once**, in `config/base.yaml`'s `script:` preamble, which writes
+it to `/tmp/env-fingerprint.sh`; each stimulus's `exec:` entry just runs that file. It
+cannot live in `base.yaml` as an assertion, because assertions nest under `promptSteps`,
+which `build-config.ts` requires the stimulus file to define and refuses to let
+`base.yaml` duplicate. The preamble also *runs* it, so the same output lands in
+`customScript/output.log` — belt and braces if `/tmp` turns out not to be shared with
+the `exec` phase, which is also why the `exec:` entry falls back to a bare `uname`
+rather than printing nothing.
+
 
 ## Why the VSIX route
 

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -245,7 +245,7 @@ so the probe reports one `name=value` per line:
 | Group | Probed |
 | --- | --- |
 | Staged assets | the graders tree at `/agent/assets/graders/evals/graders`, and the VSIX's byte size |
-| Language runtimes | `node`, `npm`, `npx`, `python3`, `pip`, `pip3`, `dotnet`, `java`, `go` |
+| Language runtimes | `node`, `npm`, `npx`, `python3`, `pip`, `pip3`, `pip_module`, `python_venv`, `dotnet`, `java`, `go` |
 | Database clients | `psql`, `sqlcmd`, `mongosh`, `redis-cli` |
 | Cloud and containers | `az`, `azd`, `func`, `docker` |
 | Build essentials | `git`, `make`, `gcc`, `unzip`, `curl` |
@@ -270,6 +270,44 @@ Read `net_*` narrowly: it proves the endpoint answered, not that `npm install` w
 intercepting proxy returns 200 too, and so does a registry that then refuses the actual
 package fetch. It is conclusive in the negative direction — a `000` means outcome (b) is
 off the table — and only suggestive in the positive one.
+
+Two probes are spelled awkwardly on purpose. `go` and `java` are asked with `go version`
+and `java -version`, because neither accepts `--version` and the `--version` form would
+report an error string that reads as "installed but broken". And `pip_module` runs
+`python3 -m pip`, because a run on 2026-08-26 found `pip` and `pip3` both absent while
+`python3` was present — the binary's absence does not settle whether Python packages can
+be installed. `python_venv` imports `ensurepip` rather than `venv`, since on Debian and
+Ubuntu `import venv` succeeds even when `python3 -m venv` cannot bootstrap pip.
+
+### What the first run found
+
+Recorded by run
+[`2026082611060474`](https://msbenchapp.azurewebsites.net/run-analysis/2026082611060474),
+a throwaway one-line-prompt config submitted purely to read the fingerprint
+($0.03, one model request):
+
+```
+uname=Linux x86_64
+os=Ubuntu 22.04.5 LTS
+node=v22.22.2   npm=10.9.7   python3=Python 3.10.12   az=azure-cli 2.89.1
+git=2.34.1   make=4.3   gcc=11.4.0   curl=7.81.0   unzip=6.00
+pip=MISSING  pip3=MISSING  dotnet=MISSING  go=MISSING  java=MISSING
+psql=MISSING mongosh=MISSING redis-cli=MISSING sqlcmd=MISSING
+func=MISSING azd=MISSING docker=MISSING
+disk=82G free of 145G   mem=15.6GB   cpus=4
+net_npm=200  net_pypi=200  net_nuget=200
+```
+
+So the container is **Node-only** — outcome (b) for every non-Node stack. Node and npm
+are first-class, egress reaches npm, PyPI and NuGet, and there is 82 GB of disk and a
+C toolchain to install into. Everything else (Python packaging, .NET, Java, Go, every
+database client, `func`, `azd`, Docker) has to be installed in the `script:` preamble,
+which costs setup minutes per run. Docker being absent also rules out
+database-in-a-container gates; those need a real service or an emulator.
+
+That run is also the cleanest possible proof that the fingerprint cannot fail anything:
+its `eval.json` is `"resolved": true` with `"details": []` — one row recorded in `exec`,
+zero assertions generated.
 
 Every probe is individually failure-tolerant — a missing binary prints `MISSING` and the
 script continues, so one absent tool cannot truncate the answer.

--- a/evals/msbench/config/base.yaml
+++ b/evals/msbench/config/base.yaml
@@ -56,3 +56,85 @@ script: |
   mkdir -p /workspace/.github/agents
   cp -r /tmp/corext/extension/resources/agents/. /workspace/.github/agents/
   ls -la /workspace/.github/agents/
+
+  # Environment fingerprint. We borrow `vscbench.say_hello` purely for its
+  # container image, so nobody here chose its contents — and the set of project
+  # stacks the suite can build and run is bounded by what that image already
+  # has. This probe asks it, at zero cost, on runs we were making anyway.
+  #
+  # It is *defined* once here and merely *invoked* by each stimulus's
+  # non-asserting `exec:` entry, because assertions nest under `promptSteps`,
+  # which build-config.ts requires to come from the stimulus file and refuses
+  # to let base.yaml define. Running it here too means the answer also lands in
+  # customScript/output.log, so a shared-/tmp assumption that turns out to be
+  # wrong still leaves us with the fingerprint. `|| true` keeps a probe from
+  # aborting the agent seeding above, which is the part that actually matters.
+  cat > /tmp/env-fingerprint.sh <<'FINGERPRINT'
+  # Every probe is individually failure-tolerant: a missing binary prints
+  # MISSING and the script carries on, so this can never abort partway and
+  # leave half an answer behind.
+  TO=""
+  command -v timeout >/dev/null 2>&1 && TO="timeout 10"
+
+  probe() {
+    bin=$1
+    shift
+    if command -v "$bin" >/dev/null 2>&1; then
+      out=$($TO "$bin" "$@" 2>&1 | head -1 | tr -d '\r')
+      echo "$bin=${out:-present}"
+    else
+      echo "$bin=MISSING"
+    fi
+  }
+
+  # 000 means the request never completed (no route, DNS failure, blocked);
+  # anything else is an HTTP status, so a 200 means egress works.
+  net() {
+    if command -v curl >/dev/null 2>&1; then
+      code=$(curl -s -o /dev/null --connect-timeout 5 --max-time 8 -w '%{http_code}' "$1" 2>/dev/null)
+      echo "${code:-000}"
+    else
+      echo "no-curl"
+    fi
+  }
+
+  echo "=== env-fingerprint begin ==="
+  echo "uname=$(uname -sm)"
+  os=$(. /etc/os-release 2>/dev/null; echo "$PRETTY_NAME")
+  echo "os=${os:-unknown}"
+  echo "cwd=$(pwd)"
+  echo "user=$(id -un 2>/dev/null || echo unknown)"
+
+  # Language runtimes
+  for b in node npm npx python3 pip pip3 dotnet go; do probe "$b" --version; done
+  probe java -version
+
+  # Database clients
+  for b in psql mongosh redis-cli; do probe "$b" --version; done
+  probe sqlcmd '-?'
+
+  # Cloud and container tooling
+  for b in az func docker; do probe "$b" --version; done
+  probe azd version
+
+  # Build essentials
+  for b in git make gcc curl; do probe "$b" --version; done
+  probe unzip -v
+
+  # Capacity
+  disk=$(df -Ph / 2>/dev/null | awk 'NR==2 {print $4 " free of " $2}')
+  echo "disk=${disk:-unknown}"
+  mem=$(awk '/MemTotal/ {printf "%.1fGB", $2/1048576}' /proc/meminfo 2>/dev/null)
+  echo "mem=${mem:-unknown}"
+  cpus=$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null)
+  echo "cpus=${cpus:-unknown}"
+
+  # Network egress — the one that decides whether installing a missing
+  # toolchain in this preamble is even an option.
+  echo "proxy=${HTTPS_PROXY:-${https_proxy:-none}}"
+  echo "net_npm=$(net https://registry.npmjs.org/)"
+  echo "net_pypi=$(net https://pypi.org/simple/)"
+  echo "net_nuget=$(net https://api.nuget.org/v3/index.json)"
+  echo "=== env-fingerprint end ==="
+  FINGERPRINT
+  sh /tmp/env-fingerprint.sh || true

--- a/evals/msbench/config/base.yaml
+++ b/evals/msbench/config/base.yaml
@@ -105,6 +105,23 @@ script: |
   echo "cwd=$(pwd)"
   echo "user=$(id -un 2>/dev/null || echo unknown)"
 
+  # Staged assets. A grader tree at an unexpected path makes every `exec:`
+  # grader fail like a product regression, and a missing or truncated VSIX
+  # makes everything fail for no visible reason — these two lines are what
+  # tell you otherwise. A good VSIX is ~7 MB; a broken one is ~1 MB.
+  GRADERS=/agent/assets/graders/evals/graders
+  if [ -d "$GRADERS" ]; then
+    echo "graders=$(ls "$GRADERS" 2>/dev/null | head -20 | tr '\n' ' ')"
+  else
+    echo "graders=MISSING at $GRADERS"
+  fi
+  VSIX=/agent/assets/extensions/vscode-azureresourcegroups.vsix
+  if [ -f "$VSIX" ]; then
+    echo "vsix=$(wc -c < "$VSIX" 2>/dev/null | tr -d ' ') bytes"
+  else
+    echo "vsix=MISSING at $VSIX"
+  fi
+
   # Language runtimes
   for b in node npm npx python3 pip pip3 dotnet go; do probe "$b" --version; done
   probe java -version

--- a/evals/msbench/config/base.yaml
+++ b/evals/msbench/config/base.yaml
@@ -80,7 +80,7 @@ script: |
     bin=$1
     shift
     if command -v "$bin" >/dev/null 2>&1; then
-      out=$($TO "$bin" "$@" 2>&1 | head -1 | tr -d '\r')
+      out=$($TO "$bin" "$@" 2>&1 | head -1 | tr -d '\r' | tr -s ' ')
       echo "$bin=${out:-present}"
     else
       echo "$bin=MISSING"
@@ -98,7 +98,7 @@ script: |
     fi
   }
 
-  echo "=== env-fingerprint begin ==="
+  echo "fingerprint=begin"
   echo "uname=$(uname -sm)"
   os=$(. /etc/os-release 2>/dev/null; echo "$PRETTY_NAME")
   echo "os=${os:-unknown}"
@@ -122,9 +122,25 @@ script: |
     echo "vsix=MISSING at $VSIX"
   fi
 
-  # Language runtimes
-  for b in node npm npx python3 pip pip3 dotnet go; do probe "$b" --version; done
+  # Language runtimes. `go` and `java` take a subcommand or a single dash
+  # rather than `--version`, so they are probed with their own spelling — a
+  # 2026-08-26 run confirmed the `--version` form reports an error string,
+  # which would read as "broken" rather than "present".
+  for b in node npm npx python3 pip pip3 dotnet; do probe "$b" --version; done
+  probe go version
   probe java -version
+  # `pip` and `pip3` were both MISSING in that run while python3 was present,
+  # so the binary's absence does not settle whether Python packages can be
+  # installed. The module form is the one `python3 -m pip install` would use.
+  if command -v python3 >/dev/null 2>&1; then
+    pipmod=$($TO python3 -m pip --version 2>&1 | head -1)
+    case "$pipmod" in
+      pip*) echo "pip_module=$pipmod" ;;
+      *) echo "pip_module=MISSING" ;;
+    esac
+    venvmod=$($TO python3 -c 'import ensurepip, venv' 2>&1 | tail -1)
+    echo "python_venv=${venvmod:-ok}"
+  fi
 
   # Database clients
   for b in psql mongosh redis-cli; do probe "$b" --version; done
@@ -152,6 +168,6 @@ script: |
   echo "net_npm=$(net https://registry.npmjs.org/)"
   echo "net_pypi=$(net https://pypi.org/simple/)"
   echo "net_nuget=$(net https://api.nuget.org/v3/index.json)"
-  echo "=== env-fingerprint end ==="
+  echo "fingerprint=end"
   FINGERPRINT
   sh /tmp/env-fingerprint.sh || true

--- a/evals/msbench/config/stimuli/api-only-inventory.yaml
+++ b/evals/msbench/config/stimuli/api-only-inventory.yaml
@@ -38,5 +38,5 @@ promptSteps:
 
       # Recorded, not asserted. See config/stimuli/photo-app-requirements.yaml.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        exec: 'sh /tmp/env-fingerprint.sh 2>&1 || { uname -sm; echo "env-fingerprint=MISSING, see customScript/output.log"; }'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/multi-service-order-processing.yaml
+++ b/evals/msbench/config/stimuli/multi-service-order-processing.yaml
@@ -33,5 +33,5 @@ promptSteps:
 
       # Recorded, not asserted. See config/stimuli/photo-app-requirements.yaml.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        exec: 'sh /tmp/env-fingerprint.sh 2>&1 || { uname -sm; echo "env-fingerprint=MISSING, see customScript/output.log"; }'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/no-datastore-converter.yaml
+++ b/evals/msbench/config/stimuli/no-datastore-converter.yaml
@@ -31,5 +31,5 @@ promptSteps:
 
       # Recorded, not asserted. See config/stimuli/photo-app-requirements.yaml.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        exec: 'sh /tmp/env-fingerprint.sh 2>&1 || { uname -sm; echo "env-fingerprint=MISSING, see customScript/output.log"; }'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/photo-app-requirements.yaml
+++ b/evals/msbench/config/stimuli/photo-app-requirements.yaml
@@ -54,7 +54,12 @@ promptSteps:
       # the `exec` table without generating a check, so it can never fail the run
       # and does not change the assertion count. Read it first when the exec grader
       # above goes red: no Node, Node too old to strip types, and a mis-staged tree
-      # are indistinguishable from the outside. See README.md.
+      # are indistinguishable from the outside.
+      #
+      # The probe itself is written by the `script:` preamble in config/base.yaml,
+      # so it has one definition rather than one copy per stimulus. It reports the
+      # runtimes, database clients, cloud tooling and network egress that decide
+      # which project stacks this container can actually build. See README.md.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        exec: 'sh /tmp/env-fingerprint.sh 2>&1 || { uname -sm; echo "env-fingerprint=MISSING, see customScript/output.log"; }'
         assertZeroExitCode: false


### PR DESCRIPTION
## The plain-language version

We're about to test **lots** of project types — React + Functions + Postgres, Python + FastAPI + Cosmos, C# + Functions + SQL, Vue, Svelte, static sites, workers — and to add gates that actually *build and run* the generated project instead of just checking that files were written.

All of that runs **inside a container we borrowed and never inspected.** `evals/msbench/` reuses `vscbench.say_hello` purely for its image; that's the trick that keeps this cheap (no new benchmark instance, no image to publish, no PR into the upstream eval repo). The flip side is that nobody here chose what's in it — and the stacks we can test are bounded by what's already there.

So: ask it. For free, on runs we were making anyway.

## Why this cannot fail a run

The stimuli already carry a diagnostic `exec:` entry with `assertZeroExitCode: false`. That flag means the harness **records the command's output into the `exec` table without generating a check** — no assertion, no pass/fail, no change to the assertion count (still 7 / 5 / 4 / 4). This PR only extends what that command prints. Every probe is individually failure-tolerant: a missing binary prints `MISSING` and the script keeps going, so one absent tool can't truncate the answer.

## What it now reports

One `name=value` per line: `node npm npx python3 pip pip3 dotnet java go` · `psql sqlcmd mongosh redis-cli` · `az azd func docker` · `git make gcc unzip curl` · free disk, memory, CPU count · and **network egress** — short-timeout HTTP probes against the npm registry, PyPI and NuGet, plus `HTTPS_PROXY`.

Egress is the critical one, because it decides which of three answers we get:

| Outcome | What it means for the breadth plan |
| --- | --- |
| **(a) toolchains present** | Stack breadth is essentially free. Add stimuli and build gates. |
| **(b) absent but installable** | Breadth costs setup minutes per run — and is only possible at all if the container can reach the internet. `net_*=200` says yes, `net_*=000` says no. |
| **(c) neither** | Breadth needs our own published image, forfeiting the cheapness of borrowing one. |

## Where it lives, and why

Defined **once**, in `config/base.yaml`'s `script:` preamble, which writes `/tmp/env-fingerprint.sh`; each stimulus's `exec:` entry is now a one-liner that runs it. It can't live in `base.yaml` *as an assertion* — assertions nest under `promptSteps`, which `build-config.ts` requires the stimulus file to define and refuses to let `base.yaml` duplicate. The preamble also runs the probe itself, so the same output lands in `customScript/output.log`; if `/tmp` turns out not to be shared with the `exec` phase we still get the answer, and the `exec:` entry falls back to a bare `uname` rather than printing nothing.

## Reading the results

```bash
msbench-cli extract --run_id <id> --output ./out
sqlite3 session.sqlite "SELECT output FROM exec WHERE command LIKE '%uname%'"
```

(The command string still contains `uname`, so the query documented in the README keeps working.) Same output is also in `out/customScript/output.log`.

## We already ran it — here is the answer

Run [`2026082611060474`](https://msbenchapp.azurewebsites.net/run-analysis/2026082611060474), a throwaway one-line-prompt config submitted purely to read the fingerprint. **$0.03, one model request, ~4 minutes.**

```
uname=Linux x86_64
os=Ubuntu 22.04.5 LTS
node=v22.22.2  npm=10.9.7  python3=Python 3.10.12  az=azure-cli 2.89.1
git=2.34.1  make=4.3  gcc=11.4.0  curl=7.81.0  unzip=6.00
pip=MISSING  pip3=MISSING  dotnet=MISSING  go=MISSING  java=MISSING
psql=MISSING  mongosh=MISSING  redis-cli=MISSING  sqlcmd=MISSING
func=MISSING  azd=MISSING  docker=MISSING
disk=82G free of 145G   mem=15.6GB   cpus=4
net_npm=200  net_pypi=200  net_nuget=200
```

**It is (b) — except Node, which is (a).** Not (c), which is the important negative: nothing returned `000`, so egress is open and we do not need to publish our own image. Node and npm are first-class, so React / Vue / Svelte / static-site / TS-Functions stacks cost nothing extra. Everything else installs in the preamble, with 82 GB and a C toolchain to install into; the recurring bill lands hardest on `func` and `azd`, which *every* Functions stack's local-run and deploy gates need.

The sharpest constraint is **`docker=MISSING`** — not practically fixable by a preamble install, so live-database gates want an emulator or a real Azure resource rather than a container.

That run is also the cleanest proof that this cannot fail anything: its `eval.json` is `"resolved": true` with `"details": []` — **one row recorded in `exec`, zero assertions generated.**

### The run found two bugs in the probe, now fixed

- **`go --version` is not the spelling** (`go version` is). The container has no Go, so `command -v` short-circuited and the run could not catch it; verified instead against `golang:1.23-bookworm`, which now reports `go=go version go1.23.12 linux/arm64`.
- **`pip=MISSING` with `python3` present does not settle Python.** Added `pip_module` (`python3 -m pip`) and `python_venv` (imports `ensurepip`, not `venv`, since `import venv` succeeds on Ubuntu even when it cannot bootstrap pip). Verified both ways against `ubuntu:22.04` and `python:3.11-slim`. The next run tells us whether Python is really (a) or (b).
- Delimiters are now `fingerprint=begin` / `fingerprint=end` so every line is genuinely `name=value`, and `az`'s column padding is squashed.

## Verification

Locally, after every change:

- `node evals/msbench/build-config.ts <stimulus>` for all four stimuli, plus a real YAML parse of each generated `assets/user-overrides.yaml`. Assertion counts unchanged at 7 / 5 / 4 / 4 (the fingerprint is the extra, non-asserting entry).
- The shell was run end-to-end in Docker under **bash**, **dash** (`debian:bookworm-slim`) and **busybox ash** (`alpine`), including the full `set -eux` preamble against a stub VSIX — the agent seeding still succeeds, and the fingerprint prints `MISSING` for everything in a slim image rather than aborting.
- Both branches of the `exec:` one-liner exercised: file present, and file deleted (falls back to `uname`, exit 0).
- Staged-asset probes exercised present *and* absent; `go`/`pip`/`venv` probes exercised in images that have them and images that don't.

No changes to `run.sh`, the model, timeouts or the eval layout. No TypeScript touched, so `npm run typecheck` is unaffected.
