### PR TITLE
Turn on MSBench run queueing, pin smoke mode off, and document the artifact cap

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -353,6 +353,169 @@ answer than inventing a brittle SQL proxy for a judgement call. It is not a subs
 for `exec:` on anything the validators already decide deterministically.
 
 
+## Run queueing
+
+**If you submit MSBench runs for this eval by any route other than `run.sh`, use exactly
+these two values:**
+
+| Key | Value | Where it comes from |
+| --- | --- | --- |
+| endpoint tag | `copilot-on-rails` | `--tag endpoint=copilot-on-rails` (set by `run.sh`) |
+| model | `claude-sonnet-4.5` | derived from `modelSelector` in [`config/base.yaml`](config/base.yaml) |
+
+CES serialises runs that share the same **(model, endpoint tag)** pair: the second one
+waits in a queue rather than racing the first for the same model capacity. Unqueued runs
+race — ours against each other, and against any other team on the same model.
+
+The catch is that **there is no validation of these strings**. A run tagged
+`copilot_on_rails`, `CopilotOnRails`, or `copilot-on-rails ` is accepted, submitted, and
+put in a *different* queue, where it races the runs it was supposed to wait behind.
+Queueing then silently does nothing and looks exactly like it is working. That is the
+whole reason the values are written down here.
+
+We were opted out by omission until [#1707](https://github.com/microsoft/vscode-azureresourcegroups/pull/1707):
+`run.sh` set no endpoint tag at all.
+
+### Why the model half needs no flag
+
+`--model .` is `ASSET_MODEL_SENTINEL`. It does **not** mean "no model" — it tells the
+`vscode` plugin to read `modelSelector` out of the staged `assets/user-overrides.yaml`
+instead of resolving one itself, and the plugin hands the result back as
+`resolved_model`. The CLI then sets `agent_config.model` from it
+(`model_source: agent_assets`). A dry run confirms the sentinel is resolved before
+submission, not passed through:
+
+```
+"model": "claude-sonnet-4.5",
+"model_source" ... "resolved_model": "claude-sonnet-4.5",
+"runner_notes": [
+  "modelSelector set in user-overrides.yaml; using it because --model . was supplied.",
+  "modelSelector in user-overrides.yaml: copilot/claude-sonnet-4.5."
+]
+```
+
+So `--model .` is fully compatible with queueing, and keeping it is required for other
+reasons (see "Why the VSIX route"). The consequence is only that the model half of the
+queueing key lives in `config/base.yaml` rather than on the command line.
+
+### Never pass `--parallel_repeats`
+
+`--parallel_repeats` exists **specifically to drop the endpoint tag** so repeat attempts
+can run concurrently — it is the documented opt-*out* of queueing. Using it with this
+eval un-does everything in this section.
+
+It cannot be passed accidentally: `run.sh` always sets the endpoint tag, and the two are
+mutually exclusive, so the CLI refuses the run outright rather than quietly dropping the
+tag:
+
+```
+$ ./run.sh --repeat 2 --parallel_repeats
+ERROR --parallel-repeats cannot be used with an endpoint tag. Remove the endpoint tag
+      to allow CES to schedule repeat attempts in parallel.
+```
+
+For the same reason `run.sh` appends its `--tag` **after** any pass-through arguments:
+CLI tags are last-wins, so a caller's `--tag endpoint=...` is overridden by ours (with a
+`Duplicate tag endpoint; overriding` warning) rather than the other way round.
+
+### This is not a rate-limit fix
+
+Queueing stops our runs racing each other and it is the mechanism MSBench documents for
+this, which is reason enough to switch it on. But it is **not established** that it fixes
+the 429s described in "Is this run a result?". Those appear to come from
+`FrontDoorLimiter`, a per-user *request-count* limiter in `copilot-api` — not from
+exhausting token quota, since this eval uses roughly 0.1% of the 31M TPM allocated to the
+`autodev-test` integration. Serialising our own runs does not obviously change a
+per-user request-rate ceiling. Treat the effect on throttling as unmeasured until a run
+demonstrates otherwise; `verify-run.ts` and its exit 75 are still the safety net.
+
+## Smoke mode is pinned off
+
+`run.sh` passes `--smoke_mode none`.
+
+Smoke is a CES preflight for multi-instance runs: it takes the **first requested
+instance**, executes it for real — same image, runner, credentials, agent package and
+model — and only then fans out to the rest. It is a real instance consuming real tokens
+and a real slot.
+
+**This is currently a no-op.** Smoke is opt-in and off by default in msbench-cli
+`0.3.54`; a dry run reports `"smoke_mode": "none"` with the flag absent. It is pinned
+anyway because the wiki states the default will flip to on for eligible runs, and
+`--smoke_mode none` is documented as the opt-out that remains after that flip.
+
+The reason to pin it *now* rather than when it flips: **smoke only applies to runs with
+more than one instance.** It is inert while we submit one stimulus per run, and would
+start silently duplicating a full end-to-end scenario the moment we stop — which is the
+direction this eval is heading. The cost lands exactly when it is least affordable.
+
+What we give up is an early setup-validity check. That is a reasonable trade here: it
+earns its keep when a bad agent package or missing credential would fail every instance
+identically, and `run.sh` already checks the VSIX for `resources/agents/` and
+`dist/extension.bundle.js` and regenerates the config locally before submitting.
+
+The flag is placed **before** `"${PASSTHRU[@]}"`, so `./run.sh --smoke_mode auto` still
+works if you deliberately want it.
+
+> There is no `MSBENCH_DISABLE_SMOKE_TEST` environment variable. It appears in an older
+> *proposed* version of the wiki page; it does not exist in the shipped CLI, and setting
+> it does nothing. `--smoke_mode` is the real control.
+
+## A `missing` instance is probably an oversized artifact
+
+**This is the most likely cause of a `missing` instance, and it is not flaky
+infrastructure — it is deterministic.**
+
+MSBench's artifact ingestor reads each GitHub Actions artifact **fully into memory**
+(`ArtifactIngestor.ReadArtifactStreamToMemoryAsync`) and rejects anything over a
+**1 GiB** cap:
+
+```
+Artifact <name> (id=…) … size <N> bytes exceeds maximum allowed 1073741824 bytes
+```
+
+An `output.zip` over 1 GiB therefore fails **every retry identically**. After
+`MaxDequeueCount = 5` the message is moved to the `artifact-ingestion-poison` queue and
+that artifact is **never** reconciled into blob storage — it reads as a missing blob for
+that instance. The run itself looks fine. The results are simply gone.
+
+We are a strong candidate to hit this: each run captures a screen recording, trajectory
+data and `session.sqlite`, over a session budgeted at up to five hours.
+
+To confirm rather than assume, query the ingestor's App Insights (the queue depth is not
+in Kusto) for the run's window:
+
+| Field | Value |
+| --- | --- |
+| Cluster | `https://ade.applicationinsights.io/subscriptions/d0c05057-7972-46ff-9bcf-3c932250155e/resourcegroups/CodeExecService/providers/microsoft.insights/components/msbench-kusto-ingestor-func-prod-ai` |
+| Database | `msbench-kusto-ingestor-func-prod-ai` |
+| Tables | `traces` (poison-move lines), `exceptions` (op `ArtifactIngestionTrigger` — the real failure) |
+
+### Why we cannot currently bound it
+
+Both obvious levers are unavailable, so this is documented rather than fixed:
+
+- **Screen recording cannot be shortened or disabled.** `TestConfig.schema.json` has no
+  `screenRecording`/`recording` property — nothing matching `record`, `video`, `mp4`, or
+  any artifact size limit. There is no supported setting to turn it down.
+- **`snapshotWorkspace: false` would fail our runs fast, by design.** It defaults to
+  `true` and its own schema description warns it "can produce multi-gigabyte
+  `session.sqlite` files" — precisely our risk, since these stimuli run a real
+  `npm install` and build, so `node_modules` lands in the snapshot. But the schema also
+  says the run **fails fast if snapshotting is disabled while any assertion queries the
+  `files` table**, and *every* stimulus does:
+
+  ```
+  SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'
+  ```
+
+  Turning it off means first rewriting every artifact assertion in all four stimuli from
+  SQL to `exec:`. That is a much larger change than a size guard and would alter what the
+  eval measures, so it is deliberately not done here.
+
+If a run ever does come back `missing`, check the artifact size before filing it as
+platform flakiness. The upstream fix — stream oversized artifacts to blob instead of
+buffering, and fail soft on one bad artifact — sits with the MSBench KustoIngestor team.
+
 ## Is this run a result?
 
 A finished run is not automatically a *result*. Two things can make the results table

