### PR TITLE
Add the local-debug eval gates from #1694

### DIFF
--- a/evals/grader-certification/manifest.json
+++ b/evals/grader-certification/manifest.json
@@ -1,22 +1,35 @@
 {
-    "schemaVersion": 1,
-    "fixture": {
-        "id": "sample-agent-output",
-        "path": "evals/grader-certification/sample-agent-output",
-        "description": "Workspace as the planning and scaffold agents leave it \u2014 the artifacts the offline validators grade. Kept separate from reference-node-fullstack, which is a plain deployable app carrying no agent artifacts.",
-        "offlineValidators": [
-            "requirements",
-            "project-plan",
-            "plan-gate",
-            "preview",
-            "integration-plan",
-            "frontend-scaffold"
-        ]
-    },
+    "schemaVersion": 2,
+    "fixtures": [
+        {
+            "id": "sample-agent-output",
+            "path": "evals/grader-certification/sample-agent-output",
+            "description": "Workspace as the planning and scaffold agents leave it \u2014 the artifacts those phases are contracted to produce.",
+            "offlineValidators": [
+                "requirements",
+                "project-plan",
+                "plan-gate",
+                "preview",
+                "integration-plan",
+                "frontend-scaffold"
+            ]
+        },
+        {
+            "id": "reference-node-fullstack",
+            "path": "evals/grader-certification/reference-node-fullstack",
+            "description": "A real, runnable Node full-stack app plus the local-debug artifacts generated for it. The debug validators grade artifacts against the project they describe, so they certify here rather than against the scaffold fixture.",
+            "offlineValidators": [
+                "debug-plan",
+                "debug-config",
+                "debug-artifacts"
+            ]
+        }
+    ],
     "mutations": [
         {
             "id": "requirements-schema-version",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "requirements",
             "file": ".azure/requirements.json",
             "operation": "replace",
@@ -27,6 +40,7 @@
         {
             "id": "project-plan-numbering",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "project-plan",
             "file": ".azure/project-plan.md",
             "operation": "replace",
@@ -37,6 +51,7 @@
         {
             "id": "plan-gate-frontend-dropped",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "plan-gate",
             "file": ".azure/project-plan.md",
             "operation": "replace",
@@ -47,6 +62,7 @@
         {
             "id": "plan-gate-preview-manifest-missing",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "plan-gate",
             "file": ".azure/.preview-temp/manifest.json",
             "operation": "delete",
@@ -55,6 +71,7 @@
         {
             "id": "preview-not-ready",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "preview",
             "file": ".azure/.preview-temp/manifest.json",
             "operation": "replace",
@@ -65,6 +82,7 @@
         {
             "id": "frontend-preview-not-embeddable",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "frontend-scaffold",
             "file": "services/web/vite.config.ts",
             "operation": "replace",
@@ -75,6 +93,7 @@
         {
             "id": "frontend-dev-script-does-not-serve",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "frontend-scaffold",
             "file": "services/web/package.json",
             "operation": "replace",
@@ -85,6 +104,7 @@
         {
             "id": "frontend-frame-busting-csp",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "frontend-scaffold",
             "file": "services/web/index.html",
             "operation": "replace",
@@ -95,6 +115,7 @@
         {
             "id": "frontend-api-seam-bypassed",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "frontend-scaffold",
             "file": "services/web/src/pages/TicketsPage.tsx",
             "operation": "replace",
@@ -105,6 +126,7 @@
         {
             "id": "integration-plan-missing-no-seed-rule",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "integration-plan",
             "file": ".azure/integration-plan.md",
             "operation": "replace",
@@ -115,6 +137,7 @@
         {
             "id": "integration-plan-missing-backend-run-command",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "integration-plan",
             "file": ".azure/integration-plan.md",
             "operation": "replace",
@@ -125,6 +148,7 @@
         {
             "id": "integration-plan-missing-route-inventory",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "integration-plan",
             "file": ".azure/integration-plan.md",
             "operation": "replace",
@@ -135,16 +159,18 @@
         {
             "id": "integration-plan-route-inventory-shadowed-by-auth-heading",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "integration-plan",
             "file": ".azure/integration-plan.md",
             "operation": "replace",
             "search": "## API Routes",
-            "replacement": "## Auth (required on every route except `/api/health`)\n\nMock API key — send `X-API-Key: <API_KEY>`. Missing key → `401 UNAUTHORIZED`.\n\n## API Routes",
+            "replacement": "## Auth (required on every route except `/api/health`)\n\nMock API key \u2014 send `X-API-Key: <API_KEY>`. Missing key \u2192 `401 UNAUTHORIZED`.\n\n## API Routes",
             "expectedCode": "passed"
         },
         {
             "id": "integration-plan-missing-api-seam",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "integration-plan",
             "file": ".azure/integration-plan.md",
             "operation": "replace",
@@ -155,6 +181,7 @@
         {
             "id": "integration-plan-missing-service-classification",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "integration-plan",
             "file": ".azure/integration-plan.md",
             "operation": "replace",
@@ -165,6 +192,7 @@
         {
             "id": "frontend-api-client-interface-dropped",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "frontend-scaffold",
             "file": "services/web/src/api/client.ts",
             "operation": "replace",
@@ -175,6 +203,7 @@
         {
             "id": "frontend-mock-client-dropped",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "frontend-scaffold",
             "file": "services/web/src/api/mockClient.ts",
             "operation": "replace",
@@ -185,6 +214,7 @@
         {
             "id": "integration-plan-no-seed-rule-in-heading",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "integration-plan",
             "file": ".azure/integration-plan.md",
             "operation": "replace",
@@ -195,6 +225,7 @@
         {
             "id": "integration-plan-no-seed-rule-as-table-row",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "integration-plan",
             "file": ".azure/integration-plan.md",
             "operation": "replace",
@@ -205,6 +236,7 @@
         {
             "id": "integration-plan-port-inside-run-command",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "integration-plan",
             "file": ".azure/integration-plan.md",
             "operation": "replace",
@@ -215,12 +247,165 @@
         {
             "id": "integration-plan-missing-backend-port",
             "tier": "offline",
+            "fixture": "sample-agent-output",
             "validator": "integration-plan",
             "file": ".azure/integration-plan.md",
             "operation": "replace",
             "search": "| Port | 7071 (override with `PORT`) |\n| Health endpoint | `GET /api/health` |",
             "replacement": "| Health endpoint | `GET /api/health` |",
             "expectedCode": "missingBackendPort"
+        },
+        {
+            "id": "debug-plan-table-concatenated",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-plan",
+            "file": ".azure/vscode-debug-plan.md",
+            "operation": "replace",
+            "search": "|---|---|---|---|---|---|---|---|\n",
+            "replacement": "|---|---|---|---|---|---|---|---|| [x] | Ghost App (debug) | Ghost App | `./ghost` | Backend | Node.js | 22.x | None |\n",
+            "expectedCode": "tableRowConcatenated"
+        },
+        {
+            "id": "debug-plan-checklist-stub",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-plan",
+            "file": ".azure/vscode-debug-plan.md",
+            "operation": "replace",
+            "search": "\u2705 Persistence \u2014 Created project remained visible after restarting the service, confirming the local JSON store is written through.",
+            "replacement": "\u2705 Persistence \u2014 TBD",
+            "expectedCode": "checklistStub"
+        },
+        {
+            "id": "debug-plan-diagram-dropped",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-plan",
+            "file": ".azure/vscode-debug-plan.md",
+            "operation": "replace",
+            "search": "## Architecture Diagram",
+            "replacement": "## Architecture Notes",
+            "expectedCode": "missingSection"
+        },
+        {
+            "id": "debug-plan-status-regressed",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-plan",
+            "file": ".azure/vscode-debug-plan.md",
+            "operation": "replace",
+            "search": "> **Status:** Implemented",
+            "replacement": "> **Status:** Planning",
+            "expectedCode": "unexpectedStatus"
+        },
+        {
+            "id": "debug-config-prelaunch-dangling",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-config",
+            "file": ".vscode/launch.json",
+            "operation": "replace",
+            "search": "\"preLaunchTask\": \"prepare\"",
+            "replacement": "\"preLaunchTask\": \"prepare-everything\"",
+            "expectedCode": "preLaunchTaskUnresolved"
+        },
+        {
+            "id": "debug-config-dependson-dangling",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-config",
+            "file": ".vscode/tasks.json",
+            "operation": "replace",
+            "search": "\"dependsOn\": \"install\"",
+            "replacement": "\"dependsOn\": \"restore\"",
+            "expectedCode": "dependsOnUnresolved"
+        },
+        {
+            "id": "debug-config-dependson-cycle",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-config",
+            "file": ".vscode/tasks.json",
+            "operation": "replace",
+            "search": "\"command\": \"npm ci --ignore-scripts\",",
+            "replacement": "\"command\": \"npm ci --ignore-scripts\",\n            \"dependsOn\": \"prepare\",",
+            "expectedCode": "dependsOnCycle"
+        },
+        {
+            "id": "debug-artifacts-unchecked-config-generated",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-artifacts",
+            "file": ".azure/vscode-debug-plan.md",
+            "operation": "replace",
+            "search": "| [x] | Golden App (debug) |",
+            "replacement": "| [ ] | Golden App (debug) |",
+            "expectedCode": "uncheckedConfigGenerated"
+        },
+        {
+            "id": "debug-artifacts-script-not-registered",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-artifacts",
+            "file": ".azure/vscode-debug-plan.md",
+            "operation": "replace",
+            "search": "| [x] | start | ./package.json |",
+            "replacement": "| [x] | serve | ./package.json |",
+            "expectedCode": "scriptNotRegistered"
+        },
+        {
+            "id": "debug-artifacts-api-collection-empty",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-artifacts",
+            "file": "api-test-collections/golden-app/health/invoke.sh",
+            "operation": "delete",
+            "expectedCode": "apiCollectionEmpty"
+        },
+        {
+            "id": "debug-config-task-run-options",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-config",
+            "file": ".vscode/tasks.json",
+            "operation": "replace",
+            "search": "\"instancePolicy\": \"silent\"",
+            "replacement": "\"instancePolicy\": \"prompt\"",
+            "expectedCode": "invalidTaskRunOptions"
+        },
+        {
+            "id": "debug-config-duplicate-task-label",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-config",
+            "file": ".vscode/tasks.json",
+            "operation": "replace",
+            "search": "\"label\": \"build\",",
+            "replacement": "\"label\": \"install\",",
+            "expectedCode": "duplicateTaskLabels"
+        },
+        {
+            "id": "debug-artifacts-extension-recommendations",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-artifacts",
+            "file": ".vscode/extensions.json",
+            "operation": "replace",
+            "search": "\"ms-vscode.js-debug\"",
+            "replacement": "\"js-debug\"",
+            "expectedCode": "invalidExtensionRecommendations"
+        },
+        {
+            "id": "debug-artifacts-redacted-secret",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "debug-artifacts",
+            "file": ".env.example",
+            "operation": "replace",
+            "replacement": "DATABASE_URL=postgres://golden:******@localhost:5432/golden",
+            "expectedCode": "redactedSecretPlaceholder",
+            "search": "PORT=7071"
         }
     ]
 }

--- a/evals/grader-certification/reference-node-fullstack/.azure/vscode-debug-plan.md
+++ b/evals/grader-certification/reference-node-fullstack/.azure/vscode-debug-plan.md
@@ -2,47 +2,56 @@
 
 > **Status:** Implemented
 > **Execution Mode:** Auto
+> **Created:** 2026-08-07T00:00:00.000Z
 > **Last Updated:** 2026-08-07T00:00:00.000Z
 
 ## Prerequisites
 
-| Tool | Installed |
-|---|---|
-| Node.js 22 | Yes |
-| npm | Yes |
+| Tool | Required Version | Installed | Action Required |
+|---|---|---|---|
+| Node.js | 22.x | ✅ | None |
+| npm | 10.x | ✅ | None |
 
 ## Debug Configurations
 
-| Generate | Debug Config Name | Service Root | Project Type | Runtime | Notes |
-|---|---|---|---|---|---|
-| [x] | Golden App (debug) | `.` | Backend | Node.js | Launch with CDP inspector |
+| Generate | Debug Config Name | Service Label | Service Root | Project Type | Runtime | Version | Azure Dependencies |
+|---|---|---|---|---|---|---|---|
+| [x] | Golden App (debug) | Golden App | `.` | Backend | Node.js | 22.x | None |
 
 ## Orchestrator
 
 | Orchestrator | Selected | Notes |
 |---|---|---|
-| VS Code task and launch configuration | Yes | Build before launch |
-
-## Architecture
-
-```text
-Browser -> Node.js API and static server -> JSON file
-             |
-             +-> CDP inspector on port 9229
-```
+| VS Code task and launch configuration | Yes | Single service, so no compound configuration is required. |
 
 ## Emulators
 
-No emulators are required.
+No emulators are required. The app persists to a local JSON file, so no containerized dependency is started.
+
+## Architecture Diagram
+
+```mermaid
+graph LR
+    Browser[Browser] --> App[Golden App<br/>Node.js API + static server]
+    App --> Store[(Local JSON file)]
+    Debugger[VS Code debugger] -. CDP :9229 .-> App
+```
+
+## Convenience Scripts
+
+| Generate | Script | Registered In | Purpose |
+|---|---|---|---|
+| [x] | start | ./package.json | Run the Golden App outside the debugger. |
 
 ## API Test Collections
 
-No generated API test collection is required.
+| Generate | Service | Endpoints | Notes |
+|---|---|---|---|
+| [x] | Golden App | GET /api/health | Health probe used to confirm the service is listening. |
 
 ## Debug Configuration Checklist
 
 Debug Configuration Checklist:
-
-✅ Golden App (debug) — HTTP health returned 200 and CDP inspector metadata was available.
-✅ Golden Project Tracker — browser interaction and accessibility checks passed.
-✅ Persistence — created project remained visible after service restart.
+✅ Golden App (debug) — Ready signal `Server listening on :3000` observed on the `prepare` task chain; `curl http://localhost:3000/api/health` → `200`; CDP inspector metadata available on `ws://127.0.0.1:9229`.
+✅ Golden Project Tracker — Browser interaction and accessibility checks passed against the served UI at `http://localhost:3000`.
+✅ Persistence — Created project remained visible after restarting the service, confirming the local JSON store is written through.

--- a/evals/grader-certification/reference-node-fullstack/.env.example
+++ b/evals/grader-certification/reference-node-fullstack/.env.example
@@ -1,0 +1,3 @@
+# Copy to .env before launching the Golden App (debug) configuration.
+PORT=7071
+DATA_FILE=./data/projects.json

--- a/evals/grader-certification/reference-node-fullstack/api-test-collections/golden-app/health/invoke.sh
+++ b/evals/grader-certification/reference-node-fullstack/api-test-collections/golden-app/health/invoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Health probe for the Golden App debug configuration.
+set -euo pipefail
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+curl --fail --silent --show-error "${BASE_URL}/api/health"

--- a/evals/graders/validate-debug-artifacts.ts
+++ b/evals/graders/validate-debug-artifacts.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Grades the generated workspace against the plan that specified it.
+ *
+ * The plan is the contract: every row marked `[x]` must have produced exactly one
+ * artifact, and every row marked `[ ]` must have produced none. This grader catches
+ * the case where generation quietly diverges from what the user approved.
+ */
+
+import { validateDebugArtifacts } from '../src/artifacts/debugArtifacts.ts';
+import { failWithIssues, runGraderAsync, workspacePath } from './graderHarness.ts';
+
+await runGraderAsync('generated debug artifacts match the approved plan', async () => {
+    const result = await validateDebugArtifacts(workspacePath('.'));
+    if (!result.valid) {
+        failWithIssues('plan/artifact conformance errors:', result.issues);
+    }
+});

--- a/evals/graders/validate-debug-config.ts
+++ b/evals/graders/validate-debug-config.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Grades the generated `.vscode/launch.json` and `.vscode/tasks.json` for structural
+ * soundness: named configurations, resolvable `preLaunchTask` and `dependsOn` chains,
+ * terminating dependency graphs, and compounds that start each service exactly once.
+ *
+ * These are the defects a user hits on the first F5, and they are all detectable
+ * without running anything.
+ *
+ * Flags: --assert-compound, --assert-no-compound, --assert-config-count=N
+ */
+
+import { existsSync } from 'node:fs';
+import { readLaunchDocument, validateDebugLaunchConfiguration } from '../src/artifacts/launchConfig.ts';
+import { fail, failWithIssues, readArtifact, runGrader, workspacePath } from './graderHarness.ts';
+
+runGrader('launch.json and tasks.json are structurally sound', () => {
+    const args = process.argv.slice(2);
+    const launchText = readArtifact('.vscode/launch.json');
+    // A workspace whose configurations declare no preLaunchTask legitimately has no
+    // tasks file; the validator reports a dangling reference if one is needed.
+    const tasksText = existsSync(workspacePath('.vscode/tasks.json')) ? readArtifact('.vscode/tasks.json') : undefined;
+
+    const result = validateDebugLaunchConfiguration(launchText, tasksText);
+    if (!result.valid) {
+        failWithIssues('debug configuration errors:', result.issues);
+    }
+
+    const launch = readLaunchDocument(launchText);
+    if (args.includes('--assert-compound') && launch.compounds.length === 0) {
+        fail('Expected a compound configuration for a multi-service project, found none');
+    }
+    if (args.includes('--assert-no-compound') && launch.compounds.length > 0) {
+        fail(`Expected no compound configuration for a single-service project, found ${launch.compounds.length}`);
+    }
+
+    const countFlag = args.find(arg => arg.startsWith('--assert-config-count='));
+    if (countFlag) {
+        const expected = Number(countFlag.split('=')[1]);
+        if (!Number.isInteger(expected) || expected < 0) {
+            // A bad flag is a miswired eval spec, not a product defect.
+            throw new Error(`Invalid ${countFlag}: expected a non-negative integer`);
+        }
+        if (launch.configurations.length !== expected) {
+            fail(`Expected ${expected} launch configurations, got ${launch.configurations.length}`);
+        }
+    }
+});

--- a/evals/graders/validate-debug-gate.ts
+++ b/evals/graders/validate-debug-gate.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Grades the approval gate at the end of the planning phase.
+ *
+ * `azure-debug-plan` is contracted to produce the plan and then STOP: it must not
+ * write launch/tasks configuration, a compose file, or scripts before the user has
+ * approved. Generating early is the failure mode this grader exists to catch, so it
+ * asserts both that the plan is present and reviewable, and that nothing downstream
+ * of the gate has appeared yet.
+ *
+ * Flags: --assert-status=<status>   (defaults to Planning)
+ */
+
+import { existsSync } from 'node:fs';
+import { validateLocalDebugPlanArtifact } from '../src/artifacts/localDebugPlan.ts';
+import { fail, failWithIssues, readArtifact, runGrader, workspacePath } from './graderHarness.ts';
+
+/**
+ * Artifacts that *only* the generation phase can create.
+ *
+ * Compose files are deliberately absent. A scaffolded project may already ship a
+ * `docker-compose.yml` for its own dependencies — `azure-debug-plan` is contracted to
+ * *merge* into an existing compose file rather than overwrite it — so its presence at
+ * the gate proves nothing about whether generation ran. Detecting a premature *merge*
+ * would need a pre-gate baseline to diff against, which a post-hoc grader does not have.
+ * These three are unambiguous: nothing upstream of the gate writes them.
+ */
+const POST_GATE_ARTIFACTS = [
+    '.vscode/launch.json',
+    '.vscode/tasks.json',
+    'api-test-collections',
+];
+
+runGrader('debug planning stopped at the approval gate', () => {
+    const args = process.argv.slice(2);
+    const expectedStatus = args.find(arg => arg.startsWith('--assert-status='))?.split('=')[1] || 'Planning';
+
+    const content = readArtifact('.azure/vscode-debug-plan.md');
+    const result = validateLocalDebugPlanArtifact(content, { expectedStatus });
+    if (!result.valid) {
+        failWithIssues('debug plan is not in a reviewable state at the gate:', result.issues);
+    }
+
+    const premature = POST_GATE_ARTIFACTS.filter(relativePath => existsSync(workspacePath(relativePath)));
+    if (premature.length > 0) {
+        fail(`Generation ran before approval — found ${premature.join(', ')}`);
+    }
+});

--- a/evals/graders/validate-debug-plan.ts
+++ b/evals/graders/validate-debug-plan.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Grades `.azure/vscode-debug-plan.md` against the certified debug-plan validator.
+ *
+ * Contract checks (header, table integrity, required sections, checklist) live in
+ * `evals/src/artifacts/localDebugPlan.ts`. Only scenario-specific expectations —
+ * how many services this project has, which emulators it needs — are expressed here.
+ *
+ * Flags: --assert-status=<Planning|Approved|Executing|Implemented>
+ *        --assert-service-count=N
+ *        --assert-emulator=<substring>   (repeatable)
+ *        --assert-no-emulators
+ *        --assert-checklist
+ */
+
+import type { LocalDebugPlanExpectations } from '../src/artifacts/localDebugPlan.ts';
+import { validateLocalDebugPlanArtifact } from '../src/artifacts/localDebugPlan.ts';
+import { failWithIssues, readArtifact, runGrader } from './graderHarness.ts';
+
+runGrader('vscode-debug-plan.md satisfies the debug plan contract', () => {
+    const args = process.argv.slice(2);
+    const content = readArtifact('.azure/vscode-debug-plan.md');
+
+    const expectations: LocalDebugPlanExpectations = {
+        expectedStatus: valueOf(args, '--assert-status'),
+        expectedServiceCount: countOf(args, '--assert-service-count'),
+        expectedEmulators: valuesOf(args, '--assert-emulator'),
+        expectNoEmulators: args.includes('--assert-no-emulators'),
+        requireChecklist: args.includes('--assert-checklist'),
+    };
+
+    const result = validateLocalDebugPlanArtifact(content, expectations);
+    if (!result.valid) {
+        failWithIssues('debug plan validation errors:', result.issues);
+    }
+});
+
+function valueOf(args: string[], flag: string): string | undefined {
+    const match = args.find(arg => arg.startsWith(`${flag}=`));
+    return match?.slice(flag.length + 1) || undefined;
+}
+
+function valuesOf(args: string[], flag: string): string[] | undefined {
+    const values = args.filter(arg => arg.startsWith(`${flag}=`)).map(arg => arg.slice(flag.length + 1)).filter(Boolean);
+    return values.length ? values : undefined;
+}
+
+function countOf(args: string[], flag: string): number | undefined {
+    const raw = valueOf(args, flag);
+    if (raw === undefined) {
+        return undefined;
+    }
+    const parsed = Number(raw);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+        // A bad flag is a miswired eval spec, not a product defect. Throwing a plain
+        // Error routes it to exit 3 so the report blames the harness.
+        throw new Error(`Invalid ${flag}=${raw}: expected a non-negative integer`);
+    }
+    return parsed;
+}

--- a/evals/local-dev/eval.yaml
+++ b/evals/local-dev/eval.yaml
@@ -1,0 +1,104 @@
+name: azure-local-dev-contracts
+description: >
+  Verify the local development phase — azure-debug-plan scans a real scaffolded
+  workspace and produces a valid debug plan, stops at the approval gate, and
+  azure-debug-generate emits launch/tasks/compose artifacts that conform to it.
+type: capability
+
+defaults:
+  runs: 1
+  # Scaffolding a real project before the debug phase runs is slow; this is a
+  # chained multi-agent suite, not a single-turn one.
+  timeout: 45m
+  executor: azure-agent-executor
+
+# Chain the *real* scaffold agent so the debug agents analyse genuine generated
+# output rather than a hand-written fixture that can drift from what scaffold emits.
+# Only the approved plan is seeded: azure-project-scaffold requires
+# `.azure/project-plan.md` to exist and be Approved, but does not require the
+# azure-project-plan agent to have produced it — so we skip the cost and flakiness
+# of the requirements phase without giving up scaffold fidelity.
+environment:
+  files:
+    - src: ${REPO_ROOT=../..}/evals/local-dev/fixtures/functions-postgres/.azure/project-plan.md
+      dest: .azure/project-plan.md
+  env:
+    # The executor loads every agent named here, so skill activation is chosen by
+    # the model from the shipped descriptions, exactly as it is in VS Code.
+    AZURE_EVAL_AGENTS: azure-project-scaffold,azure-debug-plan,azure-debug-generate
+
+stimuli:
+  # ─── 2.1 Debug plan stops at the approval gate ────────────────────────────
+  - name: debug-plan-approval-gate
+    turns:
+      - |
+        The project plan has been approved. Execute the approved
+        `.azure/project-plan.md` and scaffold the project.
+      - |
+        Now set up local debugging for this project so I can hit F5 in VS Code.
+    graders:
+      - type: file-exists
+        name: debug-plan-exists
+        config:
+          path: .azure/vscode-debug-plan.md
+      - type: program
+        name: debug-plan-contract-valid
+        config:
+          program: node
+          args: [--disable-warning=MODULE_TYPELESS_PACKAGE_JSON, ${REPO_ROOT=../..}/evals/graders/validate-debug-plan.ts]
+      - type: program
+        name: stops-at-approval-gate
+        config:
+          program: node
+          args: [--disable-warning=MODULE_TYPELESS_PACKAGE_JSON, ${REPO_ROOT=../..}/evals/graders/validate-debug-gate.ts]
+      - type: tool-calls
+        name: opens-local-plan-view
+        config:
+          required: [workflow-tools-open_local_plan_view]
+      - type: tool-calls
+        name: no-premature-generate-handoff
+        config:
+          disallowed: [workflow-tools-start_azure_debug_generate]
+    constraints:
+      reject_tools: [vscode_askQuestions]
+
+  # ─── 2.2 Approved plan generates conforming artifacts ─────────────────────
+  - name: debug-generate-artifacts
+    turns:
+      - |
+        The project plan has been approved. Execute the approved
+        `.azure/project-plan.md` and scaffold the project.
+      - |
+        Now set up local debugging for this project so I can hit F5 in VS Code.
+      - "The debug plan looks good, approved. Generate the configuration."
+      # azure-debug-plan is contracted to call start_azure_debug_generate and STOP
+      # (azure-debug-plan.agent.md step 4). In VS Code that tool call spawns the
+      # generate agent; the harness MCP tool is a stub, so this turn carries the
+      # exact hand-off prompt the tool would have sent, verbatim from that step.
+      - "The local debugging plan has been approved. Now generate the artifacts as specified by `.azure/vscode-debug-plan.md`."
+    graders:
+      - type: file-exists
+        name: launch-json-exists
+        config:
+          path: .vscode/launch.json
+      - type: program
+        name: debug-plan-implemented
+        config:
+          program: node
+          args: [--disable-warning=MODULE_TYPELESS_PACKAGE_JSON, ${REPO_ROOT=../..}/evals/graders/validate-debug-plan.ts, --assert-status=Implemented, --assert-checklist]
+      - type: program
+        name: debug-config-structurally-sound
+        config:
+          program: node
+          args: [--disable-warning=MODULE_TYPELESS_PACKAGE_JSON, ${REPO_ROOT=../..}/evals/graders/validate-debug-config.ts]
+      - type: program
+        name: artifacts-conform-to-plan
+        config:
+          program: node
+          args: [--disable-warning=MODULE_TYPELESS_PACKAGE_JSON, ${REPO_ROOT=../..}/evals/graders/validate-debug-artifacts.ts]
+      - type: tool-calls
+        name: generate-handoff
+        config:
+          required: [workflow-tools-start_azure_debug_generate]
+    constraints:
+      reject_tools: [vscode_askQuestions]

--- a/evals/local-dev/fixtures/functions-postgres/.azure/project-plan.md
+++ b/evals/local-dev/fixtures/functions-postgres/.azure/project-plan.md
@@ -1,0 +1,70 @@
+# Project Plan
+
+**Status**: Approved
+**Created**: 2026-08-24
+**Mode**: New Project
+
+## 1. Project Overview
+
+**App Type**: Web Application
+
+Build a task tracker with a React frontend, an Azure Functions HTTP backend, and a
+PostgreSQL database for durable storage. Uploaded attachments are held in Blob Storage.
+
+### User Flow
+
+A user opens the tracker, creates a task with an optional attachment, and sees the
+task persist across restarts.
+
+### Architecture
+
+- A React single-page app calls the Functions API.
+- An Azure Functions (Node.js) app exposes the task routes.
+- PostgreSQL stores task records; Blob Storage holds attachments.
+
+## 2. Services Required
+
+| Name | Responsibility |
+|---|---|
+| web | React frontend for creating and listing tasks |
+| api | Azure Functions HTTP API for task CRUD |
+| database | PostgreSQL store for task records |
+| storage | Blob Storage for task attachments |
+
+## 3. Prerequisites
+
+- Node.js 22
+- npm
+- Docker (for the local PostgreSQL and Azurite containers)
+- Azure Functions Core Tools v4
+
+## 4. Project Structure
+
+```text
+web/src/App.tsx
+web/package.json
+api/src/functions/tasks.js
+api/host.json
+api/package.json
+```
+
+## 5. Route Definitions
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | /api/health | Liveness probe |
+| GET | /api/tasks | List tasks |
+| POST | /api/tasks | Create a task |
+
+## 6. Azure Dependencies
+
+| Dependency | Service | Local Emulator |
+|---|---|---|
+| PostgreSQL | database | `postgres:16` container |
+| Blob Storage | storage | Azurite container |
+
+## 7. Acceptance Criteria
+
+- `GET /api/health` returns 200.
+- A created task survives an API restart.
+- The frontend lists tasks returned by the API.

--- a/evals/package-lock.json
+++ b/evals/package-lock.json
@@ -10,7 +10,8 @@
             "license": "MIT",
             "dependencies": {
                 "@github/copilot-sdk": "^1.0.9-preview.2",
-                "@microsoft/vally": "0.13.0"
+                "@microsoft/vally": "0.13.0",
+                "jsonc-parser": "^2.3.1"
             },
             "devDependencies": {
                 "@microsoft/vally-cli": "0.13.0",
@@ -1200,6 +1201,12 @@
             "dependencies": {
                 "base64-js": "^1.5.1"
             }
+        },
+        "node_modules/jsonc-parser": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+            "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+            "license": "MIT"
         },
         "node_modules/jsonfile": {
             "version": "6.2.1",

--- a/evals/package.json
+++ b/evals/package.json
@@ -8,7 +8,9 @@
         "eval": "node run-eval.cjs",
         "eval:plan": "node run-eval.cjs --suite project-plan",
         "drift": "node check-agent-drift.ts",
-        "lint": "vally lint --eval-spec project-plan/eval.yaml",
+        "lint": "npm run lint:plan && npm run lint:local-dev",
+        "lint:plan": "vally lint --eval-spec project-plan/eval.yaml",
+        "lint:local-dev": "vally lint --eval-spec local-dev/eval.yaml",
         "typecheck": "tsc --noEmit -p tsconfig.json",
         "certify": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON src/graderCertification.ts",
         "regrade": "node --disable-warning=ExperimentalWarning msbench/regrade.ts",
@@ -19,7 +21,8 @@
     "license": "MIT",
     "dependencies": {
         "@github/copilot-sdk": "^1.0.9-preview.2",
-        "@microsoft/vally": "0.13.0"
+        "@microsoft/vally": "0.13.0",
+        "jsonc-parser": "^2.3.1"
     },
     "devDependencies": {
         "@microsoft/vally-cli": "0.13.0",

--- a/evals/results/grader-certification/offline/report.json
+++ b/evals/results/grader-certification/offline/report.json
@@ -1,13 +1,17 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-26T03:11:58.458Z",
+  "generatedAt": "2026-08-26T03:12:21.319Z",
   "mode": "offline",
-  "fixture": "sample-agent-output",
+  "fixtures": [
+    "sample-agent-output",
+    "reference-node-fullstack"
+  ],
   "outcome": "passed",
   "cases": [
     {
       "id": "golden-requirements",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "requirements",
       "expected": "passed",
       "actual": [],
@@ -17,6 +21,7 @@
     {
       "id": "golden-project-plan",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "project-plan",
       "expected": "passed",
       "actual": [],
@@ -26,6 +31,7 @@
     {
       "id": "golden-plan-gate",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "plan-gate",
       "expected": "passed",
       "actual": [],
@@ -35,6 +41,7 @@
     {
       "id": "golden-preview",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "preview",
       "expected": "passed",
       "actual": [],
@@ -44,6 +51,7 @@
     {
       "id": "golden-integration-plan",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "integration-plan",
       "expected": "passed",
       "actual": [],
@@ -53,6 +61,7 @@
     {
       "id": "golden-frontend-scaffold",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "frontend-scaffold",
       "expected": "passed",
       "actual": [],
@@ -62,6 +71,7 @@
     {
       "id": "requirements-schema-version",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "requirements",
       "expected": "schemaVersion",
       "actual": [
@@ -73,6 +83,7 @@
     {
       "id": "project-plan-numbering",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "project-plan",
       "expected": "nonSequentialHeading",
       "actual": [
@@ -85,6 +96,7 @@
     {
       "id": "plan-gate-frontend-dropped",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "plan-gate",
       "expected": "frontendIntentMismatch",
       "actual": [
@@ -96,6 +108,7 @@
     {
       "id": "plan-gate-preview-manifest-missing",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "plan-gate",
       "expected": "previewManifestMissingAtGate",
       "actual": [
@@ -107,6 +120,7 @@
     {
       "id": "preview-not-ready",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "preview",
       "expected": "previewNotReady",
       "actual": [
@@ -118,6 +132,7 @@
     {
       "id": "frontend-preview-not-embeddable",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "frontend-scaffold",
       "expected": "devServerRejectsWebviewOrigin",
       "actual": [
@@ -129,6 +144,7 @@
     {
       "id": "frontend-dev-script-does-not-serve",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "frontend-scaffold",
       "expected": "devScriptDoesNotServe",
       "actual": [
@@ -140,6 +156,7 @@
     {
       "id": "frontend-frame-busting-csp",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "frontend-scaffold",
       "expected": "previewFrameBusting",
       "actual": [
@@ -151,6 +168,7 @@
     {
       "id": "frontend-api-seam-bypassed",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "frontend-scaffold",
       "expected": "apiSeamBypassed",
       "actual": [
@@ -162,6 +180,7 @@
     {
       "id": "integration-plan-missing-no-seed-rule",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "integration-plan",
       "expected": "missingNoSeedRule",
       "actual": [
@@ -173,6 +192,7 @@
     {
       "id": "integration-plan-missing-backend-run-command",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "integration-plan",
       "expected": "missingBackendCommand",
       "actual": [
@@ -184,6 +204,7 @@
     {
       "id": "integration-plan-missing-route-inventory",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "integration-plan",
       "expected": "missingRouteInventory",
       "actual": [
@@ -195,6 +216,7 @@
     {
       "id": "integration-plan-route-inventory-shadowed-by-auth-heading",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "integration-plan",
       "expected": "passed",
       "actual": [],
@@ -204,6 +226,7 @@
     {
       "id": "integration-plan-missing-api-seam",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "integration-plan",
       "expected": "missingApiSeam",
       "actual": [
@@ -215,6 +238,7 @@
     {
       "id": "integration-plan-missing-service-classification",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "integration-plan",
       "expected": "missingServiceClassification",
       "actual": [
@@ -226,6 +250,7 @@
     {
       "id": "frontend-api-client-interface-dropped",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "frontend-scaffold",
       "expected": "missingApiClientInterface",
       "actual": [
@@ -237,6 +262,7 @@
     {
       "id": "frontend-mock-client-dropped",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "frontend-scaffold",
       "expected": "missingMockClient",
       "actual": [
@@ -248,6 +274,7 @@
     {
       "id": "integration-plan-no-seed-rule-in-heading",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "integration-plan",
       "expected": "passed",
       "actual": [],
@@ -257,6 +284,7 @@
     {
       "id": "integration-plan-no-seed-rule-as-table-row",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "integration-plan",
       "expected": "passed",
       "actual": [],
@@ -266,6 +294,7 @@
     {
       "id": "integration-plan-port-inside-run-command",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "integration-plan",
       "expected": "passed",
       "actual": [],
@@ -275,10 +304,212 @@
     {
       "id": "integration-plan-missing-backend-port",
       "tier": "offline",
+      "fixture": "sample-agent-output",
       "validator": "integration-plan",
       "expected": "missingBackendPort",
       "actual": [
         "missingBackendPort"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "golden-debug-plan",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-plan",
+      "expected": "passed",
+      "actual": [],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "golden-debug-config",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-config",
+      "expected": "passed",
+      "actual": [],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "golden-debug-artifacts",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-artifacts",
+      "expected": "passed",
+      "actual": [],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-plan-table-concatenated",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-plan",
+      "expected": "tableRowConcatenated",
+      "actual": [
+        "tableRowConcatenated",
+        "invalidGenerateMarker"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-plan-checklist-stub",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-plan",
+      "expected": "checklistStub",
+      "actual": [
+        "checklistStub"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-plan-diagram-dropped",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-plan",
+      "expected": "missingSection",
+      "actual": [
+        "missingSection"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-plan-status-regressed",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-plan",
+      "expected": "unexpectedStatus",
+      "actual": [
+        "unexpectedStatus"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-config-prelaunch-dangling",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-config",
+      "expected": "preLaunchTaskUnresolved",
+      "actual": [
+        "preLaunchTaskUnresolved"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-config-dependson-dangling",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-config",
+      "expected": "dependsOnUnresolved",
+      "actual": [
+        "dependsOnUnresolved"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-config-dependson-cycle",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-config",
+      "expected": "dependsOnCycle",
+      "actual": [
+        "dependsOnCycle"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-artifacts-unchecked-config-generated",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-artifacts",
+      "expected": "uncheckedConfigGenerated",
+      "actual": [
+        "uncheckedConfigGenerated"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-artifacts-script-not-registered",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-artifacts",
+      "expected": "scriptNotRegistered",
+      "actual": [
+        "scriptNotRegistered"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-artifacts-api-collection-empty",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-artifacts",
+      "expected": "apiCollectionEmpty",
+      "actual": [
+        "apiCollectionEmpty"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-config-task-run-options",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-config",
+      "expected": "invalidTaskRunOptions",
+      "actual": [
+        "invalidTaskRunOptions"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-config-duplicate-task-label",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-config",
+      "expected": "duplicateTaskLabels",
+      "actual": [
+        "duplicateTaskLabels",
+        "dependsOnUnresolved",
+        "dependsOnCycle"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-artifacts-extension-recommendations",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-artifacts",
+      "expected": "invalidExtensionRecommendations",
+      "actual": [
+        "invalidExtensionRecommendations"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "debug-artifacts-redacted-secret",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "debug-artifacts",
+      "expected": "redactedSecretPlaceholder",
+      "actual": [
+        "redactedSecretPlaceholder"
       ],
       "passed": true,
       "durationMs": 0

--- a/evals/results/grader-certification/offline/report.md
+++ b/evals/results/grader-certification/offline/report.md
@@ -1,37 +1,54 @@
 # Copilot on Rails Grader Certification
 
 - Mode: `offline`
-- Fixture: `sample-agent-output`
+- Fixtures: `sample-agent-output`, `reference-node-fullstack`
 - Outcome: **PASSED**
-- Cases: 27/27 passed
+- Cases: 44/44 passed
 
-| Case | Validator | Expected | Actual | Result |
-|---|---|---|---|---|
-| `golden-requirements` | `requirements` | `passed` | `passed` | PASS |
-| `golden-project-plan` | `project-plan` | `passed` | `passed` | PASS |
-| `golden-plan-gate` | `plan-gate` | `passed` | `passed` | PASS |
-| `golden-preview` | `preview` | `passed` | `passed` | PASS |
-| `golden-integration-plan` | `integration-plan` | `passed` | `passed` | PASS |
-| `golden-frontend-scaffold` | `frontend-scaffold` | `passed` | `passed` | PASS |
-| `requirements-schema-version` | `requirements` | `schemaVersion` | `schemaVersion` | PASS |
-| `project-plan-numbering` | `project-plan` | `nonSequentialHeading` | `nonSequentialHeading, nonSequentialHeading` | PASS |
-| `plan-gate-frontend-dropped` | `plan-gate` | `frontendIntentMismatch` | `frontendIntentMismatch` | PASS |
-| `plan-gate-preview-manifest-missing` | `plan-gate` | `previewManifestMissingAtGate` | `previewManifestMissingAtGate` | PASS |
-| `preview-not-ready` | `preview` | `previewNotReady` | `previewNotReady` | PASS |
-| `frontend-preview-not-embeddable` | `frontend-scaffold` | `devServerRejectsWebviewOrigin` | `devServerRejectsWebviewOrigin` | PASS |
-| `frontend-dev-script-does-not-serve` | `frontend-scaffold` | `devScriptDoesNotServe` | `devScriptDoesNotServe` | PASS |
-| `frontend-frame-busting-csp` | `frontend-scaffold` | `previewFrameBusting` | `previewFrameBusting` | PASS |
-| `frontend-api-seam-bypassed` | `frontend-scaffold` | `apiSeamBypassed` | `apiSeamBypassed` | PASS |
-| `integration-plan-missing-no-seed-rule` | `integration-plan` | `missingNoSeedRule` | `missingNoSeedRule` | PASS |
-| `integration-plan-missing-backend-run-command` | `integration-plan` | `missingBackendCommand` | `missingBackendCommand` | PASS |
-| `integration-plan-missing-route-inventory` | `integration-plan` | `missingRouteInventory` | `missingRouteInventory` | PASS |
-| `integration-plan-route-inventory-shadowed-by-auth-heading` | `integration-plan` | `passed` | `passed` | PASS |
-| `integration-plan-missing-api-seam` | `integration-plan` | `missingApiSeam` | `missingApiSeam` | PASS |
-| `integration-plan-missing-service-classification` | `integration-plan` | `missingServiceClassification` | `missingServiceClassification` | PASS |
-| `frontend-api-client-interface-dropped` | `frontend-scaffold` | `missingApiClientInterface` | `missingApiClientInterface` | PASS |
-| `frontend-mock-client-dropped` | `frontend-scaffold` | `missingMockClient` | `missingMockClient` | PASS |
-| `integration-plan-no-seed-rule-in-heading` | `integration-plan` | `passed` | `passed` | PASS |
-| `integration-plan-no-seed-rule-as-table-row` | `integration-plan` | `passed` | `passed` | PASS |
-| `integration-plan-port-inside-run-command` | `integration-plan` | `passed` | `passed` | PASS |
-| `integration-plan-missing-backend-port` | `integration-plan` | `missingBackendPort` | `missingBackendPort` | PASS |
+| Case | Fixture | Validator | Expected | Actual | Result |
+|---|---|---|---|---|---|
+| `golden-requirements` | `sample-agent-output` | `requirements` | `passed` | `passed` | PASS |
+| `golden-project-plan` | `sample-agent-output` | `project-plan` | `passed` | `passed` | PASS |
+| `golden-plan-gate` | `sample-agent-output` | `plan-gate` | `passed` | `passed` | PASS |
+| `golden-preview` | `sample-agent-output` | `preview` | `passed` | `passed` | PASS |
+| `golden-integration-plan` | `sample-agent-output` | `integration-plan` | `passed` | `passed` | PASS |
+| `golden-frontend-scaffold` | `sample-agent-output` | `frontend-scaffold` | `passed` | `passed` | PASS |
+| `requirements-schema-version` | `sample-agent-output` | `requirements` | `schemaVersion` | `schemaVersion` | PASS |
+| `project-plan-numbering` | `sample-agent-output` | `project-plan` | `nonSequentialHeading` | `nonSequentialHeading, nonSequentialHeading` | PASS |
+| `plan-gate-frontend-dropped` | `sample-agent-output` | `plan-gate` | `frontendIntentMismatch` | `frontendIntentMismatch` | PASS |
+| `plan-gate-preview-manifest-missing` | `sample-agent-output` | `plan-gate` | `previewManifestMissingAtGate` | `previewManifestMissingAtGate` | PASS |
+| `preview-not-ready` | `sample-agent-output` | `preview` | `previewNotReady` | `previewNotReady` | PASS |
+| `frontend-preview-not-embeddable` | `sample-agent-output` | `frontend-scaffold` | `devServerRejectsWebviewOrigin` | `devServerRejectsWebviewOrigin` | PASS |
+| `frontend-dev-script-does-not-serve` | `sample-agent-output` | `frontend-scaffold` | `devScriptDoesNotServe` | `devScriptDoesNotServe` | PASS |
+| `frontend-frame-busting-csp` | `sample-agent-output` | `frontend-scaffold` | `previewFrameBusting` | `previewFrameBusting` | PASS |
+| `frontend-api-seam-bypassed` | `sample-agent-output` | `frontend-scaffold` | `apiSeamBypassed` | `apiSeamBypassed` | PASS |
+| `integration-plan-missing-no-seed-rule` | `sample-agent-output` | `integration-plan` | `missingNoSeedRule` | `missingNoSeedRule` | PASS |
+| `integration-plan-missing-backend-run-command` | `sample-agent-output` | `integration-plan` | `missingBackendCommand` | `missingBackendCommand` | PASS |
+| `integration-plan-missing-route-inventory` | `sample-agent-output` | `integration-plan` | `missingRouteInventory` | `missingRouteInventory` | PASS |
+| `integration-plan-route-inventory-shadowed-by-auth-heading` | `sample-agent-output` | `integration-plan` | `passed` | `passed` | PASS |
+| `integration-plan-missing-api-seam` | `sample-agent-output` | `integration-plan` | `missingApiSeam` | `missingApiSeam` | PASS |
+| `integration-plan-missing-service-classification` | `sample-agent-output` | `integration-plan` | `missingServiceClassification` | `missingServiceClassification` | PASS |
+| `frontend-api-client-interface-dropped` | `sample-agent-output` | `frontend-scaffold` | `missingApiClientInterface` | `missingApiClientInterface` | PASS |
+| `frontend-mock-client-dropped` | `sample-agent-output` | `frontend-scaffold` | `missingMockClient` | `missingMockClient` | PASS |
+| `integration-plan-no-seed-rule-in-heading` | `sample-agent-output` | `integration-plan` | `passed` | `passed` | PASS |
+| `integration-plan-no-seed-rule-as-table-row` | `sample-agent-output` | `integration-plan` | `passed` | `passed` | PASS |
+| `integration-plan-port-inside-run-command` | `sample-agent-output` | `integration-plan` | `passed` | `passed` | PASS |
+| `integration-plan-missing-backend-port` | `sample-agent-output` | `integration-plan` | `missingBackendPort` | `missingBackendPort` | PASS |
+| `golden-debug-plan` | `reference-node-fullstack` | `debug-plan` | `passed` | `passed` | PASS |
+| `golden-debug-config` | `reference-node-fullstack` | `debug-config` | `passed` | `passed` | PASS |
+| `golden-debug-artifacts` | `reference-node-fullstack` | `debug-artifacts` | `passed` | `passed` | PASS |
+| `debug-plan-table-concatenated` | `reference-node-fullstack` | `debug-plan` | `tableRowConcatenated` | `tableRowConcatenated, invalidGenerateMarker` | PASS |
+| `debug-plan-checklist-stub` | `reference-node-fullstack` | `debug-plan` | `checklistStub` | `checklistStub` | PASS |
+| `debug-plan-diagram-dropped` | `reference-node-fullstack` | `debug-plan` | `missingSection` | `missingSection` | PASS |
+| `debug-plan-status-regressed` | `reference-node-fullstack` | `debug-plan` | `unexpectedStatus` | `unexpectedStatus` | PASS |
+| `debug-config-prelaunch-dangling` | `reference-node-fullstack` | `debug-config` | `preLaunchTaskUnresolved` | `preLaunchTaskUnresolved` | PASS |
+| `debug-config-dependson-dangling` | `reference-node-fullstack` | `debug-config` | `dependsOnUnresolved` | `dependsOnUnresolved` | PASS |
+| `debug-config-dependson-cycle` | `reference-node-fullstack` | `debug-config` | `dependsOnCycle` | `dependsOnCycle` | PASS |
+| `debug-artifacts-unchecked-config-generated` | `reference-node-fullstack` | `debug-artifacts` | `uncheckedConfigGenerated` | `uncheckedConfigGenerated` | PASS |
+| `debug-artifacts-script-not-registered` | `reference-node-fullstack` | `debug-artifacts` | `scriptNotRegistered` | `scriptNotRegistered` | PASS |
+| `debug-artifacts-api-collection-empty` | `reference-node-fullstack` | `debug-artifacts` | `apiCollectionEmpty` | `apiCollectionEmpty` | PASS |
+| `debug-config-task-run-options` | `reference-node-fullstack` | `debug-config` | `invalidTaskRunOptions` | `invalidTaskRunOptions` | PASS |
+| `debug-config-duplicate-task-label` | `reference-node-fullstack` | `debug-config` | `duplicateTaskLabels` | `duplicateTaskLabels, dependsOnUnresolved, dependsOnCycle` | PASS |
+| `debug-artifacts-extension-recommendations` | `reference-node-fullstack` | `debug-artifacts` | `invalidExtensionRecommendations` | `invalidExtensionRecommendations` | PASS |
+| `debug-artifacts-redacted-secret` | `reference-node-fullstack` | `debug-artifacts` | `redactedSecretPlaceholder` | `redactedSecretPlaceholder` | PASS |
 

--- a/evals/src/artifacts/debugArtifacts.ts
+++ b/evals/src/artifacts/debugArtifacts.ts
@@ -1,0 +1,354 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Conformance between `.azure/vscode-debug-plan.md` and the artifacts the generation
+ * phase produced from it.
+ *
+ * The generation contract is "the plan specifies WHAT to generate" and "only generate
+ * artifacts for rows where Generate is checked (`[x]`)". So every checked row must
+ * yield exactly one artifact, and every unchecked row must yield none — a plan that
+ * silently disagrees with the workspace is the failure this catches.
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import type { ParsedDebugPlan } from './localDebugPlan.ts';
+import { parseDebugPlan } from './localDebugPlan.ts';
+import { validateDebugEnvironment } from './debugEnvironment.ts';
+import { parseJsonc, readLaunchDocument, readTasksDocument, validateDebugLaunchConfiguration } from './launchConfig.ts';
+import type { ArtifactValidationIssue, ArtifactValidationResult } from './validationTypes.ts';
+import { createValidationResult } from './validationTypes.ts';
+
+const PLAN_PATH = path.join('.azure', 'vscode-debug-plan.md');
+const LAUNCH_PATH = path.join('.vscode', 'launch.json');
+const TASKS_PATH = path.join('.vscode', 'tasks.json');
+const EXTENSIONS_PATH = path.join('.vscode', 'extensions.json');
+const API_COLLECTIONS_DIR = 'api-test-collections';
+
+/** Compose file names the orchestrator may emit, in the order the plan prefers them. */
+const COMPOSE_FILES = ['docker-compose.yml', 'docker-compose.yaml', 'compose.yml', 'compose.yaml'];
+
+export async function validateDebugArtifacts(workspace: string): Promise<ArtifactValidationResult> {
+    const issues: ArtifactValidationIssue[] = [];
+
+    const planText = await readIfExists(path.join(workspace, PLAN_PATH));
+    if (planText === undefined) {
+        return createValidationResult([issue('planMissing', '$', `${path.join(workspace, PLAN_PATH)} does not exist, so no artifact can be checked against it.`)]);
+    }
+    const plan = parseDebugPlan(planText);
+
+    const launchText = await readIfExists(path.join(workspace, LAUNCH_PATH));
+    const tasksText = await readIfExists(path.join(workspace, TASKS_PATH));
+    if (launchText === undefined) {
+        issues.push(issue('launchJsonMissing', '$.launch', `${LAUNCH_PATH} was never generated.`));
+    }
+
+    if (launchText !== undefined) {
+        // Structural problems make the conformance comparison meaningless, so report
+        // them and skip the name matching rather than emitting cascading noise.
+        const structural = validateDebugLaunchConfiguration(launchText, tasksText);
+        const fatal = structural.issues.filter(entry => entry.code.endsWith('Unparseable'));
+        if (fatal.length > 0) {
+            return createValidationResult([...issues, ...fatal]);
+        }
+        validateConfigConformance(plan, launchText, issues);
+    }
+
+    await validateEmulatorArtifacts(workspace, plan, issues);
+    await validateExtensionRecommendations(workspace, issues);
+    await validateConvenienceScripts(workspace, plan, issues);
+    await validateApiTestCollections(workspace, plan, issues);
+
+    await validateDebugEnvironment(workspace, {
+        hasEmulators: plan.emulators.length > 0,
+        taskLabels: readTaskLabels(tasksText),
+        planText,
+    }, issues);
+
+    return createValidationResult(issues);
+}
+
+function readTaskLabels(tasksText: string | undefined): Set<string> {
+    if (tasksText === undefined) {
+        return new Set();
+    }
+    try {
+        return new Set(readTasksDocument(tasksText)
+            .tasks
+            .flatMap(task => (typeof task.label === 'string' ? [task.label] : [])));
+    } catch {
+        // A malformed tasks.json is already reported by the structural validator.
+        return new Set();
+    }
+}
+
+/**
+ * Without a recommendation for the debugger the scenario needs, the user is asked to
+ * install nothing and F5 fails with an unresolved debug type.
+ */
+async function validateExtensionRecommendations(workspace: string, issues: ArtifactValidationIssue[]): Promise<void> {
+    const raw = await readIfExists(path.join(workspace, EXTENSIONS_PATH));
+    if (raw === undefined) {
+        issues.push(issue('extensionRecommendationsMissing', '$.extensions', `${EXTENSIONS_PATH} was never generated.`));
+        return;
+    }
+    let recommendations: unknown;
+    try {
+        recommendations = (parseJsonc(raw) as { recommendations?: unknown } | null)?.recommendations;
+    } catch (error) {
+        issues.push(issue('extensionsJsonUnparseable', '$.extensions', describeError(error)));
+        return;
+    }
+    const entries = Array.isArray(recommendations) ? recommendations : [];
+    // A marketplace id is always `publisher.extension`; anything else will not resolve.
+    if (entries.length === 0 || entries.some(entry => typeof entry !== 'string' || !entry.includes('.'))) {
+        issues.push(issue('invalidExtensionRecommendations', '$.extensions', `${EXTENSIONS_PATH} must list at least one "publisher.extension" recommendation.`));
+    }
+}
+
+function validateConfigConformance(
+    plan: ParsedDebugPlan,
+    launchText: string,
+    issues: ArtifactValidationIssue[],
+): void {
+    const launch = readLaunchDocument(launchText);
+    const configNames = new Set(
+        launch.configurations
+            .map(config => (typeof config.name === 'string' ? config.name.trim().toLowerCase() : ''))
+            .filter(Boolean),
+    );
+    const compoundNames = new Set(
+        launch.compounds
+            .map(compound => (typeof compound.name === 'string' ? compound.name.trim().toLowerCase() : ''))
+            .filter(Boolean),
+    );
+
+    for (const row of plan.debugConfigs) {
+        if (!row.name) {
+            continue;
+        }
+        const key = row.name.toLowerCase();
+        const present = row.isCompound ? compoundNames.has(key) : configNames.has(key);
+
+        if (row.generate && !present) {
+            issues.push(issue(
+                row.isCompound ? 'compoundConfigMissing' : 'debugConfigMissing',
+                '$.launch',
+                `Plan row "${row.name}" is marked [x] but no matching ${row.isCompound ? 'compound' : 'launch configuration'} exists in launch.json.`,
+            ));
+        }
+        if (!row.generate && present) {
+            issues.push(issue(
+                'uncheckedConfigGenerated',
+                '$.launch',
+                `Plan row "${row.name}" is marked [ ] but launch.json generated it anyway.`,
+            ));
+        }
+    }
+
+    // A configuration nobody planned means the workspace drifted from the plan.
+    const plannedNames = new Set(plan.debugConfigs.map(row => row.name.toLowerCase()).filter(Boolean));
+    if (plannedNames.size > 0) {
+        for (const name of [...configNames, ...compoundNames]) {
+            if (!plannedNames.has(name)) {
+                issues.push(issue('unplannedConfigGenerated', '$.launch', `launch.json declares "${name}", which no plan row describes.`));
+            }
+        }
+    }
+}
+
+async function validateEmulatorArtifacts(
+    workspace: string,
+    plan: ParsedDebugPlan,
+    issues: ArtifactValidationIssue[],
+): Promise<void> {
+    const composeFile = await findFirstExisting(workspace, COMPOSE_FILES);
+    const emulatorCount = plan.emulators.length;
+
+    if (emulatorCount > 0 && !composeFile) {
+        issues.push(issue('composeMissing', '$.compose', `The plan lists ${emulatorCount} emulator(s) but no compose file was generated.`));
+        return;
+    }
+    if (emulatorCount === 0 && composeFile) {
+        issues.push(issue('unexpectedCompose', '$.compose', `The plan lists no emulators but ${composeFile} was generated.`));
+        return;
+    }
+    if (!composeFile) {
+        return;
+    }
+
+    // The agent picks its own compose service names, and plan labels are prose that
+    // often carry the image in a parenthetical — e.g.
+    // "SQL Server 2022 Container (`mcr.microsoft.com/mssql/server:2022-latest`)".
+    // Match on any recognisable token from the label rather than the whole string.
+    const compose = (await fs.readFile(path.join(workspace, composeFile), 'utf8')).toLowerCase();
+    for (const row of plan.emulators) {
+        const label = (row[1] ?? row[0] ?? '').trim();
+        const candidates = emulatorTokens(label);
+        if (candidates.length > 0 && !candidates.some(candidate => compose.includes(candidate))) {
+            issues.push(issue('emulatorNotInCompose', '$.compose', `Planned emulator "${label}" does not appear in ${composeFile} (looked for ${candidates.map(value => `"${value}"`).join(', ')}).`));
+        }
+    }
+}
+
+/**
+ * Tokens that would identify an emulator inside a compose file: the image reference
+ * the plan quotes, the image's own name, and the descriptive label stripped of its
+ * parenthetical and the word "container".
+ */
+function emulatorTokens(label: string): string[] {
+    const tokens = new Set<string>();
+    const add = (value: string): void => {
+        const cleaned = value.trim().toLowerCase();
+        // Very short fragments ("db", "sql") match almost any compose file, which
+        // would make the check unfalsifiable.
+        if (cleaned.length >= 4) {
+            tokens.add(cleaned);
+        }
+    };
+
+    for (const match of label.matchAll(/`([^`]+)`/g)) {
+        const image = match[1].trim();
+        add(image);
+        // `mcr.microsoft.com/mssql/server:2022-latest` also identifies as `mssql/server`.
+        const withoutTag = image.replace(/:[^/:]*$/, '');
+        add(withoutTag);
+        add(withoutTag.split('/').slice(-2).join('/'));
+        add(withoutTag.split('/').pop() ?? '');
+    }
+
+    const prose = label
+        .replace(/\([^)]*\)/g, '')
+        .replace(/`[^`]*`/g, '')
+        .replace(/\bcontainer\b/gi, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    add(prose);
+    // "PostgreSQL 16" and "Azurite" both reduce to a product name the compose file
+    // almost certainly mentions, in an image, a service key, or both.
+    add(prose.split(/\s+/)[0] ?? '');
+
+    return [...tokens];
+}
+
+async function validateConvenienceScripts(
+    workspace: string,
+    plan: ParsedDebugPlan,
+    issues: ArtifactValidationIssue[],
+): Promise<void> {
+    for (const row of plan.convenienceScripts) {
+        if (!row.generate || !row.script) {
+            continue;
+        }
+        const manifestPath = row.registeredIn || './package.json';
+        const absolute = path.join(workspace, manifestPath);
+        const raw = await readIfExists(absolute);
+        if (raw === undefined) {
+            issues.push(issue('scriptManifestMissing', '$.scripts', `Convenience script "${row.script}" is registered in ${manifestPath}, which does not exist.`));
+            continue;
+        }
+        let scripts: Record<string, unknown>;
+        try {
+            scripts = ((parseJsonc(raw) as { scripts?: Record<string, unknown> } | null)?.scripts) ?? {};
+        } catch (error) {
+            issues.push(issue('scriptManifestUnparseable', '$.scripts', `${manifestPath} could not be parsed: ${error instanceof Error ? error.message : String(error)}`));
+            continue;
+        }
+        if (!(row.script in scripts)) {
+            issues.push(issue('scriptNotRegistered', '$.scripts', `Convenience script "${row.script}" is marked [x] but is not registered in ${manifestPath}.`));
+        }
+    }
+}
+
+async function validateApiTestCollections(
+    workspace: string,
+    plan: ParsedDebugPlan,
+    issues: ArtifactValidationIssue[],
+): Promise<void> {
+    const checked = plan.apiTestCollections.filter(row => row.generate);
+    const root = path.join(workspace, API_COLLECTIONS_DIR);
+    const directories = await listDirectories(root);
+
+    if (checked.length === 0) {
+        if (directories.length > 0) {
+            issues.push(issue('unexpectedApiCollections', '$.apiTestCollections', `${API_COLLECTIONS_DIR}/ was generated but no plan row requests it.`));
+        }
+        return;
+    }
+    if (directories.length === 0) {
+        issues.push(issue('apiCollectionsMissing', '$.apiTestCollections', `${checked.length} service(s) request API test collections but ${API_COLLECTIONS_DIR}/ is empty or absent.`));
+        return;
+    }
+    // The plan names services by label while the directories use service ids, so
+    // compare counts rather than inventing a label-to-id mapping.
+    if (directories.length < checked.length) {
+        issues.push(issue('apiCollectionsIncomplete', '$.apiTestCollections', `${checked.length} service(s) request API test collections but only ${directories.length} directory/directories exist under ${API_COLLECTIONS_DIR}/.`));
+    }
+
+    for (const directory of directories) {
+        const invocations = await findInvokeScripts(path.join(root, directory));
+        if (invocations === 0) {
+            issues.push(issue('apiCollectionEmpty', '$.apiTestCollections', `${API_COLLECTIONS_DIR}/${directory} contains no invoke script.`));
+        }
+    }
+}
+
+async function findInvokeScripts(directory: string): Promise<number> {
+    let count = 0;
+    for (const child of await listDirectories(directory)) {
+        const entries = await listFiles(path.join(directory, child));
+        if (entries.some(name => /^invoke\.(sh|ps1)$/i.test(name))) {
+            count++;
+        }
+    }
+    return count;
+}
+
+async function readIfExists(target: string): Promise<string | undefined> {
+    try {
+        return await fs.readFile(target, 'utf8');
+    } catch {
+        return undefined;
+    }
+}
+
+async function findFirstExisting(workspace: string, candidates: string[]): Promise<string | undefined> {
+    for (const candidate of candidates) {
+        try {
+            await fs.access(path.join(workspace, candidate));
+            return candidate;
+        } catch {
+            continue;
+        }
+    }
+    return undefined;
+}
+
+async function listDirectories(target: string): Promise<string[]> {
+    try {
+        const entries = await fs.readdir(target, { withFileTypes: true });
+        return entries.filter(entry => entry.isDirectory()).map(entry => entry.name);
+    } catch {
+        return [];
+    }
+}
+
+async function listFiles(target: string): Promise<string[]> {
+    try {
+        const entries = await fs.readdir(target, { withFileTypes: true });
+        return entries.filter(entry => entry.isFile()).map(entry => entry.name);
+    } catch {
+        return [];
+    }
+}
+
+function issue(code: string, path: string, message: string): ArtifactValidationIssue {
+    return { code, path, message };
+}
+
+function describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/evals/src/artifacts/debugEnvironment.ts
+++ b/evals/src/artifacts/debugEnvironment.ts
@@ -1,0 +1,199 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Environment-level checks on the generated local development setup.
+ *
+ * Everything here catches a defect that a purely structural read of `launch.json`
+ * cannot see: a config file that looks well-formed but hands the service a masked
+ * credential, an empty interpolated variable, or an emulator that rejects the SDK
+ * the app actually uses. Each rule was learned from a real failed run, so they are
+ * kept together and applied to whatever generated files exist.
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import type { ArtifactValidationIssue } from './validationTypes.ts';
+
+/** Generated files that carry credentials and connection strings. */
+const CONFIG_FILE_PATTERN = /(^|[/\\])(docker-compose\.ya?ml|compose\.ya?ml|local\.settings\.json|\.env(\..+)?)$/i;
+
+/** A run of asterisks where a value belongs — the fingerprint of a redaction filter. */
+const REDACTION_MASK_PATTERN = /\*{3,}/;
+
+const COMPOSE_FILES = ['docker-compose.yml', 'docker-compose.yaml', 'compose.yml', 'compose.yaml'];
+
+const SKIP_DIRECTORIES = new Set(['node_modules', '.git', 'dist', 'out', '.venv', '__pycache__']);
+
+export interface DebugEnvironmentContext {
+    /** Whether the plan asked for emulators, which is what makes compose mandatory. */
+    hasEmulators: boolean;
+    /** Task labels declared in `tasks.json`. */
+    taskLabels: Set<string>;
+    /** Raw plan text, used to tell which emulator images were requested. */
+    planText: string;
+}
+
+export async function validateDebugEnvironment(
+    workspace: string,
+    context: DebugEnvironmentContext,
+    issues: ArtifactValidationIssue[],
+): Promise<void> {
+    await validateRedactedSecrets(workspace, issues);
+    await validateComposeInterpolation(workspace, issues);
+    await validateEmulatorSetup(workspace, context, issues);
+}
+
+/**
+ * A secret-redaction filter rewrites a concrete credential to `***` before the text
+ * reaches disk. The resulting file parses fine and then fails at runtime with an
+ * authentication error that looks like a misconfigured service.
+ */
+async function validateRedactedSecrets(workspace: string, issues: ArtifactValidationIssue[]): Promise<void> {
+    for (const filePath of await listFiles(workspace)) {
+        if (!CONFIG_FILE_PATTERN.test(filePath)) {
+            continue;
+        }
+        const content = await readIfExists(filePath);
+        if (content === undefined) {
+            continue;
+        }
+        const relative = path.relative(workspace, filePath) || path.basename(filePath);
+        content.split('\n').forEach((line, index) => {
+            const match = REDACTION_MASK_PATTERN.exec(line);
+            // Glob patterns such as `**/*` legitimately contain adjacent asterisks.
+            if (!match || line.includes('*/') || line.includes('/*')) {
+                return;
+            }
+            issues.push({
+                code: 'redactedSecretPlaceholder',
+                path: `$.generatedConfig["${relative}"].line[${index + 1}]`,
+                message: `${relative} line ${index + 1} contains a redaction mask ("${match[0]}") where a value is expected. `
+                    + 'Build connection strings from discrete variables instead of inlining user:password@host.',
+            });
+        });
+    }
+}
+
+/**
+ * `${VAR}` in a compose file interpolates from `.env` or the shell, never from a
+ * service's own `environment:` block. With nothing to resolve it, compose substitutes
+ * an empty string and the dependency starts with blank credentials instead of
+ * failing fast.
+ */
+async function validateComposeInterpolation(workspace: string, issues: ArtifactValidationIssue[]): Promise<void> {
+    const composeFile = await findFirstExisting(workspace, COMPOSE_FILES);
+    if (!composeFile) {
+        return;
+    }
+    const compose = await readIfExists(path.join(workspace, composeFile));
+    if (compose === undefined) {
+        return;
+    }
+
+    const referenced = new Set<string>();
+    for (const match of compose.matchAll(/\$\{([A-Za-z_][A-Za-z0-9_]*)(:?-[^}]*)?\}/g)) {
+        // A default (`${VAR:-fallback}`) makes the reference safe on its own.
+        if (!match[2]) {
+            referenced.add(match[1]);
+        }
+    }
+    if (referenced.size === 0) {
+        return;
+    }
+
+    const envText = await readIfExists(path.join(workspace, '.env'));
+    const declared = envText === undefined ? new Set<string>() : parseEnvKeys(envText);
+    const missing = [...referenced].filter(name => !declared.has(name)).sort();
+    if (missing.length > 0) {
+        issues.push({
+            code: 'missingComposeEnvValues',
+            path: '$.compose.interpolation',
+            message: `${composeFile} interpolates ${missing.map(name => `\${${name}}`).join(', ')} but `
+                + `${envText === undefined ? 'no .env file exists' : `.env does not declare ${missing.length === 1 ? 'it' : 'them'}`}. `
+                + 'Compose resolves undeclared variables to an empty string, so services start with blank credentials.',
+        });
+    }
+}
+
+async function validateEmulatorSetup(
+    workspace: string,
+    context: DebugEnvironmentContext,
+    issues: ArtifactValidationIssue[],
+): Promise<void> {
+    if (!context.hasEmulators) {
+        return;
+    }
+    if (!context.taskLabels.has('Start Emulators')) {
+        issues.push({
+            code: 'missingEmulatorTask',
+            path: '$.tasks',
+            message: 'A plan with emulators requires a "Start Emulators" task so the dependencies come up before the debugger attaches.',
+        });
+    }
+
+    const composeFile = await findFirstExisting(workspace, COMPOSE_FILES);
+    if (!composeFile || !/\bazurite\b/i.test(context.planText)) {
+        return;
+    }
+    const compose = await readIfExists(path.join(workspace, composeFile));
+    // Azurite rejects API versions newer than the ones it knows about, so a current
+    // Azure Storage SDK fails against it unless the check is disabled.
+    if (compose !== undefined && !/skipApiVersionCheck/i.test(compose)) {
+        issues.push({
+            code: 'azuriteApiVersionCheckEnabled',
+            path: '$.compose.services.azurite',
+            message: 'Azurite must start with --skipApiVersionCheck, otherwise newer Azure Storage SDK API versions are rejected locally.',
+        });
+    }
+}
+
+function parseEnvKeys(content: string): Set<string> {
+    return new Set(content.split('\n').flatMap(line => {
+        const parsed = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/.exec(line);
+        return parsed ? [parsed[1]] : [];
+    }));
+}
+
+async function listFiles(directory: string): Promise<string[]> {
+    const found: string[] = [];
+    let entries;
+    try {
+        entries = await fs.readdir(directory, { withFileTypes: true });
+    } catch {
+        return found;
+    }
+    for (const entry of entries) {
+        const absolute = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+            if (!SKIP_DIRECTORIES.has(entry.name)) {
+                found.push(...await listFiles(absolute));
+            }
+            continue;
+        }
+        found.push(absolute);
+    }
+    return found;
+}
+
+async function findFirstExisting(workspace: string, candidates: string[]): Promise<string | undefined> {
+    for (const candidate of candidates) {
+        try {
+            await fs.access(path.join(workspace, candidate));
+            return candidate;
+        } catch {
+            continue;
+        }
+    }
+    return undefined;
+}
+
+async function readIfExists(target: string): Promise<string | undefined> {
+    try {
+        return await fs.readFile(target, 'utf8');
+    } catch {
+        return undefined;
+    }
+}

--- a/evals/src/artifacts/launchConfig.ts
+++ b/evals/src/artifacts/launchConfig.ts
@@ -1,0 +1,281 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Structural contract for the VS Code debug configuration the generation phase emits.
+ *
+ * This validator never launches anything — it answers the question a user hits on the
+ * first F5: does `launch.json` reference tasks that exist, do the `dependsOn` chains
+ * terminate, and can the compound start every service exactly once? Those are the
+ * defects that make a generated setup unusable, and they are all visible statically.
+ *
+ * Rules come from `resources/agents/azure-debug-generate/references/multi-service.md`
+ * and `validation.md`.
+ */
+
+import { parse, printParseErrorCode } from 'jsonc-parser';
+import type { ParseError } from 'jsonc-parser';
+import type { ArtifactValidationIssue, ArtifactValidationResult } from './validationTypes.ts';
+import { createValidationResult } from './validationTypes.ts';
+
+export interface LaunchConfiguration {
+    name?: unknown;
+    preLaunchTask?: unknown;
+    type?: unknown;
+}
+
+export interface CompoundConfiguration {
+    name?: unknown;
+    configurations?: unknown;
+    preLaunchTask?: unknown;
+}
+
+export interface TaskDefinition {
+    label?: unknown;
+    dependsOn?: unknown;
+    dependsOrder?: unknown;
+    isBackground?: unknown;
+    problemMatcher?: unknown;
+    runOptions?: { instancePolicy?: unknown; instanceLimit?: unknown };
+}
+
+export interface LaunchDocument {
+    configurations: LaunchConfiguration[];
+    compounds: CompoundConfiguration[];
+}
+
+export interface TasksDocument {
+    tasks: TaskDefinition[];
+}
+
+/**
+ * Parse JSONC — `launch.json` and `tasks.json` are commented by design, and the
+ * generation phase leans on that to explain each configuration.
+ *
+ * Uses the same `jsonc-parser` the extension itself ships with, so a file the
+ * grader accepts is a file the product can read.
+ */
+export function parseJsonc(text: string): unknown {
+    const errors: ParseError[] = [];
+    const value = parse(text, errors, { allowTrailingComma: true, disallowComments: false });
+    if (errors.length > 0) {
+        const [first] = errors;
+        throw new SyntaxError(`${printParseErrorCode(first.error)} at offset ${first.offset}`);
+    }
+    return value;
+}
+
+export function readLaunchDocument(text: string): LaunchDocument {
+    const parsed = parseJsonc(text) as { configurations?: unknown; compounds?: unknown } | null;
+    return {
+        configurations: Array.isArray(parsed?.configurations) ? parsed.configurations as LaunchConfiguration[] : [],
+        compounds: Array.isArray(parsed?.compounds) ? parsed.compounds as CompoundConfiguration[] : [],
+    };
+}
+
+export function readTasksDocument(text: string): TasksDocument {
+    const parsed = parseJsonc(text) as { tasks?: unknown } | null;
+    return { tasks: Array.isArray(parsed?.tasks) ? parsed.tasks as TaskDefinition[] : [] };
+}
+
+/**
+ * Validate `launch.json` against `tasks.json`.
+ *
+ * `tasksText` may be undefined — a workspace whose configs declare no `preLaunchTask`
+ * legitimately has no tasks file, but one that references tasks must have it.
+ */
+export function validateDebugLaunchConfiguration(
+    launchText: string,
+    tasksText: string | undefined,
+): ArtifactValidationResult {
+    const issues: ArtifactValidationIssue[] = [];
+
+    let launch: LaunchDocument;
+    try {
+        launch = readLaunchDocument(launchText);
+    } catch (error) {
+        return createValidationResult([issue('launchJsonUnparseable', '$.launch', describeError(error))]);
+    }
+
+    let tasks: TasksDocument = { tasks: [] };
+    if (tasksText !== undefined) {
+        try {
+            tasks = readTasksDocument(tasksText);
+        } catch (error) {
+            return createValidationResult([issue('tasksJsonUnparseable', '$.tasks', describeError(error))]);
+        }
+    }
+
+    if (launch.configurations.length === 0) {
+        issues.push(issue('noLaunchConfigurations', '$.launch', 'launch.json declares no configurations.'));
+    }
+
+    const taskByLabel = new Map<string, TaskDefinition>();
+    for (const task of tasks.tasks) {
+        if (typeof task.label !== 'string' || !task.label.trim()) {
+            issues.push(issue('unlabeledTask', '$.tasks', 'A task has no label.'));
+            continue;
+        }
+        if (taskByLabel.has(task.label)) {
+            // VS Code resolves a `dependsOn` by label, so a duplicate makes the
+            // startup graph ambiguous.
+            issues.push(issue('duplicateTaskLabels', '$.tasks', `Task label "${task.label}" is declared more than once.`));
+        }
+        taskByLabel.set(task.label, task);
+
+        // Re-running F5, or a compound whose members share a chain, invokes the same
+        // task again. Without a silent single-instance policy VS Code either prompts
+        // the user or starts the service a second time.
+        if (task.runOptions?.instanceLimit !== 1 || task.runOptions?.instancePolicy !== 'silent') {
+            issues.push(issue(
+                'invalidTaskRunOptions',
+                '$.tasks',
+                `Task "${task.label}" must set runOptions.instanceLimit to 1 and runOptions.instancePolicy to "silent" so a repeated invocation is a no-op.`,
+            ));
+        }
+        // A background task with an empty problem matcher never signals "ready", so
+        // the debugger attaches before the service is listening.
+        if (task.isBackground === true && isEmptyProblemMatcher(task.problemMatcher)) {
+            issues.push(issue(
+                'missingBackgroundProblemMatcher',
+                '$.tasks',
+                `Background task "${task.label}" has no problem matcher, so nothing detects when the service is ready.`,
+            ));
+        }
+    }
+
+    const configByName = new Map<string, LaunchConfiguration>();
+    for (const config of launch.configurations) {
+        if (typeof config.name !== 'string' || !config.name.trim()) {
+            issues.push(issue('unnamedLaunchConfig', '$.launch', 'A launch configuration has no name.'));
+            continue;
+        }
+        if (configByName.has(config.name)) {
+            issues.push(issue('duplicateLaunchConfig', '$.launch', `Launch configuration "${config.name}" is declared more than once.`));
+        }
+        configByName.set(config.name, config);
+        if (typeof config.type !== 'string' || !config.type.trim()) {
+            issues.push(issue('missingDebuggerType', '$.launch', `Launch configuration "${config.name}" has no debugger "type".`));
+        }
+    }
+
+    // Every referenced task must exist, and the chains it pulls in must terminate.
+    for (const [name, config] of configByName) {
+        const preLaunchTask = config.preLaunchTask;
+        if (preLaunchTask === undefined) {
+            continue;
+        }
+        if (typeof preLaunchTask !== 'string') {
+            issues.push(issue('invalidPreLaunchTask', '$.launch', `Launch configuration "${name}" has a non-string preLaunchTask.`));
+            continue;
+        }
+        if (!taskByLabel.has(preLaunchTask)) {
+            issues.push(issue('preLaunchTaskUnresolved', '$.launch', `Launch configuration "${name}" references task "${preLaunchTask}", which is not defined in tasks.json.`));
+        }
+    }
+
+    validateTaskGraph(taskByLabel, issues);
+    validateCompounds(launch, configByName, issues);
+
+    return createValidationResult(issues);
+}
+
+function validateTaskGraph(taskByLabel: Map<string, TaskDefinition>, issues: ArtifactValidationIssue[]): void {
+    for (const [label, task] of taskByLabel) {
+        for (const dependency of dependsOnLabels(task)) {
+            if (!taskByLabel.has(dependency)) {
+                issues.push(issue('dependsOnUnresolved', '$.tasks', `Task "${label}" depends on "${dependency}", which is not defined.`));
+            }
+        }
+    }
+
+    // A cycle makes the chain never terminate, so VS Code would hang on F5.
+    const visiting = new Set<string>();
+    const settled = new Set<string>();
+    const reported = new Set<string>();
+
+    const visit = (label: string, trail: string[]): void => {
+        if (settled.has(label)) {
+            return;
+        }
+        if (visiting.has(label)) {
+            const cycle = [...trail.slice(trail.indexOf(label)), label].join(' -> ');
+            if (!reported.has(cycle)) {
+                reported.add(cycle);
+                issues.push(issue('dependsOnCycle', '$.tasks', `Task dependency cycle: ${cycle}.`));
+            }
+            return;
+        }
+        visiting.add(label);
+        for (const dependency of dependsOnLabels(taskByLabel.get(label))) {
+            if (taskByLabel.has(dependency)) {
+                visit(dependency, [...trail, label]);
+            }
+        }
+        visiting.delete(label);
+        settled.add(label);
+    };
+
+    for (const label of taskByLabel.keys()) {
+        visit(label, []);
+    }
+}
+
+/**
+ * The compound is where a broken startup graph shows up: a member that names a
+ * configuration nobody defined simply never starts, leaving the user with a
+ * partially-running stack and no error.
+ */
+function validateCompounds(
+    launch: LaunchDocument,
+    configByName: Map<string, LaunchConfiguration>,
+    issues: ArtifactValidationIssue[],
+): void {
+    for (const compound of launch.compounds) {
+        const name = typeof compound.name === 'string' ? compound.name : '(unnamed)';
+        const members = Array.isArray(compound.configurations) ? compound.configurations : [];
+        if (members.length === 0) {
+            issues.push(issue('emptyCompound', '$.launch', `Compound "${name}" lists no member configurations.`));
+            continue;
+        }
+
+        for (const member of members) {
+            if (typeof member !== 'string') {
+                issues.push(issue('compoundMemberUnresolved', '$.launch', `Compound "${name}" has a non-string member.`));
+                continue;
+            }
+            if (!configByName.has(member)) {
+                issues.push(issue('compoundMemberUnresolved', '$.launch', `Compound "${name}" references configuration "${member}", which is not defined.`));
+            }
+        }
+    }
+}
+
+/** A missing or `[]` problem matcher gives VS Code no ready signal to wait on. */
+function isEmptyProblemMatcher(problemMatcher: unknown): boolean {
+    if (problemMatcher === undefined || problemMatcher === null) {
+        return true;
+    }
+    return Array.isArray(problemMatcher) && problemMatcher.length === 0;
+}
+
+function dependsOnLabels(task: TaskDefinition | undefined): string[] {
+    const dependsOn = task?.dependsOn;
+    if (typeof dependsOn === 'string') {
+        return [dependsOn];
+    }
+    if (Array.isArray(dependsOn)) {
+        return dependsOn.filter((entry): entry is string => typeof entry === 'string');
+    }
+    return [];
+}
+
+function describeError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function issue(code: string, path: string, message: string): ArtifactValidationIssue {
+    return { code, path, message };
+}

--- a/evals/src/artifacts/localDebugPlan.ts
+++ b/evals/src/artifacts/localDebugPlan.ts
@@ -1,0 +1,554 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Contract for `.azure/vscode-debug-plan.md` — the artifact the local development
+ * phase produces and the generation phase then treats as its single source of truth.
+ *
+ * Parsing goes through the shipped `parseLocalDebugPlanMarkdown`, so a plan this
+ * validator accepts is by construction a plan the product webview can render. The
+ * rules encoded here come from `resources/agents/azure-debug-plan/references/plan-template.md`
+ * and the generation contract in `resources/agents/azure-debug-generate/`.
+ */
+
+import type { LocalPlanContent, LocalPlanData, LocalPlanSection, LocalPlanTableContent } from '../../../src/webviews/copilotOnRails/views/utils/parseLocalDebugPlanMarkdown.ts';
+import {
+    LocalDebugPlanStatus,
+    findColumnIndex,
+    findSection,
+    firstTable,
+    flattenContent,
+    isChecked,
+    parseLocalDebugPlanMarkdown,
+} from '../../../src/webviews/copilotOnRails/views/utils/parseLocalDebugPlanMarkdown.ts';
+import type { ArtifactValidationIssue, ArtifactValidationResult } from './validationTypes.ts';
+import { createValidationResult } from './validationTypes.ts';
+
+/** Marks the compound row in the Debug Configurations table. */
+export const COMPOUND_PROJECT_TYPE = '*Compound Config*';
+
+const requiredSections = [
+    'prerequisites',
+    'debug configurations',
+    'orchestrator',
+    'emulators',
+    'architecture diagram',
+] as const;
+
+const executionModes = ['auto', 'guided'] as const;
+
+export interface LocalDebugPlanExpectations {
+    /** Status the plan must record, e.g. `Planning` at the approval gate. */
+    expectedStatus?: string;
+    /** Number of generated, non-compound services the scan should have found. */
+    expectedServiceCount?: number;
+    /** Substrings that must each match an Emulators row (e.g. `Azurite`, `PostgreSQL`). */
+    expectedEmulators?: string[];
+    /** The scenario has no Azure dependencies, so no emulator may be planned. */
+    expectNoEmulators?: boolean;
+    /** Require the Debug Configuration Checklist to be present and free of stubs. */
+    requireChecklist?: boolean;
+}
+
+export interface DebugConfigRow {
+    generate: boolean;
+    name: string;
+    serviceRoot: string;
+    projectType: string;
+    runtime: string;
+    isCompound: boolean;
+}
+
+export interface ParsedDebugPlan {
+    data: LocalPlanData;
+    debugConfigs: DebugConfigRow[];
+    emulators: string[][];
+    migrations: PlanChecklistRow[];
+    apiTestCollections: PlanChecklistRow[];
+    convenienceScripts: ConvenienceScriptRow[];
+}
+
+export interface PlanChecklistRow {
+    generate: boolean;
+    service: string;
+}
+
+export interface ConvenienceScriptRow {
+    generate: boolean;
+    script: string;
+    registeredIn: string;
+}
+
+export function validateLocalDebugPlanArtifact(
+    content: string,
+    expectations: LocalDebugPlanExpectations = {},
+): ArtifactValidationResult {
+    const issues: ArtifactValidationIssue[] = [];
+    const data = parseLocalDebugPlanMarkdown(content);
+    if (data.parseError) {
+        issues.push(issue('productionParserFailure', '$', data.parseError.message));
+    }
+
+    validateHeader(data, expectations, issues);
+    validateTableIntegrity(data, issues);
+    validatePlaceholders(data, issues);
+
+    for (const sectionName of requiredSections) {
+        if (!findSection(data, sectionName)) {
+            issues.push(issue('missingSection', '$', `Missing required "${sectionName}" section.`));
+        }
+    }
+
+    validatePrerequisites(data, issues);
+    const debugConfigs = validateDebugConfigurations(data, expectations, issues);
+    validateEmulators(data, expectations, issues);
+    validateArchitectureDiagram(data, issues);
+    validateChecklist(data, debugConfigs, expectations, issues);
+
+    return createValidationResult(issues);
+}
+
+/**
+ * Pull the plan's structured tables out once so both this validator and the
+ * artifact-conformance validator read the plan the same way.
+ */
+export function parseDebugPlan(content: string): ParsedDebugPlan {
+    const data = parseLocalDebugPlanMarkdown(content);
+    return {
+        data,
+        debugConfigs: readDebugConfigRows(data),
+        emulators: findTable(data, 'emulators')?.rows ?? [],
+        migrations: readChecklistRows(data, 'migrations'),
+        apiTestCollections: readChecklistRows(data, 'api test collections'),
+        convenienceScripts: readConvenienceScriptRows(data),
+    };
+}
+
+function validateHeader(
+    data: LocalPlanData,
+    expectations: LocalDebugPlanExpectations,
+    issues: ArtifactValidationIssue[],
+): void {
+    // plan-template.md mandates `# Azure Debug Plan`. Nothing in the product reads the
+    // title, so this is a drift signal rather than a functional break — but the plan is
+    // the generation phase's only input, and a renamed document means the agent has
+    // stopped following the template it is supposed to fill in.
+    if (data.title.trim() !== 'Azure Debug Plan') {
+        issues.push(issue('invalidTitle', '$.title', `Plan title must be "Azure Debug Plan", found "${data.title.trim()}".`));
+    }
+
+    const status = data.status.trim();
+    if (!status || status === 'Unknown') {
+        issues.push(issue('missingStatus', '$.Status', 'Plan header must record a **Status**.'));
+    } else if (!Object.values(LocalDebugPlanStatus).includes(status.toLowerCase() as LocalDebugPlanStatus)) {
+        issues.push(issue('unknownStatus', '$.Status', `Status "${status}" is not one of ${Object.values(LocalDebugPlanStatus).join(', ')}.`));
+    }
+
+    if (expectations.expectedStatus && status.toLowerCase() !== expectations.expectedStatus.toLowerCase()) {
+        issues.push(issue('unexpectedStatus', '$.Status', `Expected status "${expectations.expectedStatus}", found "${status || 'missing'}".`));
+    }
+
+    const mode = data.executionMode.trim();
+    if (!mode || mode === 'Unknown') {
+        issues.push(issue('missingExecutionMode', '$.ExecutionMode', 'Plan header must record an **Execution Mode**.'));
+    } else if (!executionModes.includes(mode.toLowerCase() as typeof executionModes[number])) {
+        issues.push(issue('unknownExecutionMode', '$.ExecutionMode', `Execution Mode "${mode}" is not one of Auto, Guided.`));
+    }
+}
+
+/**
+ * `plan-template.md` calls out concatenated table rows as the failure that "breaks
+ * parsing completely" — a row merged onto the separator line loses its cells, so the
+ * generation phase silently reads the wrong plan. A row whose cell count disagrees
+ * with the header, or that still carries separator dashes, is that failure.
+ */
+function validateTableIntegrity(data: LocalPlanData, issues: ArtifactValidationIssue[]): void {
+    for (const { section, content } of walkContent(data)) {
+        if (content.type !== 'table') {
+            continue;
+        }
+        for (const [index, row] of content.rows.entries()) {
+            if (row.some(cell => /^:?-{3,}:?$/.test(cell.trim()))) {
+                issues.push(issue(
+                    'tableRowConcatenated',
+                    `$.${section}`,
+                    `Row ${index + 1} still contains separator dashes — a table row was merged onto the "|---|" line.`,
+                ));
+                continue;
+            }
+            // Trailing empty cells are cosmetic (the shipped compound row writes `||||`),
+            // so only extra cells that actually carry content indicate merged rows.
+            const overflow = row.slice(content.headers.length).filter(cell => cell.trim().length > 0);
+            if (overflow.length > 0) {
+                issues.push(issue(
+                    'tableRowConcatenated',
+                    `$.${section}`,
+                    `Row ${index + 1} has ${overflow.length} cell(s) beyond the ${content.headers.length} the header declares: ${overflow.join(', ')}.`,
+                ));
+            }
+        }
+    }
+}
+
+/**
+ * A `{placeholder}` left in means the agent copied the template without filling it.
+ *
+ * Route parameters (`/api/photos/{id}`) and inline JSON payloads are legitimate plan
+ * content, so a brace only counts when it names a template field — either a known
+ * single-word token or a multi-word prompt like `{ISO-8601 datetime}`.
+ */
+const templateTokens = new Set([
+    'name', 'path', 'type', 'runtime', 'version', 'label', 'service', 'services',
+    'status', 'description', 'tool', 'emulator', 'orchestrator', 'category',
+]);
+
+function validatePlaceholders(data: LocalPlanData, issues: ArtifactValidationIssue[]): void {
+    for (const { section, content } of walkContent(data)) {
+        const text = contentText(content);
+        for (const match of text.matchAll(/(.?)\{([^}\n]+)\}/g)) {
+            const [, preceding, body] = match;
+            // `/api/pairs/{id}` — a route parameter, not an unfilled field.
+            if (preceding === '/' || preceding === '"') {
+                continue;
+            }
+            const inner = body.trim();
+            const isTemplatePrompt = /[\s|/]/.test(inner) || templateTokens.has(inner.toLowerCase());
+            if (isTemplatePrompt && !/^["\d]/.test(inner)) {
+                issues.push(issue('unfilledPlaceholder', `$.${section}`, `Template placeholder "{${inner}}" was never filled in.`));
+                break;
+            }
+        }
+    }
+}
+
+function validatePrerequisites(data: LocalPlanData, issues: ArtifactValidationIssue[]): void {
+    const table = findTable(data, 'prerequisites');
+    if (!table) {
+        return;
+    }
+    const installed = findColumnIndex(table.headers, 'installed');
+    if (installed === -1) {
+        issues.push(issue('missingPrerequisiteColumn', '$.prerequisites', 'Prerequisites table must have an "Installed" column.'));
+        return;
+    }
+    let hasUnconfirmed = false;
+    for (const row of table.rows) {
+        const marker = row[installed]?.trim() ?? '';
+        if (marker === '❓') {
+            hasUnconfirmed = true;
+        } else if (marker !== '✅') {
+            issues.push(issue('invalidInstalledMarker', '$.prerequisites', `Installed must be ✅ or ❓, found "${marker || 'empty'}".`));
+        }
+    }
+    // The template pairs any ❓ with an explicit call to action, because that marker is
+    // the user's only cue to check a tool before approving.
+    if (hasUnconfirmed && !hasActionRequiredCallout(data)) {
+        issues.push(issue('missingActionRequiredCallout', '$.prerequisites', 'A ❓ prerequisite requires the "Action required" callout.'));
+    }
+}
+
+function validateDebugConfigurations(
+    data: LocalPlanData,
+    expectations: LocalDebugPlanExpectations,
+    issues: ArtifactValidationIssue[],
+): DebugConfigRow[] {
+    const table = findTable(data, 'debug configurations');
+    if (!table) {
+        return [];
+    }
+    for (const column of ['generate', 'debug config name']) {
+        if (findColumnIndex(table.headers, column) === -1) {
+            issues.push(issue('missingDebugConfigColumn', '$.debugConfigurations', `Debug Configurations table must have a "${column}" column.`));
+        }
+    }
+
+    const rows = readDebugConfigRows(data);
+    if (rows.length === 0) {
+        issues.push(issue('noDebugConfigRows', '$.debugConfigurations', 'Debug Configurations table has no rows.'));
+        return rows;
+    }
+
+    const generateColumn = findColumnIndex(table.headers, 'generate');
+    if (generateColumn !== -1) {
+        for (const row of table.rows) {
+            const marker = row[generateColumn]?.trim() ?? '';
+            if (!/^\[[ xX]\]$/.test(marker)) {
+                issues.push(issue('invalidGenerateMarker', '$.debugConfigurations', `Generate must be [x] or [ ], found "${marker || 'empty'}".`));
+            }
+        }
+    }
+
+    const generated = rows.filter(row => row.generate);
+    const services = generated.filter(row => !row.isCompound);
+    if (generated.length === 0) {
+        issues.push(issue('noGeneratedConfigs', '$.debugConfigurations', 'No Debug Configurations row is marked [x], so generation would produce nothing.'));
+    }
+
+    for (const row of services) {
+        if (!row.name) {
+            issues.push(issue('incompleteDebugConfigRow', '$.debugConfigurations', 'A generated row has no Debug Config Name.'));
+        }
+        for (const [label, value] of [['Service Root', row.serviceRoot], ['Project Type', row.projectType], ['Runtime', row.runtime]] as const) {
+            if (!value || value === '—') {
+                issues.push(issue('incompleteDebugConfigRow', '$.debugConfigurations', `Generated config "${row.name || '(unnamed)'}" is missing ${label}.`));
+            }
+        }
+    }
+
+    const duplicates = findDuplicates(services.map(row => row.name.toLowerCase()));
+    for (const duplicate of duplicates) {
+        issues.push(issue('duplicateDebugConfigName', '$.debugConfigurations', `Debug Config Name "${duplicate}" is used more than once.`));
+    }
+
+    // A workspace with two or more debuggable services needs a single entry point,
+    // otherwise the user has to start each service by hand.
+    const hasCompound = generated.some(row => row.isCompound);
+    if (services.length > 1 && !hasCompound) {
+        issues.push(issue('missingCompoundConfig', '$.debugConfigurations', `${services.length} services are generated but no "${COMPOUND_PROJECT_TYPE}" row is present.`));
+    }
+    if (services.length <= 1 && hasCompound) {
+        issues.push(issue('unexpectedCompoundConfig', '$.debugConfigurations', 'A compound config row is present but there is fewer than two services to compose.'));
+    }
+
+    if (expectations.expectedServiceCount !== undefined && services.length !== expectations.expectedServiceCount) {
+        issues.push(issue('unexpectedServiceCount', '$.debugConfigurations', `Expected ${expectations.expectedServiceCount} generated services, found ${services.length}.`));
+    }
+
+    return rows;
+}
+
+function validateEmulators(
+    data: LocalPlanData,
+    expectations: LocalDebugPlanExpectations,
+    issues: ArtifactValidationIssue[],
+): void {
+    const rows = findTable(data, 'emulators')?.rows ?? [];
+    const text = rows.map(row => row.join(' ')).join('\n');
+
+    if (expectations.expectNoEmulators && rows.length > 0) {
+        issues.push(issue('unexpectedEmulator', '$.emulators', `Expected no emulators, found ${rows.length}.`));
+    }
+    for (const expected of expectations.expectedEmulators ?? []) {
+        if (!text.toLowerCase().includes(expected.toLowerCase())) {
+            issues.push(issue('missingEmulator', '$.emulators', `Expected an emulator matching "${expected}", found: ${rows.length ? text.replace(/\n/g, '; ') : '(none)'}.`));
+        }
+    }
+}
+
+function validateArchitectureDiagram(data: LocalPlanData, issues: ArtifactValidationIssue[]): void {
+    const section = findSection(data, 'architecture diagram');
+    if (!section) {
+        return;
+    }
+    const mermaid = flattenContent(section.content).find(
+        content => content.type === 'codeBlock' && content.language.toLowerCase() === 'mermaid',
+    );
+    if (!mermaid) {
+        issues.push(issue('missingMermaidDiagram', '$.architectureDiagram', 'Architecture Diagram section must contain a ```mermaid code block.'));
+        return;
+    }
+    if (mermaid.type === 'codeBlock' && mermaid.code.trim().length === 0) {
+        issues.push(issue('emptyMermaidDiagram', '$.architectureDiagram', 'The mermaid diagram is empty.'));
+    }
+}
+
+/**
+ * The checklist is the generation phase's evidence that it really validated each
+ * configuration. `validation.md` names a stubbed or missing checklist the single most
+ * common failure mode, so an `Implemented` plan must carry a real result per config.
+ */
+function validateChecklist(
+    data: LocalPlanData,
+    debugConfigs: DebugConfigRow[],
+    expectations: LocalDebugPlanExpectations,
+    issues: ArtifactValidationIssue[],
+): void {
+    const implemented = data.status.trim().toLowerCase() === LocalDebugPlanStatus.Implemented;
+    if (!expectations.requireChecklist && !implemented) {
+        return;
+    }
+
+    const section = findSection(data, 'debug configuration checklist');
+    if (!section) {
+        issues.push(issue('missingChecklist', '$.debugConfigurationChecklist', 'A plan reporting validation results must include a "Debug Configuration Checklist" section.'));
+        return;
+    }
+
+    const entries = checklistEntries(section);
+    if (entries.length === 0) {
+        issues.push(issue('missingChecklist', '$.debugConfigurationChecklist', 'The Debug Configuration Checklist has no entries.'));
+        return;
+    }
+
+    for (const entry of entries) {
+        if (!/^[✅❌]/.test(entry)) {
+            issues.push(issue('checklistStub', '$.debugConfigurationChecklist', `Checklist entry "${truncate(entry)}" has no ✅ or ❌ result.`));
+            continue;
+        }
+        // An entry reads `✅ <Config Name> — <evidence>`; only the evidence half tells
+        // us whether validation actually happened, so isolate it before judging.
+        const body = entry.slice(1).trim();
+        const separator = /\s+(?:—|–|-{1,2}|:)\s+/.exec(body);
+        const detail = separator ? body.slice(separator.index + separator[0].length).trim() : '';
+        // A stub is the *absence* of evidence: no evidence half at all, or the
+        // template's own `<ready signal + curl result>` placeholder. Real entries
+        // legitimately quote JSON payloads and words like "pending", so never match
+        // on those.
+        if (!detail || /^<[^>]*>$/.test(detail) || /^(TBD|TODO|pending|N\/A)\.?$/i.test(detail)) {
+            issues.push(issue('checklistStub', '$.debugConfigurationChecklist', `Checklist entry "${truncate(entry)}" is still a stub.`));
+        }
+    }
+
+    const joined = entries.join('\n').toLowerCase();
+    for (const row of debugConfigs.filter(config => config.generate && config.name)) {
+        if (!joined.includes(row.name.toLowerCase())) {
+            issues.push(issue('checklistMissingEntry', '$.debugConfigurationChecklist', `No checklist entry for generated config "${row.name}".`));
+        }
+    }
+}
+
+function checklistEntries(section: LocalPlanSection): string[] {
+    const entries: string[] = [];
+    for (const content of flattenContent(section.content)) {
+        if (content.type === 'bulletList') {
+            entries.push(...content.items.map(item => item.trim()));
+            continue;
+        }
+        const text = contentText(content);
+        for (const line of text.split('\n').map(value => value.trim())) {
+            // Skip the section's own lead-in line ("Debug Configuration Checklist:").
+            if (!line || /^debug configuration checklist:?$/i.test(line)) {
+                continue;
+            }
+            entries.push(line);
+        }
+    }
+    return entries;
+}
+
+function readDebugConfigRows(data: LocalPlanData): DebugConfigRow[] {
+    const table = findTable(data, 'debug configurations');
+    if (!table) {
+        return [];
+    }
+    const generate = findColumnIndex(table.headers, 'generate');
+    const name = findColumnIndex(table.headers, 'debug config name');
+    const serviceRoot = findColumnIndex(table.headers, 'service root');
+    const projectType = findColumnIndex(table.headers, 'project type');
+    const runtime = findColumnIndex(table.headers, 'runtime');
+
+    return table.rows
+        .filter(row => row.some(cell => cell.trim().length > 0))
+        .map(row => {
+            const type = cell(row, projectType);
+            return {
+                generate: isChecked(cell(row, generate)),
+                name: cell(row, name),
+                serviceRoot: cell(row, serviceRoot),
+                projectType: type,
+                runtime: cell(row, runtime),
+                isCompound: type.toLowerCase().includes('compound'),
+            };
+        });
+}
+
+function readChecklistRows(data: LocalPlanData, sectionName: string): PlanChecklistRow[] {
+    const table = findTable(data, sectionName);
+    if (!table) {
+        return [];
+    }
+    const generate = findColumnIndex(table.headers, 'generate');
+    const service = findColumnIndex(table.headers, 'service');
+    return table.rows
+        .filter(row => row.some(value => value.trim().length > 0))
+        .map(row => ({
+            generate: isChecked(cell(row, generate)),
+            service: cell(row, service),
+        }));
+}
+
+function readConvenienceScriptRows(data: LocalPlanData): ConvenienceScriptRow[] {
+    const table = findTable(data, 'convenience scripts');
+    if (!table) {
+        return [];
+    }
+    const generate = findColumnIndex(table.headers, 'generate');
+    const script = findColumnIndex(table.headers, 'script');
+    const registeredIn = findColumnIndex(table.headers, 'registered in');
+    return table.rows
+        .filter(row => row.some(value => value.trim().length > 0))
+        .map(row => ({
+            generate: isChecked(cell(row, generate)),
+            script: cell(row, script).replace(/`/g, ''),
+            registeredIn: cell(row, registeredIn).replace(/`/g, ''),
+        }));
+}
+
+/** The first table inside the section whose title contains `sectionTitle`. */
+function findTable(data: LocalPlanData, sectionTitle: string): LocalPlanTableContent | undefined {
+    const section = findSection(data, sectionTitle);
+    return section && firstTable(section);
+}
+
+/** Section titles carry emoji and punctuation; key on letters and digits only. */
+function sectionKey(title: string): string {
+    return title.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function cell(row: string[], index: number): string {
+    return index === -1 ? '' : (row[index] ?? '').trim();
+}
+
+function walkContent(data: LocalPlanData): Array<{ section: string; content: LocalPlanContent }> {
+    return data.sections.flatMap(section =>
+        flattenContent(section.content).map(content => ({ section: sectionKey(section.title), content })),
+    );
+}
+
+function contentText(content: LocalPlanContent): string {
+    switch (content.type) {
+        case 'table':
+            return [content.headers.join(' '), ...content.rows.map(row => row.join(' '))].join('\n');
+        case 'blockquote':
+        case 'paragraph':
+            return content.text;
+        case 'bulletList':
+            return content.items.join('\n');
+        case 'codeBlock':
+        case 'subsection':
+            // Diagram bodies legitimately use braces, and subsection children are
+            // visited separately by `flatten`.
+            return '';
+    }
+}
+
+function hasActionRequiredCallout(data: LocalPlanData): boolean {
+    return walkContent(data).some(({ content }) =>
+        content.type === 'blockquote' && /action required/i.test(content.text),
+    );
+}
+
+function findDuplicates(values: string[]): string[] {
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+    for (const value of values) {
+        if (!value) {
+            continue;
+        }
+        if (seen.has(value)) {
+            duplicates.add(value);
+        }
+        seen.add(value);
+    }
+    return [...duplicates];
+}
+
+function truncate(value: string): string {
+    return value.length > 60 ? `${value.slice(0, 57)}...` : value;
+}
+
+function issue(code: string, path: string, message: string): ArtifactValidationIssue {
+    return { code, path, message };
+}

--- a/evals/src/graderCertification.ts
+++ b/evals/src/graderCertification.ts
@@ -8,8 +8,11 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { PlanGateState } from './artifacts/planEvaluation.ts';
 import { validatePlanEvaluationContract } from './artifacts/planEvaluation.ts';
+import { validateDebugArtifacts } from './artifacts/debugArtifacts.ts';
 import { validateFrontendScaffold } from './artifacts/frontendScaffold.ts';
 import { validateIntegrationPlanArtifact } from './artifacts/integrationPlan.ts';
+import { validateDebugLaunchConfiguration } from './artifacts/launchConfig.ts';
+import { validateLocalDebugPlanArtifact } from './artifacts/localDebugPlan.ts';
 import { validatePreviewArtifacts } from './artifacts/preview.ts';
 import { validateProjectPlanArtifact } from './artifacts/projectPlan.ts';
 import { validateRequirementsArtifact } from './artifacts/requirements.ts';
@@ -17,21 +20,23 @@ import type { ArtifactValidationResult } from './artifacts/validationTypes.ts';
 import type { CorEvaluationScenario } from './scenario.ts';
 import { validateScenario } from './scenario.ts';
 
+interface CertificationFixture {
+    id: string;
+    path: string;
+    description: string;
+    offlineValidators: string[];
+}
+
 interface CertificationManifest {
     schemaVersion: number;
-    fixture: {
-        id: string;
-        path: string;
-        description: string;
-        offlineValidators: string[];
-        acaValidators: string[];
-    };
+    fixtures: CertificationFixture[];
     mutations: CertificationMutation[];
 }
 
 interface CertificationMutation {
     id: string;
     tier: 'offline' | 'aca';
+    fixture: string;
     validator: string;
     file?: string;
     operation: 'replace' | 'append' | 'delete' | 'scenario-status';
@@ -44,6 +49,7 @@ interface CertificationMutation {
 interface CertificationCase {
     id: string;
     tier: 'offline' | 'aca';
+    fixture: string;
     validator: string;
     expected: string;
     actual: string[];
@@ -55,7 +61,7 @@ interface CertificationReport {
     schemaVersion: 1;
     generatedAt: string;
     mode: 'offline' | 'aca';
-    fixture: string;
+    fixtures: string[];
     outcome: 'passed' | 'failed';
     cases: CertificationCase[];
 }
@@ -68,22 +74,25 @@ async function main(): Promise<void> {
         throw new Error('ACA certification is not available in the planning-only subset. Add scaffold/build/runtime graders first.');
     }
     const outputIndex = process.argv.indexOf('--output');
-    const outputDirectory = outputIndex >= 0
-        ? path.resolve(process.argv[outputIndex + 1])
-        : path.join(repoRoot, 'evals', 'results', 'grader-certification', 'offline');
     const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8')) as CertificationManifest;
-    if (manifest.schemaVersion !== 1) {
+    if (manifest.schemaVersion !== 2) {
         throw new Error(`Unsupported grader certification manifest version ${manifest.schemaVersion}.`);
     }
-    const fixture = path.join(repoRoot, manifest.fixture.path);
-    const scenarioPath = path.join(fixture, 'scenario.json');
-    const scenario = validateScenario(JSON.parse(await fs.readFile(scenarioPath, 'utf8')), scenarioPath);
-    const cases = await runOfflineCertification(manifest, fixture, scenario);
+    const only = readValidatorFilter(manifest);
+    const outputDirectory = outputIndex >= 0
+        ? path.resolve(process.argv[outputIndex + 1])
+        // A filtered run is not a certification of the grader set, so it must not
+        // overwrite the report a full run produced.
+        : path.join(repoRoot, 'evals', 'results', 'grader-certification', only ? 'offline-filtered' : 'offline');
+    const cases: CertificationCase[] = [];
+    for (const fixture of manifest.fixtures) {
+        cases.push(...await certifyFixture(manifest, fixture, only));
+    }
     const report: CertificationReport = {
         schemaVersion: 1,
         generatedAt: new Date().toISOString(),
         mode: 'offline',
-        fixture: manifest.fixture.id,
+        fixtures: manifest.fixtures.map(value => value.id),
         outcome: cases.every(value => value.passed) ? 'passed' : 'failed',
         cases,
     };
@@ -92,30 +101,74 @@ async function main(): Promise<void> {
         fs.writeFile(path.join(outputDirectory, 'report.json'), `${JSON.stringify(report, null, 2)}\n`),
         fs.writeFile(path.join(outputDirectory, 'report.md'), renderMarkdown(report)),
     ]);
-    console.log(`${report.outcome.toUpperCase()}: ${cases.filter(value => value.passed).length}/${cases.length} grader certification cases passed.`);
+    console.log(`${report.outcome.toUpperCase()}: ${cases.filter(value => value.passed).length}/${cases.length} grader certification cases passed${only ? ` (filtered to ${[...only].join(', ')})` : ''}.`);
     if (report.outcome !== 'passed') {
         process.exitCode = 1;
     }
 }
 
-async function runOfflineCertification(
-    manifest: CertificationManifest,
-    fixture: string,
-    scenario: CorEvaluationScenario,
-): Promise<CertificationCase[]> {
-    const cases: CertificationCase[] = [];
-    const golden = await runOfflineValidators(fixture, scenario);
-    for (const validator of manifest.fixture.offlineValidators) {
-        const result = golden.get(validator) ?? ['validatorNotExecuted'];
-        cases.push(createCase(`golden-${validator}`, 'offline', validator, 'passed', result));
+/**
+ * `--validator <id>` (repeatable) narrows certification to one grader while you are
+ * iterating on it. The full set still runs in CI, so a filter can only make a local
+ * run smaller — never make a failing grader look certified.
+ */
+function readValidatorFilter(manifest: CertificationManifest): Set<string> | undefined {
+    const requested = process.argv.flatMap((argument, index) =>
+        argument === '--validator' && process.argv[index + 1] ? [process.argv[index + 1]] : []);
+    if (requested.length === 0) {
+        return undefined;
     }
-    for (const mutation of manifest.mutations.filter(value => value.tier === 'offline')) {
-        cases.push(await withMutatedFixture(fixture, mutation, async workspace => {
-            const results = await runOfflineValidators(workspace, scenario);
+    const known = new Set(manifest.fixtures.flatMap(value => value.offlineValidators));
+    const unknown = requested.filter(id => !known.has(id));
+    if (unknown.length > 0) {
+        throw new Error(`Unknown validator ${unknown.join(', ')}. Known validators: ${[...known].join(', ')}.`);
+    }
+    return new Set(requested);
+}
+
+/**
+ * Certify one fixture against the validators it declares.
+ *
+ * Fixtures are scoped rather than universal because an artifact is only gradeable
+ * against the project it describes: the debug plan names a service root, a runtime
+ * and the scripts it expects to find, so grading it against a different application
+ * asks whether one project's artifacts describe another's — a question with no
+ * meaningful answer. `sample-agent-output` therefore certifies the planning and
+ * scaffold contracts, and `reference-node-fullstack` certifies the local-debug ones
+ * against the app they were generated for.
+ */
+async function certifyFixture(
+    manifest: CertificationManifest,
+    fixture: CertificationFixture,
+    only: Set<string> | undefined,
+): Promise<CertificationCase[]> {
+    const validators = fixture.offlineValidators.filter(id => !only || only.has(id));
+    const mutations = manifest.mutations.filter(value =>
+        value.tier === 'offline'
+        && value.fixture === fixture.id
+        && (!only || only.has(value.validator)));
+    if (validators.length === 0 && mutations.length === 0) {
+        return [];
+    }
+
+    const root = path.join(repoRoot, fixture.path);
+    const scenarioPath = path.join(root, 'scenario.json');
+    const scenario = validateScenario(JSON.parse(await fs.readFile(scenarioPath, 'utf8')), scenarioPath);
+
+    const cases: CertificationCase[] = [];
+    const golden = await runOfflineValidators(root, scenario, fixture.offlineValidators);
+    for (const validator of validators) {
+        const result = golden.get(validator) ?? ['validatorNotExecuted'];
+        cases.push(createCase(`golden-${validator}`, 'offline', fixture.id, validator, 'passed', result));
+    }
+    for (const mutation of mutations) {
+        cases.push(await withMutatedFixture(root, mutation, async workspace => {
+            const results = await runOfflineValidators(workspace, scenario, fixture.offlineValidators);
             const actual = results.get(mutation.validator) ?? ['validatorNotExecuted'];
             return createCase(
                 mutation.id,
                 'offline',
+                fixture.id,
                 mutation.validator,
                 mutation.expectedCode,
                 actual,
@@ -129,32 +182,63 @@ async function runOfflineCertification(
 // It requires SandboxProjectValidator and SandboxLocalRuntimeValidator
 // which will be added when scaffold/build/runtime graders are introduced.
 
+/**
+ * Every offline validator, keyed by the id the manifest uses.
+ *
+ * Each entry reads its own inputs, so a fixture that carries no `requirements.json`
+ * — because it is a plain app rather than agent output — simply never asks for one.
+ * Reading eagerly for all validators would make every fixture owe every artifact.
+ */
+const OFFLINE_VALIDATORS: Record<
+    string,
+    (workspace: string, scenario: CorEvaluationScenario) => Promise<ArtifactValidationResult>
+> = {
+    requirements: async workspace =>
+        validateRequirementsArtifact(await readArtifact(workspace, '.azure/requirements.json'), { requireConfirmed: true }),
+    'project-plan': async workspace =>
+        validateProjectPlanArtifact(await readArtifact(workspace, '.azure/project-plan.md'), { expectedStatus: 'Integrated' }),
+    'integration-plan': async (workspace, scenario) =>
+        validateIntegrationPlanArtifact(await readArtifact(workspace, '.azure/integration-plan.md'), {
+            hasFrontend: (scenario.tags.frontend ?? 'none') !== 'none',
+        }),
+    'plan-gate': async (workspace, scenario) => {
+        const azure = path.join(workspace, '.azure');
+        const projectPlan = await readArtifact(workspace, '.azure/project-plan.md');
+        const state = await readPlanGateState(azure, scenario, projectPlan);
+        return validatePlanEvaluationContract(state.expectedFrontend, state.generatedFrontend, state.gate);
+    },
+    preview: async workspace => validatePreviewArtifacts(path.join(workspace, '.azure', '.preview-temp')),
+    'frontend-scaffold': async workspace => validateFrontendScaffold(workspace),
+    'debug-plan': async workspace =>
+        validateLocalDebugPlanArtifact(await readArtifact(workspace, '.azure/vscode-debug-plan.md'), {
+            expectedStatus: 'Implemented',
+            expectedServiceCount: 1,
+            expectNoEmulators: true,
+            requireChecklist: true,
+        }),
+    'debug-config': async workspace => validateDebugLaunchConfiguration(
+        await readArtifact(workspace, '.vscode/launch.json'),
+        await readArtifact(workspace, '.vscode/tasks.json'),
+    ),
+    'debug-artifacts': async workspace => validateDebugArtifacts(workspace),
+};
+
+function readArtifact(workspace: string, relativePath: string): Promise<string> {
+    return fs.readFile(path.join(workspace, ...relativePath.split('/')), 'utf8');
+}
+
 async function runOfflineValidators(
     workspace: string,
     scenario: CorEvaluationScenario,
+    validators: string[],
 ): Promise<Map<string, string[]>> {
-    const azure = path.join(workspace, '.azure');
-    const [requirements, projectPlan, integrationPlan] = await Promise.all([
-        fs.readFile(path.join(azure, 'requirements.json'), 'utf8'),
-        fs.readFile(path.join(azure, 'project-plan.md'), 'utf8'),
-        fs.readFile(path.join(azure, 'integration-plan.md'), 'utf8'),
-    ]);
-    const validations: Array<readonly [string, ArtifactValidationResult]> = await Promise.all([
-        Promise.resolve(['requirements', validateRequirementsArtifact(requirements, { requireConfirmed: true })] as const),
-        Promise.resolve(['project-plan', validateProjectPlanArtifact(projectPlan, { expectedStatus: 'Integrated' })] as const),
-        Promise.resolve([
-            'integration-plan',
-            validateIntegrationPlanArtifact(integrationPlan, { hasFrontend: (scenario.tags.frontend ?? 'none') !== 'none' }),
-        ] as const),
-        readPlanGateState(azure, scenario, projectPlan).then(state => [
-            'plan-gate',
-            validatePlanEvaluationContract(state.expectedFrontend, state.generatedFrontend, state.gate),
-        ] as const),
-        validatePreviewArtifacts(path.join(azure, '.preview-temp')).then(result => ['preview', result] as const),
-        validateFrontendScaffold(workspace).then(result => ['frontend-scaffold', result] as const),
-    ]);
-    const results = new Map(validations.map(([id, result]) => [id, issueCodes(result)]));
-    return results;
+    const unknown = validators.filter(id => !(id in OFFLINE_VALIDATORS));
+    if (unknown.length > 0) {
+        throw new Error(`Manifest names validators with no implementation: ${unknown.join(', ')}.`);
+    }
+    const validations = await Promise.all(validators.map(async id =>
+        [id, await OFFLINE_VALIDATORS[id](workspace, scenario)] as const));
+    return new Map(validations.map(([id, result]) => [id, issueCodes(result)]));
 }
 
 /**
@@ -233,6 +317,7 @@ function issueCodes(result: ArtifactValidationResult): string[] {
 function createCase(
     id: string,
     tier: 'offline' | 'aca',
+    fixture: string,
     validator: string,
     expected: string,
     actual: string[],
@@ -240,6 +325,7 @@ function createCase(
     return {
         id,
         tier,
+        fixture,
         validator,
         expected,
         actual,
@@ -253,14 +339,14 @@ function renderMarkdown(report: CertificationReport): string {
         '# Copilot on Rails Grader Certification',
         '',
         `- Mode: \`${report.mode}\``,
-        `- Fixture: \`${report.fixture}\``,
+        `- Fixtures: ${report.fixtures.map(value => `\`${value}\``).join(', ')}`,
         `- Outcome: **${report.outcome.toUpperCase()}**`,
         `- Cases: ${report.cases.filter(value => value.passed).length}/${report.cases.length} passed`,
         '',
-        '| Case | Validator | Expected | Actual | Result |',
-        '|---|---|---|---|---|',
+        '| Case | Fixture | Validator | Expected | Actual | Result |',
+        '|---|---|---|---|---|---|',
         ...report.cases.map(value =>
-            `| \`${value.id}\` | \`${value.validator}\` | \`${value.expected}\` | \`${value.actual.join(', ') || 'passed'}\` | ${value.passed ? 'PASS' : 'FAIL'} |`),
+            `| \`${value.id}\` | \`${value.fixture}\` | \`${value.validator}\` | \`${value.expected}\` | \`${value.actual.join(', ') || 'passed'}\` | ${value.passed ? 'PASS' : 'FAIL'} |`),
         '',
     ];
     return `${lines.join('\n')}\n`;

--- a/src/webviews/copilotOnRails/views/utils/parseLocalDebugPlanMarkdown.ts
+++ b/src/webviews/copilotOnRails/views/utils/parseLocalDebugPlanMarkdown.ts
@@ -52,12 +52,20 @@ export function parseLocalDebugPlanMarkdown(markdown: string): LocalPlanData {
     };
 }
 
-export enum LocalDebugPlanStatus {
-    Planning = 'planning',
-    Approved = 'approved',
-    Executing = 'executing',
-    Implemented = 'implemented',
-}
+/**
+ * Declared as a const object rather than a TS `enum` so the module stays
+ * erasable: the eval graders load this parser directly through Node's
+ * type-stripping, which rejects `enum`. Call sites are unaffected — both the
+ * value (`LocalDebugPlanStatus.Implemented`) and the type still resolve.
+ */
+export const LocalDebugPlanStatus = {
+    Planning: 'planning',
+    Approved: 'approved',
+    Executing: 'executing',
+    Implemented: 'implemented',
+} as const;
+
+export type LocalDebugPlanStatus = typeof LocalDebugPlanStatus[keyof typeof LocalDebugPlanStatus];
 
 
 const STATUS_METADATA_REGEX = /^\s*>?\s*\**Status[:*]*:[:*]*\s*(.+)$/i;


### PR DESCRIPTION
> Stacked on #1707 (scaffold gates). Review that one first — the diff here is only the debug half.

## What this adds, in plain language

After the project is scaffolded, two agents set up local debugging: one writes a plan (`.azure/vscode-debug-plan.md`), you approve it, and the other generates the actual VS Code files so F5 works. This adds four checks over that.

**Is the plan a real plan?** (`validate-debug-plan`) It's a markdown document with tables — services, prerequisites, convenience scripts, an architecture diagram, a validation checklist. The checks catch the ways a generated document goes subtly wrong: a table row concatenated onto the separator line so it parses as one blob, a checklist item filled in with "TBD", a section renamed so the webview can't find it, a status that says `Planning` when it should say `Implemented`.

**Is the debug configuration structurally sound?** (`validate-debug-config`) `launch.json` and `tasks.json` are JSON-with-comments. This parses them properly and checks the things that make F5 silently do nothing — a `preLaunchTask` naming a task that doesn't exist, a missing program path, a compound configuration referencing a config that isn't there.

**Do the generated files match the plan that was approved?** (`validate-debug-artifacts`) This is the important one. The plan is a contract: it names the debug configurations to create, the convenience scripts to register, the API test collections to write, the extensions to recommend. This checks the artifacts on disk against that promise — a config marked `[x]` but never generated, a script the plan says it registered in `package.json` that isn't there, an empty test collection directory, a placeholder secret left in `.env.example`.

**Did the planning agent jump the gun?** (`validate-debug-gate`) The plan agent must stop and wait for approval. If `launch.json` already exists when it was only supposed to have written a plan, it skipped the gate.

## This is @motm32's work

Every grader and all four validators (`localDebugPlan.ts`, `debugArtifacts.ts`, `launchConfig.ts`, `debugEnvironment.ts`) are Megan's, from #1694, unchanged. So is `local-dev/eval.yaml`, the fixture, and the 14 new certification cases. She's out; this ports her work onto the current layout rather than rewriting it.

## The interesting problem: certification needed two fixtures

Worth reading, because a certification case failed and the failure was correct.

#1693 (now #1707) split the certification fixture in two: `reference-node-fullstack` is a plain runnable app, `sample-agent-output` is the workspace as the planning and scaffold agents leave it, and only the second gets graded. Good split — grading a fixture that's simultaneously "an app" and "a pile of agent artifacts" doesn't mean much.

But Megan's debug plan, written on a separate branch, describes **the Golden App**: one Node service rooted at `.`, with a `start` script in the root `package.json`. `sample-agent-output` is a React ticket app with `services/web` and `services/shared` and no root manifest at all. Point the debug validators at it and you get `scriptManifestMissing` — which is the *right answer to a meaningless question*. The plan wasn't wrong and the validator wasn't broken; they were being asked whether one project's artifacts describe a different project.

The easy fixes were both bad: bolt a fake root `package.json` onto the scaffold fixture, or rewrite Megan's debug plan to describe the ticket app (which means re-authoring test data and re-verifying every mutation).

So instead, **certification is now multi-fixture**. Each fixture declares the validators it can answer for:

| Fixture | Certifies |
| --- | --- |
| `sample-agent-output` | requirements, project-plan, plan-gate, preview, integration-plan, frontend-scaffold |
| `reference-node-fullstack` | debug-plan, debug-config, debug-artifacts |

Each validator now reads its own inputs rather than the runner reading everything up front, so a fixture that carries no `requirements.json` is simply never asked for one. Manifest `schemaVersion` goes to 2; mutations name their fixture.

Side benefit: `reference-node-fullstack` had no consumer after #1707. It has one again, and it's the right one.

## Other notes

- **`LocalDebugPlanStatus` becomes a const object instead of a TS `enum`.** The graders load that parser directly through Node's type stripping, and `erasableSyntaxOnly` rejects `enum`. The value and the type both still resolve, so nothing at the call sites changes. Megan's change, kept as-is.
- **`preflight.sh` is deliberately not ported.** It verified that each assertion fails on a bare workspace and passes on a valid one — which is exactly what the golden + mutation certification cases already prove. A second mechanism is a second thing to keep in step.
- **`jsonc-parser` is a new dependency** (matching the `^2.x` the extension already uses) because `launch.json` is JSON-with-comments and hand-rolling a tolerant parser is ~40 lines of subtle escape and trailing-comma handling that fails *silently* when it's wrong. It does mean the MSBench staging step needs to carry that one package into the container, since `stage-graders.ts` refuses bare specifiers — handled in the stimulus-wiring PR, not here.
- `evals/local-dev/eval.yaml` is added as a linted spec (`npm run lint` now covers both specs). It still declares `executor: azure-agent-executor`; that key comes out when the retired headless path is removed.

## Verification

**No MSBench run was submitted.**

| Gate | Result |
| --- | --- |
| `npm run certify` | **44/44**, up from 27 |
| `npm run typecheck` | pass |
| `npm run drift` | pass — 16 agent contracts intact |
| `npm run lint` | pass, both specs |

Also checked by hand: `--validator <id>` narrows correctly and writes to `offline-filtered/` so a partial run can't overwrite a real report; an unknown validator id is rejected rather than silently matching nothing.
