### PR TITLE
Remove .vally.yaml paths that point at directories that never existed

### DIFF
--- a/.vally.yaml
+++ b/.vally.yaml
@@ -1,7 +1,11 @@
 # Vally project configuration
+#
+# `paths.results` is an *output* directory, created on demand and gitignored, so
+# it is correctly absent from a clean checkout. Every other path here is an input
+# and must exist — a path that points at nothing lints clean and silently
+# contributes no evals, which is worse than a missing-file error.
 paths:
   evals: [evals]
-  skills: [evals/skills]
   results: results
 
 environments:
@@ -16,6 +20,3 @@ suites:
   project-plan:
     description: azure-project-plan agent contracts
     evals: ["evals/project-plan/**"]
-  chains:
-    description: End-to-end workflow chains (nightly)
-    evals: ["evals/chains/**"]


### PR DESCRIPTION
## What this fixes

`.vally.yaml` had settings pointing at directories that don't exist. Vally requires none of these keys, and a glob matching nothing contributes no evals **silently** — so the config lints perfectly clean either way. The only signal that a suite is empty is somebody eventually noticing it never runs.

That's the same class of problem as the stale reference found while retiring the headless eval path: config that looks maintained, validates fine, and means nothing. So rather than fix one and leave the rest, here's the full audit of every path in the file.

| Setting | Points at | Verdict |
| --- | --- | --- |
| `paths.evals: [evals]` | `evals/` | fine |
| `paths.results: results` | `results/` | **fine** — output directory, created on demand, gitignored. Correctly absent from a clean checkout. |
| `paths.skills: [evals/skills]` | `evals/skills/` | **never existed on this branch** → removed |
| `suites.project-plan` | `evals/project-plan/**` | fine |
| `suites.chains` | `evals/chains/**` | **never existed anywhere, on any branch** → removed |
| `environments.default.mcpServers` | `evals/mcp/workflow-tools-server.mjs` | stale, but removed in #1709 — see below |

### Why `paths.skills` was pointing at nothing

Not an accident of deletion — it was never right on this branch. A checked-in `evals/skills/azure-project-plan/SKILL.md` was written on `meganmott/xerothermic-hippopotamus`, which never merged. The approach that *did* land generated the skill into `evals/.generated/skills` at runtime instead. The config kept the path from the abandoned approach.

### Why `suites.chains` was pointing at nothing

`git log --all -- evals/chains` returns nothing. The suite was declared aspirationally — "End-to-end workflow chains (nightly)" — and the directory was never created. A declared suite that cannot run is worse than no suite: it reads as coverage.

## Two things deliberately left alone

**The `mcpServers` block** is also stale — it names `evals/mcp/workflow-tools-server.mjs`, a file that hasn't existed since the TypeScript conversion. It's removed in **#1709** instead, because there it's part of retiring the headless path that block existed to serve, and that PR verifies `vally lint` still passes without it. Removing it in both places would just create a conflict on the same lines. The two changes touch different parts of the file, so they should merge cleanly in either order.

**The `suites:` block as a whole** may be dead shortly. Its only consumer is `run-eval.cjs --suite`, which **#1709 deletes** — `npm run lint` selects specs with `--eval-spec`, not `--suite`. I've left `suites.project-plan` here because it points at a real directory and is therefore not *stale*, only possibly *unused*, and deciding that depends on whether #1709 lands. Worth revisiting once it does.

## Verification

`npm run lint` passes. Confirmed against the Vally config schema (`@microsoft/vally/dist/config/vally-config.schema.json`) that no key in this file is required, so removing two of them is valid rather than merely tolerated.

Based on `feat/CoR` directly rather than on the scaffold/debug-gate stack, since it shares no files with it and can merge independently.
