### PR TITLE
Measure what a real multi-turn chain costs, with the first multi-turn MSBench stimulus

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -14,23 +14,27 @@ The two are complementary, not redundant:
 | Where | GitHub Actions, ~30 min | MSBench CES, with video + screenshots |
 | Role | Fast PR gate | Nightly, pass@k, model sweeps |
 
-The four **single-turn** stimuli from [`evals/project-plan/eval.yaml`](../project-plan/eval.yaml)
-are ported here, one config per stimulus in [`config/stimuli/`](config/stimuli).
-`evals/project-plan/eval.yaml` stays the source of truth; this folder is a port of it,
-so changes there need mirroring here until the remaining three (multi-turn) stimuli are
-wired up.
+Five stimuli from [`evals/project-plan/eval.yaml`](../project-plan/eval.yaml) are ported
+here — the four **single-turn** ones and the first **multi-turn** one — with one config
+per stimulus in [`config/stimuli/`](config/stimuli). `evals/project-plan/eval.yaml` stays
+the source of truth; this folder is a port of it, so changes there need mirroring here
+until the remaining two (multi-turn) stimuli are wired up.
 
-| Stimulus | Assertions | Validator flags |
-| --- | --- | --- |
-| `photo-app-requirements` (default) | 8 | — |
-| `api-only-inventory` | 6 | `--assert-no-frontend --assert-blob-storage --assert-cosmosdb` |
-| `multi-service-order-processing` | 5 | `--assert-service-count=3` |
-| `no-datastore-converter` | 5 | `--assert-no-datastore` |
+| Stimulus | Turns | Assertions | Validator flags |
+| --- | --- | --- | --- |
+| `photo-app-requirements` (default) | 1 | 8 | — |
+| `api-only-inventory` | 1 | 6 | `--assert-no-frontend --assert-blob-storage --assert-cosmosdb` |
+| `multi-service-order-processing` | 1 | 5 | `--assert-service-count=3` |
+| `no-datastore-converter` | 1 | 5 | `--assert-no-datastore` |
+| `plan-generation-task-app` | 2 | 9 | — |
 
 Assertion counts differ because they mirror each stimulus's graders one-for-one rather
 than being levelled up — only `photo-app-requirements` specifies
 `no-dotfile-requirements` and `transcript-not-contains`, and only it and