--- a/evals/msbench/config/base.yaml
+++ b/evals/msbench/config/base.yaml
@@ -24,6 +24,10 @@
 #
 # Run it with ./run.sh — see README.md.
 
+# Also the queueing key. CES serialises runs sharing the same (model, endpoint tag),
+# and the model half of that key is read from here: `--model .` makes the vscode
+# plugin resolve the model from this block rather than from the CLI flag. Changing
+# `id` therefore moves our runs into a different queue — see README.md, "Run queueing".
 modelSelector:
   id: claude-sonnet-4.5
   vendor: copilot

--- a/evals/msbench/run.sh
+++ b/evals/msbench/run.sh
@@ -41,6 +41,37 @@ VSIX_DEST="${ASSETS}/extensions/vscode-azureresourcegroups.vsix"
 # we would get a richer starting workspace later.
 BENCHMARK="${BENCHMARK:-vscbench.say_hello}"
 
+# CES serialises runs that share the same (model, endpoint tag) pair, so two of
+# our runs queue instead of racing. Both halves of that key have to match
+# character-for-character or the runs land in different queues and queueing
+# silently does nothing — see README.md, "Run queueing".
+#
+# Only the endpoint half is set here. The model half is derived: `--model .`
+# makes the vscode plugin read `modelSelector` out of the staged
+# user-overrides.yaml, so `config/base.yaml` already fixes it.
+#
+# Deliberately a literal rather than `${QUEUE_ENDPOINT_TAG:-...}`: an env
+# override is exactly the drift this value cannot tolerate.
+QUEUE_ENDPOINT_TAG="copilot-on-rails"
+
+# Smoke is a CES preflight that takes the *first requested instance* of a
+# multi-instance run and executes it for real — real image, real model tokens,
+# real slot — before fanning out. Today it is opt-in and off by default, so this
+# flag changes nothing; it is set because the MSBench wiki states the default
+# will flip to on for eligible runs, and `--smoke_mode none` is the documented
+# opt-out that survives that flip.
+#
+# It is worth pinning now rather than later: smoke only applies to runs with
+# more than one instance, so it is inert while we submit one stimulus per run
+# and would start silently duplicating a full scenario the moment we don't.
+#
+# The trade is a lost early setup-validity check. Acceptable here — that check
+# earns its keep when a bad agent package would fail every instance identically,
+# and run.sh already validates the VSIX contents and rebuilds the config locally
+# before submitting. Placed before "${PASSTHRU[@]}" so `--smoke_mode auto` can
+# still be passed deliberately.
+SMOKE_MODE="none"
+
 # Resource id of the Azure DevOps first-party app, used to mint a feed token.
 ADO_RESOURCE="499b84ac-1321-427f-aa17-267ca6975798"
 VENV="${MSBENCH_VENV:-${HOME}/.msbench-venv}"
