### PR TITLE
Fix the evals lint break left by the TypeScript conversion

### DIFF
--- a/evals/check-agent-drift.ts
+++ b/evals/check-agent-drift.ts
@@ -23,13 +23,12 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import { listEvalAssetFiles, readSupportedModels } from "./src/agent-definition.ts";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(__dirname, "..");
+const scriptDir = import.meta.dirname;
+const repoRoot = path.resolve(scriptDir, "..");
 const agentsRoot = path.join(repoRoot, "resources", "agents");
-const lockPath = path.join(__dirname, "agent-assets.lock.json");
+const lockPath = path.join(scriptDir, "agent-assets.lock.json");
 const update = process.argv.includes("--update");
 
 const PLAN = "azure-project-plan";
@@ -277,7 +276,7 @@ const currentFiles = agentAssetFiles();
  * The eval spec must run the agent on a model the product actually ships it on.
  * Catching a bad pin here costs a second; catching it at trial time costs a run.
  */
-const evalSpecPath = path.join(__dirname, "project-plan", "eval.yaml");
+const evalSpecPath = path.join(scriptDir, "project-plan", "eval.yaml");
 try {
     const supported = readSupportedModels(repoRoot, PLAN);
     const spec = fs.readFileSync(evalSpecPath, "utf8");

--- a/evals/check-gate-tools.ts
+++ b/evals/check-gate-tools.ts
@@ -25,13 +25,12 @@ import { approveAll, CopilotClient, RuntimeConnection } from "@github/copilot-sd
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import { MCP_SERVER_NAME, workflowToolDefinitions } from "./mcp/workflow-tools.ts";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scriptDir = import.meta.dirname;
 
 function bundledCliPath() {
-    const pkgDir = path.resolve(__dirname, "node_modules/@github/copilot");
+    const pkgDir = path.resolve(scriptDir, "node_modules/@github/copilot");
     for (const candidate of ["npm-loader.js", "index.js"]) {
         const full = path.resolve(pkgDir, candidate);
         if (fs.existsSync(full)) {return full;}
@@ -48,7 +47,7 @@ function bundledCliPath() {
  * themselves would not.
  */
 function requiredToolNamesFromSpecs(): Set<string> {
-    const specDir = path.join(__dirname, "project-plan");
+    const specDir = path.join(scriptDir, "project-plan");
     const names = new Set<string>();
     let files: string[];
     try {

--- a/evals/ci-local.ts
+++ b/evals/ci-local.ts
@@ -30,11 +30,10 @@ import { spawnSync, type SpawnSyncOptions, type SpawnSyncReturns } from "node:ch
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(__dirname, "..");
+const scriptDir = import.meta.dirname;
+const repoRoot = path.resolve(scriptDir, "..");
 const WORKFLOW = ".github/workflows/agent-contracts.yml";
 const IMAGE_NODE = "22";
 

--- a/evals/executor/azure-agent-executor.ts
+++ b/evals/executor/azure-agent-executor.ts
@@ -15,17 +15,15 @@ import { computeMetrics } from "@microsoft/vally";
 import type { Executor, ExecutorOptions, ExecutorRegistry, Stimulus, Trajectory, TrajectoryEvent } from "@microsoft/vally";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import { buildEvalSkill, prepareAgentWorkspace, resolveEvalModel } from "./agent-assets.ts";
 import { workflowToolDefinitions } from "../mcp/workflow-tools.ts";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const repoRoot = path.resolve(__dirname, "../..");
+const scriptDir = import.meta.dirname;
+const repoRoot = path.resolve(scriptDir, "../..");
 const AGENT_NAME = "azure-project-plan";
 
 function getBundledCliPath() {
-    const pkgDir = path.resolve(__dirname, "../node_modules/@github/copilot");
+    const pkgDir = path.resolve(scriptDir, "../node_modules/@github/copilot");
     const candidates = [];
     try {
         const pkg = JSON.parse(fs.readFileSync(path.join(pkgDir, "package.json"), "utf8"));
@@ -81,7 +79,31 @@ function parseArgs(args: unknown): Record<string, unknown> {
     }
 }
 
-function convertSdkEvent(event: any): ExecutorEvent | ExecutorEvent[] | null {
+/**
+ * The subset of the SDK's event shape this converter reads. `rawEvents` is
+ * collected as `unknown[]` off the session bus, so rather than asserting at
+ * every property access the shape is narrowed once, at the boundary below.
+ */
+type SdkEvent = {
+    type: string;
+    timestamp: string | number;
+    data?: {
+        content?: string;
+        toolRequests?: { toolCallId: string; name?: string; arguments?: unknown }[];
+        toolCallId?: string;
+        toolName?: string;
+        name?: string;
+        arguments?: unknown;
+        result?: { content?: unknown };
+        skills?: unknown[];
+    };
+};
+
+function convertSdkEvent(raw: unknown): ExecutorEvent | ExecutorEvent[] | null {
+    if (!raw || typeof raw !== "object") {
+        return null;
+    }
+    const event = raw as SdkEvent;
     switch (event.type) {
         case "assistant.message": {
             const results: ExecutorEvent[] = [];
@@ -112,7 +134,9 @@ function convertSdkEvent(event: any): ExecutorEvent | ExecutorEvent[] | null {
                 type: "tool_call",
                 timestamp: new Date(event.timestamp),
                 data: {
-                    toolCallId: event.data?.toolCallId,
+                    // `?? ""` only satisfies the optional chain; downstream the id is
+                    // read behind a truthiness check, so "" and undefined behave alike.
+                    toolCallId: event.data?.toolCallId ?? "",
                     name: event.data?.toolName ?? event.data?.name ?? "unknown",
                     arguments: parseArgs(event.data?.arguments),
                 },
@@ -124,7 +148,7 @@ function convertSdkEvent(event: any): ExecutorEvent | ExecutorEvent[] | null {
                 type: "tool_result",
                 timestamp: new Date(event.timestamp),
                 data: {
-                    toolCallId: event.data?.toolCallId,
+                    toolCallId: event.data?.toolCallId ?? "",
                     toolName: event.data?.toolName ?? "_pending_lookup_",
                     result: event.data?.result?.content ?? event.data?.result ?? "",
                 },
@@ -154,7 +178,7 @@ class AzureAgentExecutor implements Executor {
         let assistantOutput = "";
         const rawEvents: unknown[] = [];
 
-        const skillDir = buildEvalSkill(repoRoot, AGENT_NAME, path.resolve(__dirname, "../.generated/skills"));
+        const skillDir = buildEvalSkill(repoRoot, AGENT_NAME, path.resolve(scriptDir, "../.generated/skills"));
         const skillDirs = [skillDir];
 
         // Put the shipped instruction folder (including references/) in the workspace,


### PR DESCRIPTION
## What's broken

`npm run lint` is **currently red on #1615** — the `feat/CoR` → `main` integration PR — and has been at every recent `feat/CoR` commit (`2b1e6465`, `e4e719f1`, current HEAD). It is not caused by any of the in-flight eval PRs; they just inherit it. That's the most useful sentence in this PR.

Worth knowing where it does and doesn't bite: `main.yml` only triggers on PRs targeting `main`/`rel/*`, so PRs *into* `feat/CoR` never run it and look green. The breakage is therefore invisible on the feature PRs and only shows up on the integration PR — which is exactly why it has survived this long.

The cause is a one-line mismatch. `eslint.config.mjs` has an override that lints the eval harness loosely, because it was plain Node scripts rather than extension code:

```js
files: ['evals/**/*.{js,cjs,mjs}'],
```

#1696 then converted `evals/` from `.cjs`/`.mjs` to **TypeScript**. The glob didn't follow, so every converted file quietly fell through to the extension's strict ruleset. Under `eslint --max-warnings 0` that's an instant failure:

```
evals/check-agent-drift.ts               1 warning   __dirname naming-convention
evals/check-gate-tools.ts                1 warning   __dirname naming-convention
evals/ci-local.ts                        1 warning   __dirname naming-convention
evals/executor/azure-agent-executor.ts   2 warnings  __filename / __dirname
                                         1 error     Unexpected any
✖ 6 problems (1 error, 5 warnings)
```

## The fix, and why not just widen the glob

Adding `ts` to that glob would work, but the override also sets `disableTypeChecked` and `projectService: false` — so it would silently drop **type-aware** linting across all of `evals/`. That trades a visible failure for an invisible loss of coverage. Instead, both underlying causes are removed:

**1. Drop the ESM `__dirname` shim (4 files).**

```diff
-import { fileURLToPath } from "node:url";
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scriptDir = import.meta.dirname;
```

`import.meta.dirname` has been native since Node 20.11 and we run 22. Node defines it as precisely `path.dirname(fileURLToPath(import.meta.url))`, so this is equivalent — it deletes the thing the linter objected to rather than suppressing the objection.

**2. Narrow the SDK event `any` (1 file).** `rawEvents` is already declared `unknown[]`, so `convertSdkEvent` was taking `any` purely to avoid narrowing. It now takes `unknown` and is narrowed **once**, at that boundary, to a structural type covering only the fields it actually reads.

## Is narrowing the `any` a behaviour change?

**Effectively no — it is type-level, with two deltas that are unreachable in practice.** Stating them explicitly rather than claiming "purely type-level":

1. **A new `if (!raw || typeof raw !== "object") return null;` guard.** For a primitive input, behaviour is identical (`.type` was `undefined`, hit `default`, returned `null`). For `null`/`undefined` the old code would have **thrown** a `TypeError` and now returns `null`. Events come straight from `session.on(event => rawEvents.push(event))`, so the SDK never delivers `null` here — and turning a crash into a skip is the safe direction regardless.

2. **`toolCallId: event.data?.toolCallId` gained `?? ""`**, required because the optional chain yields `string | undefined` against a required `string` field. This only differs when the SDK omits `toolCallId`, and downstream it cannot matter: the id is read behind a truthiness check (`if (... && e.data.toolCallId && ...)`), and the lookup map is only ever populated with truthy keys — so `get("")` and `get(undefined)` both miss and fall back to `"unknown"` identically.

No grading logic, event mapping, or control flow is otherwise touched.

## Verification

- `npm run lint` — clean (was 6 problems)
- `npm run build` — clean
- `npm run typecheck` in `evals/` — clean
- `node check-agent-drift.ts` — still green, *16 agent contracts intact*, which confirms `import.meta.dirname` resolves correctly at runtime under Node's type stripping

## Scope

Four files, all in `evals/`. No config change, no functional change, nothing to do with timeouts or stimuli. Split out of #1700 so each PR is a single review.

> Note: this does **not** block #1700 (the timeouts PR) — that one is green, because PRs into `feat/CoR` don't run `main.yml` at all. This PR is what turns #1615 green.