-`api-only-inventory` specify `no-premature-plan`.
+`api-only-inventory` specify `no-premature-plan`. `plan-generation-task-app` is the one
+exception to one-for-one, and deliberately so: it carries a sentinel *per turn* and a
+copy of the `reject_tools` constraint *per turn*, because a step-scoped assertion only
+ever sees its own turn. See [Multi-turn stimuli](#multi-turn-stimuli).
 
 The one assertion every stimulus carries that `eval.yaml` does not specify is the
 **liveness sentinel**, `SELECT COUNT(*) > 0 FROM llm_responses`, which must be first.
@@ -39,7 +43,7 @@ empty table: a run that dies before the session database is populated would othe
 collect full marks on every negative check rather than failing. It is a property of
 *this* harness, not of the source spec, which is why it is not mirrored from there.
 
-All four are verified by a real green run; ids are under
+All four single-turn stimuli are verified by a real green run; ids are under
 [Verified result](#verified-result). Those runs predate the sentinel, so they report
 one assertion fewer than the table above.
 
@@ -332,10 +336,59 @@ than a test double.
 | `program` | `exec:` (defaults to asserting exit code 0) |
 
 Every table carries a `stepIndex`, and `AND stepIndex = :stepIndex` is appended
-automatically so an assertion only sees its own turn — which is what will make the
+automatically so an assertion only sees its own turn — which is what makes the
 multi-turn stimuli straightforward. `llm_responses.response` is user-facing prose
 only, excluding tool output and thinking blocks, so substring assertions don't
 false-match text the agent merely read.
+
+## Multi-turn stimuli
+
+`promptSteps` is natively multi-turn: each entry is one user message into the **same**
+chat session, and each carries its own `assertions`. `plan-generation-task-app` is the
+first stimulus here to use more than one, porting stimulus 1.5 from `eval.yaml`.
+
+The mechanism is `SQLiteAssertionDatabase.formatWithStepIndexFilter` (ported verbatim
+into [`regrade.ts`](regrade.ts)): `:stepIndex` is bound to the index of the step an
+assertion is **declared under**, and the filter is appended to the query. So *where an
+assertion lives is a load-bearing decision*, not a formatting one. An assertion under
+the wrong step still passes — it just stops meaning anything, which is the failure this
+folder keeps having to design against.
+
+Three rules fall out of that, and all three are things a naive port gets wrong:
+
+1. **A grader marked `turn: N` in `eval.yaml` goes under `promptSteps[N]`.** An
+   untargeted Vally grader reads the whole trajectory and the final workspace
+   (`executor/azure-agent-executor.ts` sends every turn into one session and grades once),
+   so it goes under the **last** step. For the plan graders that is also a slightly
+   stronger claim than the source makes — the plan must be written *in the turn after
+   confirmation*, not merely exist by the end — which is the actual product contract.
+2. **One sentinel per turn.** The single sentinel from
+   [PR #1706](https://github.com/microsoft/vscode-azureresourcegroups/pull/1706) only
+   proves *some* turn ran. The multi-turn version of that bug is a run that completes
+   turn 0 and then dies — throttled on the second turn, or stalled. A step-0 sentinel
+   still passes, while every step-1 negative assertion passes vacuously and the step-1
+   positives fail as though the product were broken. Bound to `:stepIndex = 1`, the
+   second sentinel asserts the second turn actually happened.
+3. **A whole-conversation constraint needs a copy per turn.** `constraints.reject_tools`
+   applies to the entire Vally trajectory, but each ported copy sees exactly one turn, so
+   a single copy silently leaves the other turn unchecked. The duplicate also buys
+   attribution: the failing assertion names the turn that misbehaved.
+
+`enableImpliedStepIndexFilter: false` turns the filter off for one assertion, which would
+express rule 3 as a single whole-conversation check and preserve the one-for-one grader
+mapping. It is deliberately **not** used yet — it is unverified against the harness
+version we run, and a config the runner rejects costs a whole run to discover. Plain YAML
+that cannot fail schema validation is worth one extra assertion.
+
+`exec:` needs the same care for a different reason: it runs **after the step it is
+attached to**. The two plan validators are declared under the last step because attached
+to step 0 they would run before `.azure/project-plan.md` exists and go red for a reason
+that has nothing to do with the product.
+
+Assertions can be compile-checked before spending a run, which catches
+[trap 2](#partial-re-runs-when-a-re-grade-isnt-enough) — the filter is appended
+unconditionally, so an assertion that isn't a real table query dies with
+`X_ASSERTION_DOES_NOT_COMPILE` and takes the run with it.
 
 There is also a third assertion type with no Vally equivalent: **LLM-as-judge**. A judge
 model reads whatever rows `promptInputQuery` selects and returns pass/fail.
@@ -861,8 +914,10 @@ with a clear message:
 
 ## Next steps
 
-- The three multi-turn stimuli, using `promptSteps` (native multi-turn). The per-table
-  `stepIndex` scoping already does the hard part.
+- The remaining two multi-turn stimuli (`plan-approval-scrapbook`,
+  `plan-feedback-recipe-app`), following `plan-generation-task-app` — see
+  [Multi-turn stimuli](#multi-turn-stimuli). Both reach the scaffold handoff, so both
+  cost more of the chain than 1.5 does.
 - LLM-as-judge assertions for the qualitative parts of a generated plan.
 - Nightly CI once the CES identity is allowlisted; keep
   [`agent-contracts.yml`](../../.github/workflows/agent-contracts.yml) as the fast PR

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -112,6 +112,65 @@ genuinely executing under the flags that distinguish them:
 | `api-only-inventory` | [`2026082582848923`](https://msbenchapp.azurewebsites.net/run-analysis/2026082582848923) | 5/5 |
 | `no-datastore-converter` | [`2026082585315961`](https://msbenchapp.azurewebsites.net/run-analysis/2026082585315961) | 4/4 |
 | `multi-service-order-processing` | [`2026082586199078`](https://msbenchapp.azurewebsites.net/run-analysis/2026082586199078) | 4/4 |
+| `plan-generation-task-app` (2 turns) | [`2026082614813342`](https://msbenchapp.azurewebsites.net/run-analysis/2026082614813342) | **9/9**, `resolved: true` |
+
+### What a second turn actually costs
+
+`2026082614813342` is the first run here with more than one turn, so it is the first
+number for the chain that is measured rather than extrapolated from single-turn runs.
+
+| | Single-turn baseline (mean of 7) | `plan-generation-task-app` (2 turns) | |
+| --- | --- | --- | --- |
+| Total tokens | 206.6k | **1,306.0k** | 6.3x |
+| Uncached input | 22.4k | **87.3k** | 3.9x |
+| Cached input | — | 1,188.9k (93.2% of input) | |
+| Output | — | 29.8k | |
+| Steps | 5–10 | **18** | |
+| Agent time | — | 465s (7m46s) | |
+| `output.zip` | — | ~9.5 MB (50 MB unpacked) | 0.9% of the 1 GiB ingest limit |
+
+**One extra turn does not cost one extra turn.** Doubling the turns multiplied total
+tokens by 6.3x, because every step re-sends a transcript that is itself growing — turn 1
+wrote `project-plan.md` plus ~48 KB of `.preview-temp/` mock-ups, and all of it rides
+along in each subsequent request. Marginal cost per step was previously measured rising
+at 24.5k → 26.8k → 35.5k; this run is **72.6k tokens/step**, and the marginal cost of the
+10 steps beyond the single-turn baseline is **~110k tokens/step**. The curve steepens; it
+does not flatten.
+
+Uncached input is the gentler number (3.9x) because the cache absorbs 93.2% of the input,
+so **billed cost and context pressure diverge** — quote whichever one the question is
+actually about. Note also that ~30% of chat spans went to `gpt-4o-mini` rather than the
+model under test (14 of 46), so not every span is a step of the task.
+
+Extrapolating to the full 6-phase chain is where confidence drops sharply — see
+[Extrapolating to the full chain](#extrapolating-to-the-full-chain).
+
+### Extrapolating to the full chain
+
+Straight-line from 2 phases to 6 gives ~3.9M total tokens, ~262k uncached and ~23m of
+agent time. **That is almost certainly an underestimate, and it should not be planned
+against.** Confidence is low, for reasons worth stating plainly:
+
+- **n=1.** One run, one model, one prompt. No variance estimate at all.
+- **The two cheapest phases were the ones measured.** Requirements and plan write two
+  text artifacts. Scaffold, build, local-dev and deploy write whole trees and shell out —
+  this run already spent 6 `run_in_terminal` and 4 `runSubagent` calls in turn 1 alone.
+- **Growth is superlinear, and linear extrapolation assumes it isn't.** Per-step cost
+  doubled between the single-turn baseline and this run.
+- **Context, not cost, is the likelier wall.** 1.28M input tokens across 18 steps means
+  the per-request transcript is already large; a 6-phase chain risks compaction or a
+  context limit before it exhausts any token budget, and compaction changes behaviour
+  rather than just price.
+- **Wall-clock has a hard ceiling the token budget doesn't.** `npm install` and
+  `azd provision` are slow *and* quiet, which is `stallSeconds` territory (90m), under a
+  runner cap that [looks like 2h rather than 6h](#timeouts).
+
+`output.zip` is the one risk that looks comfortable: 9.5 MB here, and the bulk is logs
+(`agent-traces.db` 9.2 MB, `chat-export-logs.json` 8.7 MB, `extension-host.log` 8.3 MB)
+which scale with steps, not wall-clock — `screen_recording.mp4` was only 1.9 MB. Even a
+10x chain lands around 100 MB, an order of magnitude below the 1 GiB limit where the
+ingestor rejects the artifact deterministically on every retry and the run reads as a
+missing blob.
 
 ### The negative control, in MSBench
 
@@ -195,6 +254,29 @@ chosen because it is the safer of the two documented limits. If the cap is ever
 confirmed, re-derive `agentSeconds` from the arithmetic above rather than just raising
 it; raising it past 6h needs confirmation from the MSBench team
 (<CodeExService@microsoft.com>).
+
+> **The observed runner cap is 2h, not 6h — so `agentSeconds: 18000` is mis-derived.**
+> The instance runlog for `2026082614813342` says, before the agent starts:
+>
+> ```
+> Using timeout of 7200 seconds
+> ```
+>
+> That is 2h, and the 5h `agentSeconds` above was derived from an *assumed* 6h cap. If
+> 7200s is the real per-instance limit then the agent budget is 2.5x the runner's, which
+> is precisely the failure this section warns about: the job is killed first, the agent
+> timeout never fires, `runnerGraceSeconds` never runs because it only starts *after*
+> the agent timeout, and nothing is flushed on the runs that most need diagnosing.
+> Re-derived from the observed cap, the arithmetic gives `7200 − ~15m setup − 15m grace
+> ⇒ ~1.5h agent (5400s)`.
+>
+> This is left unchanged pending confirmation rather than fixed here, for two reasons:
+> it is one observation, and the line does not say whether 7200s is fixed per instance
+> or something the orchestrator sets per dispatch. Nothing has come close to it yet — the
+> longest run to date is 49m and `2026082614813342` used 465s of the 7200s (6.5%) — so
+> this is a latent trap rather than an active one. It becomes active on exactly the long
+> chain runs this timeout section exists for. Worth confirming with
+> <CodeExService@microsoft.com> before the scaffold and deploy phases get wired up.
 
 **`msbench-cli run --timeout` — not the same thing, and don't add it.** It is a *local*
 wait. From `cli/arguments.py`: *"Max seconds to wait locally for completion. When
@@ -362,6 +444,12 @@ Three rules fall out of that, and all three are things a naive port gets wrong:
    so it goes under the **last** step. For the plan graders that is also a slightly
    stronger claim than the source makes — the plan must be written *in the turn after
    confirmation*, not merely exist by the end — which is the actual product contract.
+   The `files` table is a **per-step snapshot, not a delta**, measured in run
+   `2026082614813342`: `.azure/requirements.json` appears at both step 0 and step 1 with
+   identical bytes, while `.azure/project-plan.md` appears at step 1 only. So a
+   `file-exists` under the last step is exactly Vally's final-workspace semantics, and a
+   `file-not-exists` under step 0 is a genuine approval-gate check rather than a
+   statement about write ordering.
 2. **One sentinel per turn.** The single sentinel from
    [PR #1706](https://github.com/microsoft/vscode-azureresourcegroups/pull/1706) only
    proves *some* turn ran. The multi-turn version of that bug is a run that completes
@@ -389,6 +477,27 @@ Assertions can be compile-checked before spending a run, which catches
 [trap 2](#partial-re-runs-when-a-re-grade-isnt-enough) — the filter is appended
 unconditionally, so an assertion that isn't a real table query dies with
 `X_ASSERTION_DOES_NOT_COMPILE` and takes the run with it.
+
+### That the scoping discriminates, measured
+
+Turn-scoped assertions are the "looks fine, means nothing" risk: one attached to the
+wrong step still passes. Run `2026082614813342` shows the scoping doing real work rather
+than being satisfied by whichever turn happened to be convenient —
+
+```
+toolCalls    step0=6   step1=26
+files        step0=155 step1=162     (snapshot per step, not a delta)
+llm_responses step0=1  step1=1
+exec         step1=3                 (both validators + the fingerprint)
+
+step0  mcp_copilot_azure_open_requirements_view x1
+step1  mcp_copilot_azure_open_plan_view         x1
+```
+
+Each webview tool is called in exactly one turn, and it is the turn its assertion is
+bound to. `exec` rows exist only for the step the graders are declared under, which
+confirms `exec:` runs per-step — the reason the two plan validators cannot live on
+step 0.
 
 There is also a third assertion type with no Vally equivalent: **LLM-as-judge**. A judge
 model reads whatever rows `promptInputQuery` selects and returns pass/fail.

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -168,7 +168,8 @@ against.** Confidence is low, for reasons worth stating plainly:
 `output.zip` is the one risk that looks comfortable: 9.5 MB here, and the bulk is logs
 (`agent-traces.db` 9.2 MB, `chat-export-logs.json` 8.7 MB, `extension-host.log` 8.3 MB)
 which scale with steps, not wall-clock — `screen_recording.mp4` was only 1.9 MB. Even a
-10x chain lands around 100 MB, an order of magnitude below the 1 GiB limit where the
+10x chain lands around 100 MB, an order of magnitude below the
+[1 GiB ingest limit](#a-missing-instance-is-probably-an-oversized-artifact) where the
 ingestor rejects the artifact deterministically on every retry and the run reads as a
 missing blob.
 
@@ -642,6 +643,16 @@ that instance. The run itself looks fine. The results are simply gone.
 
 We are a strong candidate to hit this: each run captures a screen recording, trajectory
 data and `session.sqlite`, over a session budgeted at up to five hours.
+
+**The first multi-turn run puts a number on that risk, and it is smaller than feared.**
+`2026082614813342` produced a **~9.5 MB `output.zip`** (50 MB unpacked) — 0.9% of the
+cap. More useful than the number is the composition: the bulk is logs that scale with
+*steps* (`agent-traces.db` 9.2 MB, `chat-export-logs.json` 8.7 MB, `extension-host.log`
+8.3 MB), while `screen_recording.mp4` — the artifact the five-hour budget makes scary —
+was only **1.9 MB** for a 7m46s run. Even a 10x chain lands near 100 MB. So this stays
+worth watching as the chain grows, but on current evidence it is an order of magnitude
+away, and a `missing` instance today is more likely something else. See
+[What a second turn actually costs](#what-a-second-turn-actually-costs).
 
 To confirm rather than assume, query the ingestor's App Insights (the queue depth is not
 in Kusto) for the run's window:

--- a/evals/msbench/config/stimuli/plan-generation-task-app.yaml
+++ b/evals/msbench/config/stimuli/plan-generation-task-app.yaml
@@ -1,0 +1,128 @@
+# Stimulus 1.5 `plan-generation-task-app` from evals/project-plan/eval.yaml.
+# Concatenated onto config/base.yaml by build-config.ts.
+#
+# The FIRST multi-turn stimulus in this folder. The four before it are one
+# prompt, one artifact; this one is two prompts and exercises the link the
+# product actually depends on — requirements confirmed, THEN a plan.
+#
+# Turn scoping is the whole point, so it is worth being precise about it.
+# `SQLiteAssertionDatabase.formatWithStepIndexFilter` appends
+# `AND stepIndex = :stepIndex` (or `WHERE …`) to every *query* assertion, with
+# `:stepIndex` bound to the index of the step the assertion is declared under.
+# So an assertion sees only its own turn, and where an assertion lives is a
+# load-bearing decision rather than a formatting one — an assertion under the
+# wrong step still passes, it just stops meaning anything.
+#
+# Mapping from the source spec's graders:
+#
+#   vally grader                        turn    declared under
+#   ----------------------------------------------------------------
+#   tool-calls requirements-view-opened  0      step 0  (explicit in source)
+#   file-exists plan-exists              -      step 1
+#   program plan-structure-valid         -      step 1
+#   program plan-webview-parseable       -      step 1
+#   tool-calls plan-view-opened          -      step 1
+#   constraints.reject_tools             -      BOTH   (see below)
+#
+# The source marks only `requirements-view-opened` with `turn: 0`; the rest are
+# untargeted, and in Vally an untargeted grader reads the whole trajectory and
+# the final workspace (`executor/azure-agent-executor.ts` sends every turn into
+# one session and grades the result once). Here they are declared under step 1,
+# the last step, which is the closest equivalent — and deliberately a slightly
+# stronger claim: the plan must be produced *in the turn after confirmation*,
+# not merely exist by the end. That is the product contract this stimulus is
+# for, and it is safe under either reading of the `files` table (per-step delta
+# or per-step snapshot) because the plan is written during turn 1 either way.
+#
+# The `exec:` graders are declared under step 1 for a second, harder reason:
+# `exec:` runs after the step it is attached to. Attached to step 0 they would
+# run before `.azure/project-plan.md` exists and fail for a reason that has
+# nothing to do with the product.
+
+promptSteps:
+  # ─── Turn 0: describe the app ────────────────────────────────────────────
+  - text: |
+      I want to build a task management app where teams can create projects,
+      assign tasks to people, set due dates, and track progress. React frontend,
+      Azure Functions backend, PostgreSQL for the data. I want it to look polished.
+    assertions:
+      # Liveness sentinel — must come first. See
+      # config/stimuli/photo-app-requirements.yaml for the full reasoning.
+      - comment: Sentinel; turn 0 must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      # vally: tool-calls turn: 0 required [workflow-tools-open_requirements_view]
+      # The one grader the source pins to a turn. `turn: 0` maps onto "declared
+      # under promptSteps[0]", where the implied filter binds :stepIndex = 0.
+      # Scoping matters here: the agent may legitimately re-open the webview
+      # later, and an unscoped check would be satisfied by that instead of by
+      # the behaviour under test — asking BEFORE it has an answer.
+      - comment: Agent should have opened the requirements webview on the first turn
+        query: SELECT COUNT(*) > 0 FROM toolCalls WHERE tool LIKE '%open_requirements_view%'
+
+      # vally: constraints.reject_tools [vscode_askQuestions]
+      #
+      # Declared on BOTH steps, and that is not redundancy. A Vally constraint
+      # applies to the whole trajectory, but the implied filter makes each copy
+      # see exactly one turn — so a single copy would leave the other turn
+      # unchecked while still reading green. Duplicating it is the honest port,
+      # and it buys per-turn attribution: the failing assertion names the turn
+      # that fell back to chat questions.
+      #
+      # `enableImpliedStepIndexFilter: false` would express this as one
+      # whole-conversation assertion and keep the 1:1 grader mapping. Not used:
+      # it is unverified against this harness version, and a config the runner
+      # rejects costs a whole run to find out. Plain YAML that cannot fail
+      # schema validation is worth one extra assertion.
+      - comment: Agent should not fall back to the chat question tool (turn 0)
+        query: SELECT COUNT(*) = 0 FROM toolCalls WHERE tool LIKE '%askQuestion%'
+
+  # ─── Turn 1: requirements confirmed, expect the plan ─────────────────────
+  - text: "Requirements submitted at .azure/requirements.json. All answers confirmed."
+    assertions:
+      # The sentinel that only a multi-turn stimulus needs, and the reason this
+      # file has two. PR #1706 added the sentinel because negative assertions
+      # are vacuous against an empty table; the multi-turn version of that bug
+      # is a run which completes turn 0 and then dies — throttled on the second
+      # turn, or stalled. `llm_responses` is non-empty, so a step-0 sentinel
+      # still passes, while every step-1 negative passes trivially and the
+      # positives fail as if the product were broken. Bound to :stepIndex = 1,
+      # this asserts the second turn actually happened.
+      - comment: Sentinel; turn 1 must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      # vally: file-exists .azure/project-plan.md
+      - comment: Agent should have written the plan after requirements were confirmed
+        query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/project-plan.md'
+
+      # vally: program plan-structure-valid
+      # The real validator, shared with grader certification — structure,
+      # numbering, required sections and the route table. Semantic checks that
+      # SQL could only approximate, which is the drift this eval exists to
+      # catch. cwd is the workspace, so graderHarness resolves the artifact
+      # without EVALUATE_WORKSPACE — see README.md.
+      - comment: project-plan.md satisfies the plan contract
+        exec: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-project-plan.ts
+
+      # vally: program plan-webview-parseable
+      # Runs the extension's real `parseScaffoldPlanMarkdown` — the function the
+      # plan webview itself calls. A plan that passes here cannot fail to render
+      # in product, which a structural check alone would not establish.
+      - comment: project-plan.md renders in the plan webview
+        exec: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-webview-parseable.ts
+
+      # vally: tool-calls required [workflow-tools-open_plan_view]
+      # Scoped to turn 1, so this is the requirements -> plan handoff itself:
+      # the plan view opened on the turn that followed confirmation.
+      - comment: Agent should have opened the plan webview after confirmation
+        query: SELECT COUNT(*) > 0 FROM toolCalls WHERE tool LIKE '%open_plan_view%'
+
+      # vally: constraints.reject_tools [vscode_askQuestions] — turn 1 copy.
+      - comment: Agent should not fall back to the chat question tool (turn 1)
+        query: SELECT COUNT(*) = 0 FROM toolCalls WHERE tool LIKE '%askQuestion%'
+
+      # Recorded, not asserted. See config/stimuli/photo-app-requirements.yaml.
+      # On the last step, where the `exec:` graders above run.
+      - comment: Environment fingerprint for triage
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        assertZeroExitCode: false


### PR DESCRIPTION
## ELI5 first: what we learned

Every MSBench stimulus so far is **one prompt, one artifact, done**. But the product is a
*chain* — questionnaire → plan → scaffold → debug → deploy. So every cost, duration and
step-count number we quote for the chain is extrapolated from a 5–10 step single-turn run.
That extrapolation has misled us twice.

This PR runs **two real turns** and measures them. Headline:

> **A second turn does not cost a second turn. It cost 6.3x.**

| | Single-turn baseline (mean of 7) | This run (2 turns) | |
| --- | --- | --- | --- |
| Total tokens | 206.6k | **1,306,001** | **6.3x** |
| Uncached input | 22.4k | **87,269** | **3.9x** |
| Cached input | — | 1,188,942 (93.2% of input) | |
| Output | — | 29,790 | |
| Steps | 5–10 | **18** | |
| Agent time | — | **465s** (7m46s) | |
| `output.zip` | — | **~9.5 MB** (50 MB unpacked) | 0.9% of the 1 GiB cap |

Why 6.3x and not 2x: **every step re-sends a transcript that is itself growing.** Turn 1
wrote `project-plan.md` *plus* ~48 KB of `.preview-temp/` mock-ups, and all of it rides
along in every later request.

**The marginal-cost curve steepens — it does not flatten.** Previously measured rising at
24.5k → 26.8k → 35.5k tokens/step. This run is **72.6k tokens/step**, and the marginal
cost of the 10 steps beyond the single-turn baseline is **~110k tokens/step**.

One nuance worth carrying around: **billed cost and context pressure have diverged.** The
cache absorbed 93.2% of input, so uncached grew only 3.9x while total grew 6.3x. Quote
whichever one the question is actually about.

## Run

[`2026082614813342`](https://msbenchapp.azurewebsites.net/run-analysis/2026082614813342) —
**9/9 assertions, `resolved: true`, 100% resolved.** `verify-run.ts`: *"verified: this run
is a result."* Model requested `claude-sonnet-4.5`, model active `claude-sonnet-4.5`.

**No throttling.** No `error.json` at all, so no `"type": "RATE_LIMIT"`. Upstream census
was clean: `POST /v1/messages` 33x 200, `POST /chat/completions` 15x 200,
`POST /embeddings` 2x 200, `GET /models` 1x 200.

> ⚠️ A naive `grep -c 429 capi-proxy.log` returns **4** on this run and all four are
> millisecond timestamps (`...T04:17:20.429Z`). Match on the `-> 429` arrow, not the bare
> number, or you will invent a throttling incident that never happened.

Wall clock ~12.7 min end to end: 6.0s queued in CES (04:06:53 → 04:06:59 dispatch), 465s
agent, remainder container pull + VS Code/VSIX install + workspace setup + artifact flush.
TTFT 1.75s; TTLT median 5.3s but max **158.6s** — one turn stalled 2m39s, which is the
shape that eventually meets `stallSeconds`.

## Did turn scoping actually work?

This is the "looks fine, means nothing" failure this project keeps hitting: an assertion on
the wrong turn still passes. So it is verified, not assumed:

```
toolCalls     step0=6   step1=26
files         step0=155 step1=162
llm_responses step0=1   step1=1
exec          step1=3

step0  mcp_copilot_azure_open_requirements_view x1
step1  mcp_copilot_azure_open_plan_view         x1
```

Each webview tool is called in exactly one turn, and it is the turn its assertion binds to.
`eval.json` confirms `AND stepIndex = :stepIndex` was appended to all 9 — **including the
two `exec:` assertions**, which was not certain beforehand.

### Two findings that correct assumptions already in the README

1. **`files` is a per-step *snapshot*, not a delta.** `.azure/requirements.json` appears at
   both step 0 and step 1 with identical bytes; `.azure/project-plan.md` at step 1 only.
   This is load-bearing: it means `file-exists` under the last step is exactly Vally's
   final-workspace semantics, and `file-not-exists` under step 0 is a genuine approval-gate
   check rather than a statement about write ordering.

2. **The observed runner cap is 7200s (2h), not the assumed 6h.** The instance runlog says
   `Using timeout of 7200 seconds` before the agent starts. `base.yaml` sets
   `agentSeconds: 18000` (5h), derived from an assumed 6h cap — **2.5x the runner's own
   budget**, which is precisely the configuration the README warns produces *unflushed
   artifacts on exactly the runs you need to diagnose* (the job dies first, so the agent
   timeout never fires and `runnerGraceSeconds` never runs). Re-derived from 7200s the
   arithmetic gives ~5400s.

   **Left unchanged, deliberately** — one observation, the line doesn't say whether 7200s is
   fixed per instance or set per dispatch, and `base.yaml` has PRs in flight. Latent, not
   active: this run used 465s of 7200s (6.5%). It becomes active exactly when scaffold and
   deploy get wired up. Worth confirming with CodeExService@microsoft.com first.

## Extrapolating to a full 6-phase chain — low confidence, and I'd rather say so

Straight-line from 2 phases to 6: ~3.9M total tokens, ~262k uncached, ~23m agent.
**Almost certainly an underestimate. Do not plan against it.** Because:

- **n=1.** One run, one model, one prompt. No variance estimate at all.
- **The two *cheapest* phases were the ones measured.** Requirements and plan write two text
  artifacts. Scaffold/build/deploy write whole trees and shell out — this run already spent
  6 `run_in_terminal` and 4 `runSubagent` calls in turn 1 alone.
- **Growth is superlinear and linear extrapolation assumes it isn't** — per-step cost doubled
  between the baseline and this run.
- **Context, not cost, is the likelier wall.** 1.28M input tokens across 18 steps means the
  per-request transcript is already large; a 6-phase chain risks compaction before it
  exhausts any token budget, and compaction changes *behaviour*, not just price.
- **Wall-clock has a hard ceiling the token budget doesn't** — `npm install` and
  `azd provision` are slow *and quiet*, i.e. `stallSeconds` territory, under a cap that now
  looks like 2h.

**`output.zip` risk: downgraded, with evidence.** #1712 says we're "a strong candidate" to
hit the 1 GiB ingestor cap. At 9.5 MB we're at 0.9%, and the composition is the reassuring
part: the bulk is logs scaling with *steps* (`agent-traces.db` 9.2 MB, `chat-export-logs.json`
8.7 MB, `extension-host.log` 8.3 MB), while `screen_recording.mp4` — the artifact the 5h
budget makes scary — was **1.9 MB**. Even a 10x chain lands near 100 MB. Still worth
watching; not the current danger.

## The stimulus itself

`plan-generation-task-app`, ported from `evals/project-plan/eval.yaml` (stimulus 1.5) — two
turns, 9 asserting + the non-asserting environment fingerprint. Chosen over
`plan-approval-scrapbook` as the smallest genuine multi-turn case that still exercises the
requirements→plan handoff, the most interesting link in the chain.

Mapping the source's graders onto `promptSteps`, per the README's table
(`file-exists` → `files`, `tool-calls` → `toolCalls`, `program` → `exec:`):

| vally grader | turn | declared under |
| --- | --- | --- |
| `tool-calls` requirements-view-opened | 0 | step 0 |
| `file-exists` plan-exists | — | step 1 |
| `program` plan-structure-valid | — | step 1 |
| `program` plan-webview-parseable | — | step 1 |
| `tool-calls` plan-view-opened | — | step 1 |
| `constraints.reject_tools` | — | **both** |

Three things a naive port gets wrong, all now documented:

- **`turn: 0` → `promptSteps[0]`.** Untargeted Vally graders read the whole trajectory and
  final workspace, so they go on the **last** step — which for the plan graders is also
  slightly *stronger* than the source: the plan must appear in the turn *after* confirmation,
  not merely exist by the end.
- **One sentinel per turn.** #1706's single sentinel only proves *some* turn ran. The
  multi-turn version of that bug is a run that finishes turn 0 then dies: `llm_responses` is
  non-empty so a step-0 sentinel still passes, while every step-1 negative passes *vacuously*
  and the step-1 positives fail like a product regression. The step-1 sentinel asserts the
  second turn happened.
- **`reject_tools` needs a copy per turn.** It spans the whole Vally trajectory, but each
  ported copy sees exactly one turn, so a single copy silently leaves the other unchecked.
  The duplicate also buys attribution — the failing assertion names the turn.

`enableImpliedStepIndexFilter: false` would express that last one as a single
whole-conversation check and keep the 1:1 grader mapping. **Deliberately not used**: it's
unverified against our harness version, and a config the runner rejects costs a whole run to
discover. Plain YAML that can't fail schema validation is worth one extra assertion.

The two `program` validators run as `exec:` on the **last** step because `exec:` runs after
the step it's attached to — on step 0 they'd grade a `project-plan.md` that doesn't exist
yet. The `exec` table having rows only at step 1 confirms this.

## Pre-flight and verification

- `./run.sh --build-only` first: VSIX **6.6 MB** (not the ~1 MB broken-build tell).
- No sibling run in flight — no `assets/.run.lock`, no process; and the staged
  `user-overrides.yaml` was confirmed to contain **both** turns before submitting, which is
  the guard against the "graded the wrong stimulus" failure that bit `2026082584891952`.
- All 9 assertions **compile-checked locally** against a mock schema with the implied
  `stepIndex` filter appended, before spending the run — that's the
  `X_ASSERTION_DOES_NOT_COMPILE` trap that silently killed an earlier probe run.
- `npm run typecheck` ✅ and `npm run msbench:self-test` ✅. TypeScript only; no `.mjs`/`.cjs`.
- Rebased onto current `feat/CoR` (through #1710/#1712), re-verified after rebase.

**One run submitted, as authorised. No further runs without asking.**

### Not done / caveats

- The run was submitted from the pre-#1712 `run.sh`, so it did **not** carry
  `--smoke_mode none` or `--tag endpoint=…`. Those affect queueing and tagging, not agent
  behaviour, so the measurements stand — but the next run of this stimulus will be the first
  through the queue.
- `evals/msbench/INVESTIGATION.md` referenced in the brief **does not exist** in the repo;
  only `README.md` does.
- n=1. Everything above is one datapoint, and the extrapolation section says so.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>