@@ -204,7 +235,9 @@ set +e
     --model . \
     --benchmark "$BENCHMARK" \
     --agent-assets "$ASSETS" \
-    ${PASSTHRU[@]+"${PASSTHRU[@]}"} 2>&1 | tee "$RUN_LOG"
+    --smoke_mode "$SMOKE_MODE" \
+    ${PASSTHRU[@]+"${PASSTHRU[@]}"} \
+    --tag "endpoint=${QUEUE_ENDPOINT_TAG}" 2>&1 | tee "$RUN_LOG"
 CLI_STATUS=${PIPESTATUS[0]}
 set -e
 


### PR DESCRIPTION
## The short version

Three bits of **run hygiene** that MSBench either offers or requires, and that this eval wasn't using:

1. **Queueing** — MSBench can stop our runs colliding over the same model capacity. We never switched it on.
2. **Smoke mode** — a preflight that runs a full extra instance. Harmless today, expensive the moment we go multi-instance.
3. **The artifact size cap** — over 1 GiB, MSBench silently throws our results away. We've been misreading that as flaky infra.

Config and docs only. No change to the model, timeouts, stimuli, or layout.

---

## 1. Queueing: we were opted out by omission

When several benchmark jobs run at once they can overrun the model's usage quota. MSBench's answer is to **queue runs that use the same model and endpoint** — the second one waits instead of racing. It switches on automatically *if you supply the values*, and we supplied neither. Every run we've submitted has raced every other run, including our own.

