### PR TITLE
Fail eval runs that die early instead of giving them partial credit

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -22,18 +22,26 @@ wired up.
 
 | Stimulus | Assertions | Validator flags |
 | --- | --- | --- |
-| `photo-app-requirements` (default) | 7 | — |
-| `api-only-inventory` | 5 | `--assert-no-frontend --assert-blob-storage --assert-cosmosdb` |
-| `multi-service-order-processing` | 4 | `--assert-service-count=3` |
-| `no-datastore-converter` | 4 | `--assert-no-datastore` |
+| `photo-app-requirements` (default) | 8 | — |
+| `api-only-inventory` | 6 | `--assert-no-frontend --assert-blob-storage --assert-cosmosdb` |
+| `multi-service-order-processing` | 5 | `--assert-service-count=3` |
+| `no-datastore-converter` | 5 | `--assert-no-datastore` |
 
 Assertion counts differ because they mirror each stimulus's graders one-for-one rather
 than being levelled up — only `photo-app-requirements` specifies
 `no-dotfile-requirements` and `transcript-not-contains`, and only it and
 `api-only-inventory` specify `no-premature-plan`.
 
+The one assertion every stimulus carries that `eval.yaml` does not specify is the
+**liveness sentinel**, `SELECT COUNT(*) > 0 FROM llm_responses`, which must be first.
+It exists because a negative assertion (`COUNT(*) = 0`) is trivially true against an
+empty table: a run that dies before the session database is populated would otherwise
+collect full marks on every negative check rather than failing. It is a property of
+*this* harness, not of the source spec, which is why it is not mirrored from there.
+
 All four are verified by a real green run; ids are under
-[Verified result](#verified-result).
+[Verified result](#verified-result). Those runs predate the sentinel, so they report
+one assertion fewer than the table above.
 
 ## Quick start
 

--- a/evals/msbench/config/stimuli/api-only-inventory.yaml
+++ b/evals/msbench/config/stimuli/api-only-inventory.yaml
@@ -12,6 +12,12 @@ promptSteps:
       quantities, locations. Just the API, no UI needed. I want to use CosmosDB
       since the data structure might change a lot and I want it on Azure Functions.
     assertions:
+      # Liveness sentinel — must come first. Without it the negative assertions
+      # below pass trivially against an empty table. See
+      # config/stimuli/photo-app-requirements.yaml.
+      - comment: Sentinel; session data must exist or the negative checks below are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
       # vally: file-exists .azure/requirements.json
       - comment: Agent should have written the requirements artifact
         query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'

--- a/evals/msbench/config/stimuli/multi-service-order-processing.yaml
+++ b/evals/msbench/config/stimuli/multi-service-order-processing.yaml
@@ -13,6 +13,12 @@ promptSteps:
       handles the business logic, and a background worker that picks up new
       orders from a queue and sends confirmation emails. All in one project.
     assertions:
+      # Liveness sentinel — must come first. Without it the negative assertions
+      # below pass trivially against an empty table. See
+      # config/stimuli/photo-app-requirements.yaml.
+      - comment: Sentinel; session data must exist or the negative checks below are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
       # vally: file-exists .azure/requirements.json
       - comment: Agent should have written the requirements artifact
         query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'

--- a/evals/msbench/config/stimuli/no-datastore-converter.yaml
+++ b/evals/msbench/config/stimuli/no-datastore-converter.yaml
@@ -10,6 +10,12 @@ promptSteps:
       units and it converts. Nothing needs to be saved, no accounts, no backend.
       Just a clean little frontend tool.
     assertions:
+      # Liveness sentinel — must come first. Without it the negative assertions
+      # below pass trivially against an empty table. See
+      # config/stimuli/photo-app-requirements.yaml.
+      - comment: Sentinel; session data must exist or the negative checks below are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
       # vally: file-exists .azure/requirements.json
       - comment: Agent should have written the requirements artifact
         query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'

--- a/evals/msbench/config/stimuli/photo-app-requirements.yaml
+++ b/evals/msbench/config/stimuli/photo-app-requirements.yaml
@@ -8,6 +8,21 @@ promptSteps:
       and an Azure Functions backend with PostgreSQL for the data. Make it with
       full test coverage.
     assertions:
+      # Liveness sentinel — must come first, and every stimulus needs one.
+      #
+      # Half the assertions below are negative (`COUNT(*) = 0`), and a negative
+      # count over an *empty* table is trivially true. So a run that dies before
+      # the session database is populated — a rate limit, a container that never
+      # reached the first turn — does not fail: it quietly collects full marks on
+      # every negative check and scores partial credit. Run 2026082555313888 did
+      # exactly that. This assertion is what makes the rest of them mean anything.
+      #
+      # `llm_responses` rather than `toolCalls`, because an agent that correctly
+      # refuses a request may legitimately call no tools, and that must not be
+      # indistinguishable from an agent that never started.
+      - comment: Sentinel; session data must exist or the negative checks below are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
       # vally: file-exists .azure/requirements.json
       - comment: Agent should have written the requirements artifact
         query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'


### PR DESCRIPTION
## The bug, in plain terms

Each MSBench stimulus asks a set of yes/no questions about what the agent did. Roughly half of them are phrased as **"this must NOT have happened"** — no plan written before requirements were confirmed, no fallback to the chat question tool, no dotfile variant of the artifact.

In SQL those read `SELECT COUNT(*) = 0 FROM ...`. And "count zero rows" is **true when the table is empty**.

So if a run dies before it ever gets going — a rate limit, a container that never reached the first turn — the session database is empty, every "must not have happened" check passes, and the run reports partial credit. Nothing happened, so nothing bad happened.

That is not hypothetical. Run `2026082555313888` did exactly this after hitting a rate limit.

## The fix

One assertion, first in every stimulus:

```yaml
- comment: Sentinel; session data must exist or the negative checks below are vacuous
  query: SELECT COUNT(*) > 0 FROM llm_responses
```

If the agent never produced a single response, the run fails outright instead of scoring points for the things it never had the chance to do wrong.

`llm_responses` rather than `toolCalls` on purpose: an agent that correctly *refuses* a request may legitimately call no tools, and a correct refusal must not be indistinguishable from a run that never started.

## Credit

**This is @motm32's design.** Every suite in her scaffold eval PR (#1693) already opens with this sentinel, and her comment there is what identified the failure mode and the `2026082555313888` evidence. This PR only backfills it into the four stimuli that predate her work, so the fix lands on what we run today rather than waiting behind the adoption of #1693. The wording of the explanatory comment is hers.

## What changed

- The sentinel, added as the first assertion in all four `config/stimuli/*.yaml`.
- `README.md`: assertion counts go 7/5/4/4 to 8/6/5/5, with a short note on why this one assertion is *not* mirrored from `evals/project-plan/eval.yaml` — it is a property of this harness, not of the source spec. The verified-run table now says those runs predate the sentinel, so they legitimately report one assertion fewer.

## Verification

No MSBench run submitted — this needs none.

- `build-config.ts` regenerated for all four stimuli; each parses, and the sentinel is index 0 in every one.
- Asserted-assertion counts confirmed to match the README table (8/6/5/5; the environment fingerprint is `assertZeroExitCode: false`, so it is recorded rather than asserted and does not count).
- `npm run lint`, `npm run typecheck`, `npm run drift` all pass (drift: 16 agent contracts intact).

## Note for whoever merges

#1702 also edits all four stimulus files, replacing the `exec:` fingerprint line at the bottom. This touches only the top of the `assertions:` block, so the two should merge cleanly — but they do overlap, and whichever lands second should re-run `build-config.ts` on all four to confirm.