Two values form the key:

| Key | Value | Where it comes from |
| --- | --- | --- |
| endpoint tag | `copilot-on-rails` | `--tag endpoint=copilot-on-rails`, now set by `run.sh` |
| model | `claude-sonnet-4.5` | derived from `modelSelector` in `config/base.yaml` |

**Why identical spelling matters:** MSBench does not validate either string. `copilot_on_rails` or a stray trailing space is accepted, submitted, and put in a *different* queue — where it races the runs it was meant to wait behind. Queueing then does nothing and looks exactly like it's working. That's why both spellings are written down in a README section rather than left in the script.

### `--model .` turned out to be fine

This was the part worth checking. `--model .` is `ASSET_MODEL_SENTINEL`, and the wiki says to always use it with the `vscode` agent — so if queueing needed a real model name, we'd have had a conflict.

It doesn't. The sentinel means "read `modelSelector` from the staged assets", and the plugin hands the result back as `resolved_model`, which the CLI uses to set the model. It's resolved *before* submission, not passed through. Dry run:

```
"model": "claude-sonnet-4.5",
"model_source": "agent_assets",
"resolved_model": "claude-sonnet-4.5",
"runner_notes": [
  "modelSelector set in user-overrides.yaml; using it because --model . was supplied.",
  "modelSelector in user-overrides.yaml: copilot/claude-sonnet-4.5."
]
```

So `--model .` stays, and the model half of the queueing key lives in `config/base.yaml`.

### `--parallel_repeats` must not be used

It exists **specifically to drop the endpoint tag** so attempts run concurrently — it's the documented opt-*out*. It can't be used by accident now, because the CLI refuses the combination outright:

```
$ ./run.sh --repeat 2 --parallel_repeats
ERROR --parallel-repeats cannot be used with an endpoint tag.
```

That error is also the proof the tag reaches the run config — it only fires when `endpoint` is actually set. Without our `--tag`, the same command dry-runs happily as `parallel repeats`.

The `--tag` is appended **after** pass-through args, because CLI tags are last-wins (`Duplicate tag endpoint; overriding`). A caller's `--tag endpoint=...` loses to ours, not the other way round.

## 2. Smoke mode pinned to `none`

Smoke takes the **first requested instance** of a multi-instance run and executes it for real — real image, real tokens, real slot — before fanning out.

**Today this flag changes nothing:** smoke is opt-in and off by default in `0.3.54` (a dry run already reports `"smoke_mode": "none"` without it). It's pinned because the wiki says the default will flip to on, and `--smoke_mode none` is the documented opt-out that survives the flip.

Worth pinning *now* because smoke only applies to runs with **more than one instance**. It's inert while we submit one stimulus per run, and would start duplicating a full end-to-end scenario the moment we stop — which is where this eval is heading.

The trade: we lose an early setup-validity check. Fine here — `run.sh` already validates the VSIX contents and regenerates the config locally before submitting. Placed before `"${PASSTHRU[@]}"` so `--smoke_mode auto` still works deliberately.

> One correction: there is **no `MSBENCH_DISABLE_SMOKE_TEST` env var**. It's in an older *proposed* draft of the wiki page; it doesn't exist in the shipped CLI and setting it would have done nothing. `--smoke_mode` is the real control.

## 3. The artifact cap: documented, not fixed

A `missing` instance is very likely **not** flaky infrastructure. The ingestor reads each artifact **fully into memory** and rejects anything over **1 GiB**. An oversized `output.zip` fails *identically every retry*, so after 5 attempts it's moved to a poison queue and never reconciled — it reads as a missing blob. The run looks fine; the results are just gone. We capture a screen recording, trajectory and `session.sqlite` over a session budgeted at up to 5 hours, so we're a strong candidate.

**I could not find a supported way to bound it**, so per the brief this is documented instead:

- **Screen recording can't be turned down.** `TestConfig.schema.json` has no `screenRecording`/`recording` property — nothing matching `record`, `video`, `mp4`, or any size limit.
- **`snapshotWorkspace: false` would fail our runs fast, by design.** Its own description warns it can produce "multi-gigabyte `session.sqlite` files" — exactly our risk, since these stimuli run a real `npm install` and build. But the schema also fails fast when snapshotting is off and any assertion queries the `files` table, and *every* stimulus does (`SELECT COUNT(*) > 0 FROM files WHERE path LIKE ...`). Using it means first rewriting every artifact assertion from SQL to `exec:` — a much bigger change that would alter what the eval measures.

The README now records the failure mode and the App Insights tables to confirm it, so the next `missing` instance gets diagnosed instead of assumed.

## What this does *not* claim

**This is not a rate-limit fix, and shouldn't be described as one.** Recent investigation points at `FrontDoorLimiter`, a **per-user request-count** limiter in `copilot-api` — not token quota, since this eval uses roughly 0.1% of the 31M TPM allocated to `autodev-test`. Serialising our own runs doesn't obviously move a per-user request-rate ceiling.

Queueing is worth doing on its own merits — it stops our runs racing each other and it's the documented mechanism — but **whether it reduces the 429s is unproven**. `verify-run.ts` and its exit 75 remain the safety net.

## Verification

All offline — **no paid run was submitted.**

- Dry run (`--dry_run`, free) shows the real payload: `"model": "claude-sonnet-4.5"`, `"smoke_mode": "none"`, `"resolved_model": "claude-sonnet-4.5"`.
- Endpoint tag proven to reach the run config via the `--parallel_repeats` conflict error; proven absent without it.
- Last-wins tag ordering confirmed (`Duplicate tag endpoint; overriding`).
- `MSBENCH_DISABLE_SMOKE_TEST` confirmed absent from msbench-cli `0.3.54` and the vscode plugin; smoke default confirmed `none` in `ces_client.py` and the wiki.
- 1 GiB cap and poison-queue behaviour confirmed verbatim in MSBench's reliability runbook.
- `build-config.ts` for all four stimuli — generates and parses as valid YAML.
- `npm run typecheck` in `evals/` passes.
- `bash -n run.sh` passes.

**Unverified, deliberately:** that queueing actually engages server-side. Confirming it means submitting two concurrent paid runs purely to watch the second one log `Run is queued behind N other jobs on the same endpoint/model`. We decided that isn't worth the spend — queueing is cheap insurance that is now configured correctly either way, and the evidence points at a per-user front-door limiter rather than contention we create. It will demonstrate itself in normal use: the next time two of our own runs overlap, we get the answer for free.

