### PR TITLE
Wire the debug probe into MSBench, plus one cheap run to prove it installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,13 @@ evals/msbench/assets/stack.json
 # truth for a document that already has two.
 evals/msbench/assets/workspace/
 
+# The known-debuggable project the breakpoint stimulus runs against, copied from
+# evals/grader-certification/reference-node-fullstack by run.sh on every run.
+# Same reason as the graders above: a second checked-in copy would drift from the
+# fixture that evals/debug-probe certifies against, and then a green run here and
+# a green certification would stop meaning the same thing.
+evals/msbench/assets/fixtures/
+
 # Mutual-exclusion lock taken by run.sh while it owns assets/.
 evals/msbench/assets/.run.lock/
 

--- a/evals/debug-probe/README.md
+++ b/evals/debug-probe/README.md
@@ -307,3 +307,34 @@ fixture is for. It says nothing about whether any particular generated project
 is debuggable; that is the gate's job once it runs behind real output, and it is
 only meaningful *because* this baseline exists. A red there can now be read as a
 product finding rather than an unexplained one.
+
+## Which stacks this gate can honestly answer for
+
+**It requires a stack whose debug adapter ships with VS Code** — in practice the
+Node family, via the built-in js-debug. That is a real constraint, not a
+preference, and wiring it unconditionally produces exactly the failure this gate
+was built to prevent.
+
+Two directions, both verified rather than reasoned about:
+
+**A launch configuration naming an adapter we do not install used to produce a
+fabricated red.** `debugpy`, `go` and `coreclr` are not in this container. With
+one of those, `startDebugging` never resolves, the probe hits its deadline and
+the verdict was `appFailedToStart` — **exit 1, blaming the product for a project
+it built correctly**, since that configuration would work on a developer machine
+with the extension installed. Reproduced by setting `type: "debugpy"` on the
+known-good fixture; the verdict even misattributed the cause to "an unfinishable
+preLaunchTask". The probe now checks `contributes.debuggers[].type` across
+installed extensions before launching and returns `probeError` (exit 3) naming
+the missing adapter and listing the ones available. Certified by
+`mutation-debug-adapter-missing`.
+
+**With no `debug-probe.json`, the gate reports exit 3 forever.** The probe idles,
+no verdict is written, and the grader correctly calls that a harness fault. But
+MSBench collapses exit 1 and exit 3 into "non-zero", so on any stimulus that does
+not opt in, a `requires: {}` wiring shows a permanently failing assertion. That
+is the "gate that cannot pass" shape displaced into the exit-3 column.
+
+So the gate should be wired where the stimulus writes a probe spec **and** the
+stack is one the harness can drive. Everywhere else it is an environment gap: it
+has a real question and no way to ask it, which is a `knownGap`, not a red.

--- a/evals/debug-probe/README.md
+++ b/evals/debug-probe/README.md
@@ -224,3 +224,26 @@ reads `launch.json` directly and is only handed a configuration *name* — so
 detecting and declining is the only honest option. Certification runs its cases
 strictly sequentially for the same reason. A stack template emitting a hardcoded
 inspector port should be fixed at the source rather than worked around here.
+
+### Why certification runs sequentially
+
+The live tier must not be parallelised. Its cases contend for two ports the
+fixture **hardcodes** — `7071` via `env.PORT` and `9229` via
+`runtimeArgs: ["--inspect=9229"]` — and the probe cannot remap either, because
+VS Code reads `launch.json` directly and is handed only a configuration *name*.
+Run two cases at once and the second finds a port held by the first. The port
+guard turns that into `probeError` rather than a silent wrong answer, so it
+fails loudly — but the suite would look broken instead of parallel. Making it
+faster means fixing the hardcoded ports in the fixture, not removing the
+sequencing. This is repeated as a comment on the loop in `certify.ts`, which is
+where someone optimising for speed will actually be looking.
+
+### One thing the probe does not do
+
+It never binds or allocates a port — it only *connects* to two whose numbers it
+is given. That matters because the allocation path is where this class of bug
+tends to survive a fix: a free-port search that binds `127.0.0.1` can be handed
+an ephemeral port a squatter already holds on `0.0.0.0`, and the caller then
+latches onto the squatter believing it chose a free port. There is no such path
+here by construction, and there should not be one added without the same
+connect-based check.

--- a/evals/debug-probe/README.md
+++ b/evals/debug-probe/README.md
@@ -76,8 +76,24 @@ js-debug answers `verified: false, message: "Unbound breakpoint"` at set time
 because the script has not loaded yet, then rebinds later via a `breakpoint`
 event rather than a fresh `setBreakpoints` response. On the known-good fixture
 the breakpoint reports unverified and is hit a moment later. Gating on
-`verified === true` — the obvious check — produces a gate that can never pass.
-It is recorded as a diagnostic and nothing more.
+`verified === true` — the obvious check, and what the DAP field appears to be
+*for* — produces a gate that can never pass. It is recorded as a diagnostic and
+nothing more.
+
+**Do not gate on `verified`. Gate on the `stopped` event.** This is not a local
+quirk: it reproduced in all five MSBench container runs. From
+[`2026082623215161`](https://msbenchapp.azurewebsites.net/run-analysis/2026082623215161):
+
+```
+06:30:00.999  setBreakpoints response: [{"verified":false,"message":"Unbound breakpoint"}]
+06:30:01.074  startDebugging returned true
+06:30:01.581  trigger connected after 2 attempt(s)
+06:30:01.589  stopped: reason=breakpoint     ← hit, 0.6s after being called unverified
+```
+
+The failure this avoids is the expensive kind: an intermittent **red against a
+working project**, which reads as a product regression and gets explained away
+as flaky agent output rather than investigated.
 
 **3. The trigger request never completes on a healthy run.**
 We break *mid-request*, so the HTTP response never arrives. The signal is
@@ -247,3 +263,47 @@ an ephemeral port a squatter already holds on `0.0.0.0`, and the caller then
 latches onto the squatter believing it chose a free port. There is no such path
 here by construction, and there should not be one added without the same
 connect-based check.
+
+## Measured in-container reliability
+
+`debug-breakpoint-node` was run five times against the known-good fixture, from
+an identical tree, to turn "it worked once" into a number.
+
+| Run | Outcome | Trigger attempts | launch→connect | connect→stop | Total |
+| --- | --- | --- | --- | --- | --- |
+| [`2026082623215161`](https://msbenchapp.azurewebsites.net/run-analysis/2026082623215161) | `hit` | 2 | 0.507s | 8ms | 7.28s |
+| [`2026082624051475`](https://msbenchapp.azurewebsites.net/run-analysis/2026082624051475) | `hit` | 2 | 0.512s | 6ms | 7.43s |
+| [`2026082624376225`](https://msbenchapp.azurewebsites.net/run-analysis/2026082624376225) | `hit` | 2 | 0.507s | 6ms | 6.76s |
+| [`2026082624660033`](https://msbenchapp.azurewebsites.net/run-analysis/2026082624660033) | `hit` | 2 | 0.516s | 6ms | 7.54s |
+| [`2026082626667577`](https://msbenchapp.azurewebsites.net/run-analysis/2026082626667577) | `hit` | 2 | 0.509s | 5ms | 7.34s |
+
+**5/5 `hit`.** js-debug launches a process, binds a breakpoint and stops on it
+under xvfb-as-root on Ubuntu 22.04 with Node v22.22.2, reproducibly.
+
+### The attempt count is a floor, not a ceiling
+
+It is tempting to read "2 attempts every time" as a thin margin — one slow
+container from needing 3, then 4, then failing. **That reading is wrong, and the
+distribution shows why.** `launch→connect` is 0.507–0.516s across all five runs,
+a 9ms spread, and `TRIGGER_RETRY_DELAY_MS` is 500ms. The app becomes ready
+somewhere under 500ms after `startDebugging` returns, so attempt 1 always fires
+too early and attempt 2 always succeeds. The 2 is a **property of the retry
+interval**, not evidence of a near-miss.
+
+Nothing caps the attempt count. The loop retries until the probe's deadline, so
+a slower container spends more attempts rather than failing. The margin that
+actually matters is **time-to-listen (~0.5s) against the probe budget (180s)** —
+roughly 350×. A container would have to be two orders of magnitude slower before
+this turned red, and if it were, the verdict would say `appFailedToStart` with
+the debuggee's own output attached.
+
+The number worth watching in future runs is therefore `launch→connect`, not the
+attempt count.
+
+### What this does and does not establish
+
+It establishes that **the container can host a debugger** — which is what the
+fixture is for. It says nothing about whether any particular generated project
+is debuggable; that is the gate's job once it runs behind real output, and it is
+only meaningful *because* this baseline exists. A red there can now be read as a
+product finding rather than an unexplained one.

--- a/evals/debug-probe/README.md
+++ b/evals/debug-probe/README.md
@@ -154,6 +154,37 @@ The fixture is [`evals/grader-certification/reference-node-fullstack`](../grader
 reused as-is — it already ships `launch.json`, `tasks.json`, a health route and
 zero dependencies. This directory only reads it.
 
+## Wiring
+
+The probe rides into a run as a second `installExtensions` entry in
+[`msbench/config/base.yaml`](../msbench/config/base.yaml). That key
+**concatenates across config layers rather than replacing**, which is how our
+product VSIX already installs alongside `github.copilot-chat` — the probe is the
+second user of that behaviour.
+
+`run.sh` builds and stages `cor-debug-probe.vsix` next to the product VSIX, and
+checks the package actually contains `out/extension.js`: a VSIX packaged without
+compiling looks valid and then fails to activate, which from outside the
+container is indistinguishable from not being installed at all.
+
+The probe is **inert unless the workspace contains `debug-probe.json`**, so it is
+installed on every run and opted into per stimulus. It watches for that file
+rather than only reading it at activation, because whether the config's
+`script:` preamble seeds the workspace before or after the extension host
+finishes starting is not something we can verify from outside.
+
+### The one claim that needs a real run
+
+`evals/msbench/config/stimuli/debug-probe-smoke.yaml` is the smallest run that
+answers the only part of this design that could not be settled locally: **does a
+second extension install and activate alongside ours?** It uses a `probe-smoke`
+phase with no `chatMode` and no agent seeding, so the agent does essentially
+nothing — the evidence is written by the extension host before the first turn.
+It asserts the liveness sentinel, that `.eval/probe.log` exists, and nothing
+else. There is deliberately **no breakpoint assertion**: that is the next run,
+gated on this one, because asserting it here would conflate "the probe installed"
+with "the debugger works in a container" and a red result would not say which.
+
 ### Container notes
 
 `pwa-node` needs no display (it drives CDP over a socket), but VS Code itself
@@ -162,17 +193,5 @@ does — use `xvfb`, and `--no-sandbox` since the container runs as root. Keep t
 and `sun_path` caps at ~104 bytes. Exceeding it makes VS Code start, open no
 window, write no logs, and hang until killed — indistinguishable from a broken
 extension. `certify.ts` asserts against this explicitly rather than
-rediscovering it.
-
-## Not wired up yet
-
-This PR deliberately stops at "the probe works and the gate is certified".
-Wiring it into a run — adding the grader to `stage-graders.ts`'s entrypoints,
-adding the probe VSIX to `installExtensions` in `msbench/config/base.yaml`, and
-building it in `run.sh` — is a **follow-up PR**, because several sessions are
-editing `msbench/config/` concurrently.
-
-`installExtensions` concatenates across config layers rather than replacing,
-which is how our VSIX already rides alongside `github.copilot-chat`, so a second
-`mode: vsix` entry should install cleanly. **That has not been confirmed
-in-container yet** — it needs an MSBench run.
+rediscovering it. MSBench chooses that path, not us, so this is a hazard to
+recognise rather than one we can configure away.

--- a/evals/debug-probe/README.md
+++ b/evals/debug-probe/README.md
@@ -195,3 +195,32 @@ window, write no logs, and hang until killed — indistinguishable from a broken
 extension. `certify.ts` asserts against this explicitly rather than
 rediscovering it. MSBench chooses that path, not us, so this is a hazard to
 recognise rather than one we can configure away.
+
+## Port squatters
+
+A process that is not the project under test, holding a port the probe depends
+on, is a **harness fault** — and one that would otherwise be reported as a
+product failure with no sign of anything wrong:
+
+- something on the **trigger port** serves the request instead of the app, so
+  the breakpoint is never reached ⇒ `breakpointNotHit`, exit 1
+- something on the **inspector port** stops node starting at all ⇒
+  `appFailedToStart`, exit 1
+
+Both are wrong, and both look completely ordinary. The probe therefore checks
+both ports *before* launching and returns `probeError` if either is taken —
+afterwards a squatter is indistinguishable from a broken project.
+
+The check **connects** rather than binds. A bind test against `127.0.0.1`
+reports a port free while a squatter holds `0.0.0.0` on macOS, which is exactly
+how a stranger's process gets mistaken for the application. `certify.ts` proves
+this with `mutation-port-squatted`, which holds `0.0.0.0:7071` from a separate
+process and requires exit 3.
+
+The inspector port matters more than it looks: `reference-node-fullstack` pins
+`--inspect=9229`, and a pinned inspector port collides across concurrent runs
+and survives a crashed earlier session. The probe cannot remap it — VS Code
+reads `launch.json` directly and is only handed a configuration *name* — so
+detecting and declining is the only honest option. Certification runs its cases
+strictly sequentially for the same reason. A stack template emitting a hardcoded
+inspector port should be fixed at the source rather than worked around here.

--- a/evals/debug-probe/certify.ts
+++ b/evals/debug-probe/certify.ts
@@ -380,12 +380,24 @@ function runLiveTier(vscodeBinary: string, only?: string): CaseResult[] {
 
             // Squat from a separate process; spawnSync below blocks our event loop,
             // so an in-process server would never accept the probe's connection.
+            //
+            // `detached: false` keeps it in our process group, but that alone does
+            // not save us: if the suite is interrupted (Ctrl-C, a killed shell) the
+            // `finally` never runs and the squatter outlives us, holding 7071. Every
+            // later run then fails its port preflight — the suite poisons itself,
+            // and the symptom looks like a broken gate rather than a stale process.
+            // So it is also killed on the way out under any signal.
             let squatter: ReturnType<typeof spawn> | undefined;
+            let killSquatter = (): void => { };
             if (testCase.squatPort !== undefined) {
                 squatter = spawn(process.execPath, [
                     '-e',
                     `require('node:net').createServer(s => s.end()).listen(${testCase.squatPort}, '0.0.0.0', () => setTimeout(() => {}, 1e9))`,
                 ], { stdio: 'ignore', detached: false });
+                killSquatter = () => { try { squatter?.kill('SIGKILL'); } catch { /* already gone */ } };
+                for (const signal of ['exit', 'SIGINT', 'SIGTERM'] as const) {
+                    process.once(signal, killSquatter);
+                }
                 spawnSync(process.execPath, ['-e', 'setTimeout(()=>{},1500)']);
             }
 
@@ -455,7 +467,10 @@ function runLiveTier(vscodeBinary: string, only?: string): CaseResult[] {
                     : `expected outcome=${testCase.expectedOutcome} exit=${testCase.expectedExit}, got outcome=${outcome} exit=${code}. Grader said: ${stderr.split('\n')[0] ?? '(nothing)'}`,
             });
             } finally {
-                squatter?.kill();
+                killSquatter();
+                for (const signal of ['exit', 'SIGINT', 'SIGTERM'] as const) {
+                    process.removeListener(signal, killSquatter);
+                }
             }
         }
         return results;

--- a/evals/debug-probe/certify.ts
+++ b/evals/debug-probe/certify.ts
@@ -319,6 +319,25 @@ const LIVE_CASES: LiveCase[] = [
         expectedOutcome: 'probeError',
         expectedExit: EXIT_GRADER_ERROR,
     },
+    {
+        id: 'mutation-debug-adapter-missing',
+        // The project-builds shape, in this gate. A launch config naming an
+        // adapter this environment does not install is CORRECT — it would work
+        // on a developer machine with that extension. Only the harness cannot
+        // execute it. Before the preflight, startDebugging simply never resolved
+        // and the verdict was appFailedToStart: exit 1, blaming the product for a
+        // project it built properly.
+        description: 'a debug adapter this environment lacks is an environment gap, not a product failure',
+        spec: { ...KNOWN_GOOD_SPEC, timeoutMs: 45_000 },
+        expectedOutcome: 'probeError',
+        expectedExit: EXIT_GRADER_ERROR,
+        mutate: workspace => {
+            const launchPath = join(workspace, '.vscode', 'launch.json');
+            const launch = JSON.parse(readFileSync(launchPath, 'utf8')) as { configurations: { type?: string }[] };
+            launch.configurations[0].type = 'debugpy';
+            writeFileSync(launchPath, `${JSON.stringify(launch, null, 4)}\n`, 'utf8');
+        },
+    },
 ];
 
 function runLiveTier(vscodeBinary: string, only?: string): CaseResult[] {

--- a/evals/debug-probe/certify.ts
+++ b/evals/debug-probe/certify.ts
@@ -28,7 +28,7 @@
  *   node certify.ts --vscode=/path/to/code
  */
 
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -246,6 +246,12 @@ interface LiveCase {
     expectedExit: number;
     /** Applied to the staged copy of the fixture before VS Code runs. */
     mutate?: (workspace: string) => void;
+    /**
+     * Occupy this port from a separate process for the duration of the case.
+     * Separate because `spawnSync` blocks this process's event loop, so an
+     * in-process listener would never accept a connection.
+     */
+    squatPort?: number;
 }
 
 const LIVE_CASES: LiveCase[] = [
@@ -297,6 +303,18 @@ const LIVE_CASES: LiveCase[] = [
         expectedOutcome: 'patternMatchedNothing',
         expectedExit: EXIT_GRADER_ERROR,
     },
+    {
+        id: 'mutation-port-squatted',
+        // A stranger holding the app port would otherwise serve the trigger, the
+        // breakpoint would never be hit, and a perfectly good project would be
+        // failed for it. Binds 0.0.0.0 specifically: a bind-based free-port check
+        // against 127.0.0.1 calls that port free on macOS.
+        description: 'a stranger on the app port is a harness fault, never a product failure',
+        spec: { ...KNOWN_GOOD_SPEC, timeoutMs: 45_000 },
+        squatPort: 7071,
+        expectedOutcome: 'probeError',
+        expectedExit: EXIT_GRADER_ERROR,
+    },
 ];
 
 function runLiveTier(vscodeBinary: string, only?: string): CaseResult[] {
@@ -317,6 +335,18 @@ function runLiveTier(vscodeBinary: string, only?: string): CaseResult[] {
             testCase.mutate?.(workspace);
             writeFileSync(join(workspace, 'debug-probe.json'), `${JSON.stringify(testCase.spec, null, 2)}\n`, 'utf8');
 
+            // Squat from a separate process; spawnSync below blocks our event loop,
+            // so an in-process server would never accept the probe's connection.
+            let squatter: ReturnType<typeof spawn> | undefined;
+            if (testCase.squatPort !== undefined) {
+                squatter = spawn(process.execPath, [
+                    '-e',
+                    `require('node:net').createServer(s => s.end()).listen(${testCase.squatPort}, '0.0.0.0', () => setTimeout(() => {}, 1e9))`,
+                ], { stdio: 'ignore', detached: false });
+                spawnSync(process.execPath, ['-e', 'setTimeout(()=>{},1500)']);
+            }
+
+            try {
             process.stderr.write(`  running ${testCase.id} in real VS Code…\n`);
             // Hard wall clock per case. A hung VS Code must fail its own case, not
             // stall the whole certification the way it would stall an MSBench run.
@@ -381,6 +411,9 @@ function runLiveTier(vscodeBinary: string, only?: string): CaseResult[] {
                     ? `outcome=${outcome}, exit ${code} — ${testCase.description}`
                     : `expected outcome=${testCase.expectedOutcome} exit=${testCase.expectedExit}, got outcome=${outcome} exit=${code}. Grader said: ${stderr.split('\n')[0] ?? '(nothing)'}`,
             });
+            } finally {
+                squatter?.kill();
+            }
         }
         return results;
     } finally {

--- a/evals/debug-probe/certify.ts
+++ b/evals/debug-probe/certify.ts
@@ -26,6 +26,10 @@
  *   node certify.ts --offline           offline only (CI default)
  *   node certify.ts --live              live only
  *   node certify.ts --vscode=/path/to/code
+ *
+ * The live tier runs its cases STRICTLY SEQUENTIALLY and must keep doing so —
+ * they contend for two ports the fixture hardcodes and the probe cannot remap.
+ * See the comment on the loop in `runLiveTier` before trying to speed this up.
  */
 
 import { spawn, spawnSync } from 'node:child_process';
@@ -328,6 +332,26 @@ function runLiveTier(vscodeBinary: string, only?: string): CaseResult[] {
     const results: CaseResult[] = [];
     const cases = only ? LIVE_CASES.filter(testCase => testCase.id === only) : LIVE_CASES;
     try {
+        // ─────────────────────────────────────────────────────────────────────────
+        // DO NOT PARALLELISE THIS LOOP.
+        //
+        // Not a style preference and not laziness — the cases contend for two
+        // FIXED ports and would corrupt each other's verdicts:
+        //
+        //   7071  the fixture's app port, pinned by `env.PORT` in its launch.json
+        //   9229  the inspector port, pinned by `runtimeArgs: ["--inspect=9229"]`
+        //
+        // Neither can be remapped from here. VS Code reads `launch.json` directly
+        // and is handed only a configuration *name*, so the probe cannot rewrite
+        // the ports the way a harness that spawns the process itself could.
+        //
+        // Run two cases at once and the second one's probe finds a port held by
+        // the first one's app. The port guard turns that into `probeError`, so it
+        // fails loudly rather than silently — but every case after the first
+        // would fail that way, and the suite would look broken instead of
+        // parallel. Speeding this up means fixing the hardcoded ports in the
+        // fixture first, not removing the sequencing here.
+        // ─────────────────────────────────────────────────────────────────────────
         for (const [index, testCase] of cases.entries()) {
             const workspace = join(root, testCase.id);
             cpSync(FIXTURE, workspace, { recursive: true });

--- a/evals/debug-probe/extension/src/extension.ts
+++ b/evals/debug-probe/extension/src/extension.ts
@@ -53,12 +53,33 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     recorder.log(`activated; trusted=${vscode.workspace.isTrusted}; folder=${folder.uri.fsPath}`);
 
     const specUri = specLocation(folder);
+    if (await readJson(specUri) === undefined) {
+        // Not an error. In the container we cannot verify whether the config's
+        // `script:` preamble seeds the workspace before or after the extension
+        // host finishes starting, and guessing wrong would mean the probe reads
+        // nothing, idles, and reports no verdict — indistinguishable from never
+        // being installed at all. Watching costs nothing and removes the ordering
+        // dependency entirely.
+        recorder.log(`no ${SPEC_RELATIVE_PATH} yet — watching for it`);
+        breadcrumb(folder, `no ${SPEC_RELATIVE_PATH} at activation; watching`);
+        watchForSpec(folder, specUri, context, recorder);
+        return;
+    }
+    await start(folder, specUri, context, recorder);
+}
+
+/** Read the spec, run the probe, write the verdict. Never throws. */
+async function start(
+    folder: vscode.WorkspaceFolder,
+    specUri: vscode.Uri,
+    context: vscode.ExtensionContext,
+    recorder: Recorder,
+): Promise<void> {
     let spec: ProbeSpec | undefined;
     try {
         const raw = await readJson(specUri);
         if (raw === undefined) {
-            recorder.log(`no ${SPEC_RELATIVE_PATH} — probe idle`);
-            return;
+            throw new SpecError(`${specUri.fsPath} disappeared before it could be read`);
         }
         spec = parseProbeSpec(raw);
         const verdict = await runProbe({ folder, spec, subscriptions: context.subscriptions }, recorder);
@@ -85,6 +106,38 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 function specLocation(folder: vscode.WorkspaceFolder): vscode.Uri {
     const override = process.env[SPEC_PATH_ENV_VAR];
     return override ? vscode.Uri.file(override) : vscode.Uri.joinPath(folder.uri, SPEC_RELATIVE_PATH);
+}
+
+/**
+ * Wait for the spec to appear, then run exactly once.
+ *
+ * Guarded by `started` because a create and a change event can both fire for a
+ * single write, and running the probe twice would race two debug sessions
+ * against each other and produce a verdict for neither.
+ */
+function watchForSpec(
+    folder: vscode.WorkspaceFolder,
+    specUri: vscode.Uri,
+    context: vscode.ExtensionContext,
+    recorder: Recorder,
+): void {
+    const watcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(folder, SPEC_RELATIVE_PATH));
+    context.subscriptions.push(watcher);
+
+    let started = false;
+    const onAppeared = (uri: vscode.Uri): void => {
+        if (started) {
+            return;
+        }
+        started = true;
+        watcher.dispose();
+        recorder.log(`${SPEC_RELATIVE_PATH} appeared at ${uri.fsPath}`);
+        breadcrumb(folder, `${SPEC_RELATIVE_PATH} appeared; starting probe`);
+        void start(folder, specUri, context, recorder);
+    };
+    watcher.onDidCreate(onAppeared);
+    watcher.onDidChange(onAppeared);
 }
 
 async function readJson(uri: vscode.Uri): Promise<unknown | undefined> {

--- a/evals/debug-probe/extension/src/probe.ts
+++ b/evals/debug-probe/extension/src/probe.ts
@@ -280,6 +280,45 @@ async function findOccupiedPort(
     return undefined;
 }
 
+/**
+ * Is the debug adapter this configuration needs actually installed?
+ *
+ * Extensions declare the debug types they implement in
+ * `contributes.debuggers[].type`. js-debug ships with VS Code, so `pwa-node` and
+ * friends are always present; `debugpy`, `go`, `coreclr` and the rest are not
+ * unless something installed them.
+ *
+ * This is the difference between a product failure and an environment gap. A
+ * launch configuration naming an adapter we did not install is *correct* — it
+ * would work on a developer machine that has the extension. Only this harness
+ * cannot execute it. Without this check `startDebugging` simply never resolves,
+ * the probe hits its deadline, and the verdict is `appFailedToStart` — exit 1,
+ * blaming the product for a project it built correctly.
+ */
+function debugTypeIsInstalled(type: string): boolean {
+    for (const extension of vscode.extensions.all) {
+        const contributed = (extension.packageJSON as { contributes?: { debuggers?: { type?: string }[] } })?.contributes?.debuggers;
+        if (Array.isArray(contributed) && contributed.some(entry => entry.type === type)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/** Every debug type this environment can actually run, for the diagnostic. */
+function installedDebugTypes(): string[] {
+    const types = new Set<string>();
+    for (const extension of vscode.extensions.all) {
+        const contributed = (extension.packageJSON as { contributes?: { debuggers?: { type?: string }[] } })?.contributes?.debuggers;
+        for (const entry of contributed ?? []) {
+            if (typeof entry.type === 'string') {
+                types.add(entry.type);
+            }
+        }
+    }
+    return [...types].sort();
+}
+
 export async function runProbe(context: ProbeContext, recorder: Recorder): Promise<DebugProbeVerdict> {
     const { folder, spec } = context;
     const startedAt = Date.now();
@@ -371,9 +410,23 @@ export async function runProbe(context: ProbeContext, recorder: Recorder): Promi
         },
     }));
 
-    // ---- 4. Refuse to run if a port we depend on is already taken ----------------------
-    // Must happen BEFORE launch: afterwards a squatter is indistinguishable from
-    // a broken project, and gets blamed on the product.
+    // ---- 4. Refuse to run if this environment cannot execute the configuration --------
+    // Both checks below must happen BEFORE launch. Afterwards each failure is
+    // indistinguishable from a broken project and gets blamed on the product.
+    const debugType = typeof selected?.type === 'string' ? selected.type : undefined;
+    if (!debugType) {
+        return finish('launchConfigInvalid', `launch configuration "${spec.launchConfig}" declares no "type"`, { resolution });
+    }
+    if (!debugTypeIsInstalled(debugType)) {
+        // Environment gap, not a product defect: the configuration is probably
+        // correct and would work on a machine with that extension installed.
+        return finish('probeError',
+            `launch configuration "${spec.launchConfig}" needs debug adapter "${debugType}", which is not installed in this environment. `
+            + `The project may be perfectly debuggable elsewhere, so this says nothing about it. Installed types: ${installedDebugTypes().join(', ')}`,
+            { resolution });
+    }
+    recorder.log(`debug adapter "${debugType}" is installed`);
+
     const occupied = await findOccupiedPort(spec, selected, recorder);
     if (occupied) {
         return finish('probeError', occupied, { resolution, adapter });

--- a/evals/debug-probe/extension/src/probe.ts
+++ b/evals/debug-probe/extension/src/probe.ts
@@ -18,6 +18,7 @@
 
 import * as http from 'node:http';
 import * as https from 'node:https';
+import * as net from 'node:net';
 import * as vscode from 'vscode';
 import type {
     AdapterObservation,
@@ -192,6 +193,93 @@ async function readStack(session: vscode.DebugSession, threadId: number, recorde
     }
 }
 
+/**
+ * Is something already listening here?
+ *
+ * Tested by CONNECTING, not by binding. A bind test against `127.0.0.1` reports
+ * "free" while a squatter holds `0.0.0.0` on macOS, which is precisely how a
+ * stranger's process gets mistaken for the application under test.
+ *
+ * This matters more here than it looks. If an unrelated process holds the
+ * trigger port, the probe connects to *it*, the request never reaches our
+ * breakpoint, and the verdict is `breakpointNotHit` — a false product failure
+ * against a project that is perfectly fine. If something holds the inspector
+ * port, node cannot start at all and the verdict is `appFailedToStart`, equally
+ * misattributed. Both are harness conditions and must exit 3.
+ */
+function isPortOccupied(host: string, port: number): Promise<boolean> {
+    return new Promise(resolve => {
+        const socket = new net.Socket();
+        const finish = (occupied: boolean) => {
+            socket.destroy();
+            resolve(occupied);
+        };
+        socket.setTimeout(1_000);
+        socket.once('connect', () => finish(true));
+        socket.once('timeout', () => finish(false));
+        socket.once('error', () => finish(false));
+        socket.connect(port, host);
+    });
+}
+
+/** The inspector port a launch configuration pins, if it pins one. */
+function inspectorPortOf(configuration: Record<string, unknown> | undefined): number | undefined {
+    const runtimeArgs = configuration?.runtimeArgs;
+    if (!Array.isArray(runtimeArgs)) {
+        return undefined;
+    }
+    for (const arg of runtimeArgs) {
+        const match = /^--inspect(?:-brk)?=(?:.*:)?(\d+)$/.exec(String(arg));
+        if (match) {
+            return Number(match[1]);
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Refuse to run when a port we depend on is already taken.
+ *
+ * Returns a human-readable reason, or undefined when the coast is clear.
+ * Deliberately a *precondition* rather than a diagnosis after the fact: once the
+ * run has happened, a squatter is indistinguishable from a broken project.
+ */
+async function findOccupiedPort(
+    spec: ProbeSpec,
+    configuration: Record<string, unknown> | undefined,
+    recorder: Recorder,
+): Promise<string | undefined> {
+    const checks: { label: string; host: string; port: number }[] = [];
+
+    if (spec.trigger) {
+        try {
+            const url = new URL(spec.trigger.url);
+            const port = Number(url.port || (url.protocol === 'https:' ? 443 : 80));
+            checks.push({ label: 'trigger', host: url.hostname, port });
+        } catch {
+            return `trigger.url is not a valid URL: ${spec.trigger.url}`;
+        }
+    }
+
+    const inspectorPort = inspectorPortOf(configuration);
+    if (inspectorPort !== undefined) {
+        // A fixed inspector port in a launch config collides across concurrent
+        // runs and survives a crashed earlier session. We cannot remap it —
+        // VS Code reads launch.json directly and we only pass a config name — so
+        // the honest move is to detect it and decline.
+        checks.push({ label: 'inspector', host: '127.0.0.1', port: inspectorPort });
+    }
+
+    for (const check of checks) {
+        if (await isPortOccupied(check.host, check.port)) {
+            return `${check.label} port ${check.host}:${check.port} is already in use before launch. `
+                + `Something other than the project under test is listening, so any verdict here would be about that process, not the product.`;
+        }
+        recorder.log(`${check.label} port ${check.host}:${check.port} is free`);
+    }
+    return undefined;
+}
+
 export async function runProbe(context: ProbeContext, recorder: Recorder): Promise<DebugProbeVerdict> {
     const { folder, spec } = context;
     const startedAt = Date.now();
@@ -213,7 +301,7 @@ export async function runProbe(context: ProbeContext, recorder: Recorder): Promi
     // getConfiguration parses launch.json for us, comments and trailing commas included.
     const configurations = vscode.workspace
         .getConfiguration('launch', folder.uri)
-        .get<{ name?: string }[]>('configurations') ?? [];
+        .get<Record<string, unknown>[]>('configurations') ?? [];
     const names = configurations.map(configuration => configuration.name).filter((name): name is string => typeof name === 'string');
     recorder.log(`launch configurations: ${JSON.stringify(names)}`);
 
@@ -223,6 +311,7 @@ export async function runProbe(context: ProbeContext, recorder: Recorder): Promi
     if (!names.includes(spec.launchConfig)) {
         return finish('launchConfigInvalid', `no launch configuration named "${spec.launchConfig}"; found: ${names.join(', ') || '(none named)'}`);
     }
+    const selected = configurations.find(configuration => configuration.name === spec.launchConfig);
 
     // ---- 2. Place the breakpoint by pattern -------------------------------------------
     const resolution = await resolveBreakpoint(folder, spec, recorder);
@@ -282,7 +371,15 @@ export async function runProbe(context: ProbeContext, recorder: Recorder): Promi
         },
     }));
 
-    // ---- 4. Launch ---------------------------------------------------------------------
+    // ---- 4. Refuse to run if a port we depend on is already taken ----------------------
+    // Must happen BEFORE launch: afterwards a squatter is indistinguishable from
+    // a broken project, and gets blamed on the product.
+    const occupied = await findOccupiedPort(spec, selected, recorder);
+    if (occupied) {
+        return finish('probeError', occupied, { resolution, adapter });
+    }
+
+    // ---- 5. Launch ---------------------------------------------------------------------
     // `true` means "launch was initiated", NOT "the debuggee is running", so it can
     // only rule out a failure, never confirm success.
     //
@@ -306,7 +403,7 @@ export async function runProbe(context: ProbeContext, recorder: Recorder): Promi
         return finish('appFailedToStart', `startDebugging("${spec.launchConfig}") returned false`, { resolution, adapter });
     }
 
-    // ---- 5. Drive execution to the breakpoint -------------------------------------------
+    // ---- 6. Drive execution to the breakpoint -------------------------------------------
     // Runs until something stops, the debuggee dies, or the budget expires.
     if (spec.trigger) {
         adapter.triggerConnected = await driveTrigger(
@@ -316,7 +413,7 @@ export async function runProbe(context: ProbeContext, recorder: Recorder): Promi
             recorder);
     }
 
-    // ---- 6. Wait for a stop, a termination, or the deadline ------------------------------
+    // ---- 7. Wait for a stop, a termination, or the deadline ------------------------------
     const raced = await Promise.race([
         stoppedSignal.promise.then(value => ({ kind: 'stopped' as const, ...value })),
         terminatedSignal.promise.then(detail => ({ kind: 'terminated' as const, detail })),
@@ -349,7 +446,7 @@ export async function runProbe(context: ProbeContext, recorder: Recorder): Promi
         });
     }
 
-    // ---- 7. Capture the evidence --------------------------------------------------------
+    // ---- 8. Capture the evidence --------------------------------------------------------
     const stopped: StoppedObservation = { reason: 'breakpoint', ...(await readStack(raced.session, raced.threadId, recorder)) };
     await stopDebugging(recorder);
     return finish('hit', `breakpoint hit at ${resolution.match.file}:${resolution.match.line}`, { resolution, adapter, stopped });

--- a/evals/debug-probe/extension/src/probe.ts
+++ b/evals/debug-probe/extension/src/probe.ts
@@ -111,15 +111,22 @@ export async function resolveBreakpoint(
 }
 
 /**
- * Fire the trigger until something accepts a connection.
+ * Keep firing the trigger until execution actually stops.
  *
  * WHY "connected" rather than "responded": on a healthy run the breakpoint stops
  * the process mid-request, so the HTTP response never arrives. Awaiting the
  * response would time out against a perfectly working app and be reported as
- * `appFailedToStart`. Connection established is the only honest signal, and we
- * stop early the moment the debuggee actually stops.
+ * `appFailedToStart`. Connection established is the only honest signal.
+ *
+ * WHY it keeps going after the first connection: the app can be listening before
+ * js-debug has bound the breakpoint, in which case the first request sails
+ * straight through and nothing would ever hit the breakpoint again. Stopping at
+ * first connect makes the gate intermittently red against a working project —
+ * a false product failure, and the worst kind because it looks like a real one.
+ * So we keep driving requests until something stops, and only the deadline ends
+ * the loop.
  */
-async function triggerUntilConnected(
+async function driveTrigger(
     url: string,
     deadline: number,
     stopped: () => boolean,
@@ -127,6 +134,7 @@ async function triggerUntilConnected(
 ): Promise<boolean> {
     const request = url.startsWith('https:') ? https.get : http.get;
     let attempts = 0;
+    let everConnected = false;
     while (Date.now() < deadline && !stopped()) {
         attempts++;
         const connected = await new Promise<boolean>(resolve => {
@@ -135,16 +143,21 @@ async function triggerUntilConnected(
             const clientRequest = request(url, () => finish(true));
             clientRequest.on('socket', socket => socket.on('connect', () => finish(true)));
             clientRequest.on('error', () => finish(false));
-            setTimeout(() => { clientRequest.destroy(); finish(false); }, TRIGGER_ATTEMPT_TIMEOUT_MS);
+            // Do not destroy the request on timeout: once we are past the first
+            // connection it may be parked on the breakpoint, and tearing it down
+            // would resume the debuggee before the stack can be read.
+            setTimeout(() => finish(false), TRIGGER_ATTEMPT_TIMEOUT_MS);
         });
-        if (connected) {
+        if (connected && !everConnected) {
+            everConnected = true;
             recorder.log(`trigger connected after ${attempts} attempt(s)`);
-            return true;
         }
         await delay(TRIGGER_RETRY_DELAY_MS);
     }
-    recorder.log(`trigger never connected after ${attempts} attempt(s)`);
-    return false;
+    if (!everConnected) {
+        recorder.log(`trigger never connected after ${attempts} attempt(s)`);
+    }
+    return everConnected;
 }
 
 /** Read the top frame and its locals. Evidence that the stop was real, not just an event. */
@@ -294,8 +307,13 @@ export async function runProbe(context: ProbeContext, recorder: Recorder): Promi
     }
 
     // ---- 5. Drive execution to the breakpoint -------------------------------------------
+    // Runs until something stops, the debuggee dies, or the budget expires.
     if (spec.trigger) {
-        adapter.triggerConnected = await triggerUntilConnected(spec.trigger.url, deadline, stoppedSignal.settled, recorder);
+        adapter.triggerConnected = await driveTrigger(
+            spec.trigger.url,
+            deadline,
+            () => stoppedSignal.settled() || terminatedSignal.settled(),
+            recorder);
     }
 
     // ---- 6. Wait for a stop, a termination, or the deadline ------------------------------

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -34,6 +34,8 @@ they are wired directly against the graders merged in #1707.
 | `scaffold-unapproved-plan` | scaffold | 1 | 6 | `unapproved-plan` | — |
 | `debug-plan-approval-gate` | local-dev | 2 | 8 | `approved-fullstack` | — |
 | `debug-generate-artifacts` | local-dev | 4 | 12 | `approved-fullstack` | `--assert-status=Implemented --assert-checklist` |
+| `debug-probe-smoke` | probe-smoke | 1 | 2 | — | — (infrastructure only, see below) |
+| `debug-breakpoint-node` | debug-breakpoint | 1 | 3 | — | — (infrastructure only, see below) |
 
 The six scaffold and local-dev stimuli also each carry a `preConditions` `exec:`
 (except `scaffold-missing-plan`, which seeds nothing), which is not counted above
@@ -477,7 +479,7 @@ second checked-in copy is exactly the drift this eval exists to catch:
 
 | Path | Built by | From |
 | --- | --- | --- |
-| `assets/extensions/*.vsix` | `run.sh` | `npm run build && npm run package` |
+| `assets/extensions/*.vsix` | `run.sh` | `npm run build && npm run package`, plus `evals/debug-probe/extension` |
 | `assets/graders/**` | `stage-graders.ts` | `evals/graders`, `evals/src`, `src/webviews` |
 | `assets/user-overrides.yaml` | `build-config.ts` | `config/base.yaml` + `config/phases/<phase>.yaml` + `config/stimuli/<name>.yaml` |
 | `assets/workspace/**` | `stage-workspace.ts` | the stimulus's `# seed:` directive |
@@ -945,6 +947,39 @@ sqlite3 session.sqlite "SELECT output FROM exec WHERE command LIKE '%uname%'"
 sqlite3 session.sqlite "SELECT exitCode, stdErr FROM exec WHERE command LIKE '%validate-%'"
 ```
 
+
+## The second extension: the debug probe
+
+`installExtensions` **concatenates across config layers rather than replacing**, which
+is what lets our VSIX ride alongside `github.copilot-chat`. [`evals/debug-probe`](../debug-probe)
+is the second user of that behaviour: a test-only extension, built and staged by
+`run.sh` next to the product VSIX, that drives a generated project to a breakpoint so a
+gate can assert **F5 actually works** rather than that `launch.json` merely parses.
+
+It is **inert unless the workspace contains `debug-probe.json`**, so it installs on
+every run and stimuli opt in. `run.sh` checks the packaged VSIX contains
+`out/extension.js`, because a probe packaged without compiling looks valid and then
+fails to activate — which from outside the container is indistinguishable from never
+having been installed.
+
+That extension is the one thing in this tree with a **build step**. Graders run
+straight off `.ts` via Node's type stripping; the VS Code extension host cannot strip
+types, so the probe compiles to JavaScript.
+
+`debug-probe-smoke` is the smallest run that answers the only question this design
+could not settle locally — does a second extension install and activate at all. It uses
+the `probe-smoke` phase, which sets no `chatMode` and seeds no agent, so the agent does
+essentially nothing: the evidence is written by the extension host during workspace
+setup, before the first turn. Two assertions, one of which is the liveness sentinel.
+
+### A hazard worth recognising: `--user-data-dir` length
+
+VS Code binds a Unix domain socket inside its `--user-data-dir`, and `sun_path` caps at
+~104 bytes. Exceed it and VS Code starts, opens **no window**, writes **zero** log
+lines, and hangs until something kills it — a failure mode indistinguishable from a
+broken extension, and one that cost a day to diagnose locally. MSBench chooses that
+path rather than this config, so there is nothing to set here; this is written down so
+the next person recognises the symptom instead of suspecting their extension.
 
 ## Why the VSIX route
 

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -911,6 +911,34 @@ assertion is worth confirming against `stdErr` before believing it.
 re-runs the grader locally and reports exit 1 and exit 3 separately, so confirming a red
 `exec:` no longer means reading `stdErr` by hand.
 
+### What the `files` table can and cannot see
+
+**A `files`-table assertion can only ever see what the *agent* wrote through the tracked
+channel during a step. Anything written by an extension, by the `script:` preamble, or by
+the container itself is invisible to it.**
+
+It is not a filesystem listing. The schema is `(path, content, stepIndex)` — tracked file
+*contents*, per step — and the harness appends `AND stepIndex = :stepIndex` on top of
+whatever you write.
+
+This is easy to get wrong because the table is *non-empty* on a healthy run and therefore
+looks alive. Run [`2026082620311350`](https://msbenchapp.azurewebsites.net/run-analysis/2026082620311350)
+asserted `SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.eval/probe.log'` against a file
+an extension had demonstrably written — the run's own fingerprint printed its contents —
+and the assertion could never have passed. The whole table was:
+
+```
+0|.gitkeep
+0|.gitignore
+```
+
+The trap is not that the check was careless; it is that **the abstraction lies at the point
+of use.** `files` reads like `find`, and it is not.
+
+Use `exec:` for anything not authored by the agent — `test -f .eval/probe.log` — with a
+relative path, since `exec:` runs with cwd set to the workspace and the runner uses a
+worktree path rather than `/workspace` on some routes.
+
 ### Which assertions are `exec:` and which stay SQL
 
 Only the `program` graders. The `files`, `toolCalls` and `llm_responses` tables cover
@@ -1141,6 +1169,27 @@ whole reason the values are written down here.
 
 We were opted out by omission until [#1707](https://github.com/microsoft/vscode-azureresourcegroups/pull/1707):
 `run.sh` set no endpoint tag at all.
+
+### One observation, not a property
+
+The only direct measurement we have of the queue actually holding a run:
+
+| | |
+| --- | --- |
+| `scaffold-fullstack` completed | 22:50:28 |
+| `debug-probe-smoke` submitted | 22:38:28 (accepted by CES immediately) |
+| `debug-probe-smoke` dispatched | **22:51:03** — 35s after the run ahead of it finished |
+
+Both carried the correct key on both halves, confirmed from the run's own recorded
+`tags` (`endpoint: copilot-on-rails`) and `model_source: agent_assets`
+(`claude-sonnet-4.5`) rather than from the command line.
+
+Twelve and a half minutes accepted-but-undispatched, ending 35 seconds after an
+unrelated run completed, is a striking fit for serialisation. **It is not proof of it.**
+An ordinary dispatch latency that happens to end just after an unrelated completion is
+not excluded by a single observation, and n=1 cannot distinguish the two. Recorded here
+with timestamps so it is not re-derived from memory; if the property is ever load
+bearing it deserves a deliberate two-run test rather than inference from this.
 
 ### Why the model half needs no flag
 

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -1191,6 +1191,20 @@ not excluded by a single observation, and n=1 cannot distinguish the two. Record
 with timestamps so it is not re-derived from memory; if the property is ever load
 bearing it deserves a deliberate two-run test rather than inference from this.
 
+#### Retracted: this is no evidence either way
+
+Five repeats of `debug-breakpoint-node` measured dispatch latency directly, and it
+varies by roughly **7×** — runs started at 23:40, 23:46, 23:50 and 00:24 all did the
+same seven seconds of work, with one sitting ~33 minutes against others at ~5.
+
+Against that spread, a 12.5-minute wait ending 35 seconds after an unrelated completion
+is unremarkable. The "striking fit" was reading signal out of a distribution wide enough
+to produce that coincidence routinely, so the observation above is downgraded from
+*striking but unproven* to **no evidence either way**. It is left in place rather than
+deleted, because the reasoning is the useful part: elapsed time tells you almost nothing
+here, and any future claim about queueing needs a deliberate test rather than inference
+from timestamps.
+
 ### Why the model half needs no flag
 
 `--model .` is `ASSET_MODEL_SENTINEL`. It does **not** mean "no model" — it tells the
@@ -2025,6 +2039,22 @@ with a clear message:
   timestamp on every invocation, so running the credential-free gates locally leaves an
   unrelated one-line change staged into whatever you commit next. It has reached review on
   several PRs. `git checkout -- evals/results/` before committing.
+
+- **A `400 BadRequest` from CES at submission time is probably transient — retry before
+  changing anything.** Seen once in five back-to-back submissions, on a run submitted
+  within a second of the previous one completing:
+
+  ```
+  requests.exceptions.HTTPError: 400 Client Error: Bad Request for url:
+  https://ces-dev1.azurewebsites.net/api/ces/benchmark/startRun?smoke_mode=none&bypassProxy=false
+  Response body: 400.0 BadRequest
+  ```
+
+  The next submission, 13 seconds later with a byte-identical config, succeeded. No
+  tokens are spent and no run is created, so the only cost is the confusion. The trap is
+  that `400` reads as *"your config is malformed"*, which invites editing a config that
+  was fine — and the edit then gets credited with the fix when the retry was what worked.
+  Leave a few seconds between submissions and retry once before believing it.
 
 - **A red run that is actually rate limiting.** Back-to-back runs get throttled by the
   Copilot API mid-run. The agent then produces nothing, so artifact assertions fail

--- a/evals/msbench/config/base.yaml
+++ b/evals/msbench/config/base.yaml
@@ -76,6 +76,17 @@ installExtensions:
     # Container path. Everything under ./assets is copied to /agent/assets, and
     # unlike a benchmark config this path is NOT rewritten, so it is hardcoded.
     path: /agent/assets/extensions/vscode-azureresourcegroups.vsix
+  # The debug probe (evals/debug-probe). Test-only, never shipped to users: it
+  # drives the generated project to a breakpoint so a gate can assert that F5
+  # actually works, rather than that launch.json merely parses.
+  #
+  # This second entry is the whole reason `installExtensions` concatenating
+  # across layers matters. It is inert unless the workspace contains a
+  # `debug-probe.json`, so it is safe on every run — a stimulus opts in by
+  # writing that file, and every other stimulus is unaffected.
+  - id: ms-azuretools.cor-debug-probe
+    mode: vsix
+    path: /agent/assets/extensions/cor-debug-probe.vsix
 
 # The Vally executor approves every permission request. Without this the
 # webview-opening tools block on a confirmation nothing can answer.

--- a/evals/msbench/config/phases/debug-breakpoint.yaml
+++ b/evals/msbench/config/phases/debug-breakpoint.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/vscode-copilot-evaluation/main/doc/references/TestConfig.schema.json
+
+# Phase: `debug-breakpoint` — infrastructure only, like `probe-smoke`.
+#
+# Seeds a project that is KNOWN to be debuggable and points the probe at it.
+# The agent does nothing; the product is not under test here.
+#
+# That separation is the whole design. "Can a debugger reach a breakpoint inside
+# this container?" and "did the agent write a debuggable project this time?" are
+# different questions, and a run that mixes them cannot answer either: a red
+# would not say whether the container cannot host a debugger or the generated
+# code was bad. This phase answers the first. Only once it is green does putting
+# the probe behind real generated output mean anything.
+#
+# The fixture is `evals/grader-certification/reference-node-fullstack`, staged by
+# run.sh — the same one `evals/debug-probe/certify.ts` runs against locally, so a
+# green run here and a green certification are the same claim in two places.
+#
+# NOTE: `exitWhenDone` is deliberately absent from the spec below. It defaults to
+# false, and it must stay false: the probe quitting VS Code mid-run would take
+# the eval down with it. It is set only by the local certification runner.
+
+script: |
+  set -eux
+  cp -R /agent/assets/fixtures/reference-node-fullstack/. /workspace/
+  # Written AFTER the project is in place. The probe watches for this file rather
+  # than reading it once at activation, so it does not matter whether the
+  # extension host finished starting before this script ran — an ordering we
+  # cannot observe from outside the container, and one that already bit us:
+  # in run 2026082620311350 the probe activated to an empty workspace.
+  cat > /workspace/debug-probe.json <<'JSON'
+  {
+    "launchConfig": "Golden App (debug)",
+    "breakpoint": { "glob": "src/**/*.js", "pattern": "status:\\s*'ok'" },
+    "trigger": { "url": "http://127.0.0.1:7071/api/health" },
+    "timeoutMs": 180000
+  }
+  JSON
+  ls -la /workspace
+  cat /workspace/debug-probe.json

--- a/evals/msbench/config/phases/probe-smoke.yaml
+++ b/evals/msbench/config/phases/probe-smoke.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/vscode-copilot-evaluation/main/doc/references/TestConfig.schema.json
+
+# Phase: `probe-smoke` — infrastructure only. The product is not under test.
+#
+# Every other phase drives the product through one of its stages. This one
+# deliberately drives nothing: it exists so a run can answer a question about the
+# *harness* without paying for a product run to do it.
+#
+# Two things follow from that, and both are deliberate:
+#
+#   No `chatMode`. The stimulus must not load `azure-project-plan`, because that
+#   agent would start doing real work — asking requirements questions, writing
+#   artifacts — and turn a near-free infrastructure check into a full-price
+#   product run whose result answers a different question.
+#
+#   No agent seeding. The `plan` phase unpacks resources/agents out of the VSIX
+#   so the custom mode resolves. Nothing here needs it.
+#
+# The question this phase serves is answered *before the first turn*: the probe
+# extension activates on `onStartupFinished`, which happens during workspace
+# setup. By the time the agent says anything, the evidence already exists on
+# disk. The prompt is therefore a formality, not the experiment.
+
+script: |
+  set -eux
+  # Inventory what was actually staged into the container. If the probe VSIX is
+  # missing here, the run's real finding is a `run.sh` staging bug rather than
+  # anything about installExtensions, and these two lines are the difference
+  # between knowing that and guessing.
+  ls -la /agent/assets/extensions/ || true
+  ls -la /workspace || true

--- a/evals/msbench/config/stimuli/debug-breakpoint-node.yaml
+++ b/evals/msbench/config/stimuli/debug-breakpoint-node.yaml
@@ -1,0 +1,70 @@
+# phase: debug-breakpoint
+#
+# Stimulus `debug-breakpoint-node` — the run that answers the remaining question:
+#
+#   Can a debugger actually reach a breakpoint inside the MSBench container?
+#
+# Everything about this gate has been proven locally (17/17 certification, real
+# VS Code, real js-debug) and the *installation* half has been proven in-container
+# by run 2026082620311350. What has never been observed is js-debug launching a
+# process, binding a breakpoint and stopping on it under this container's
+# constraints — Ubuntu 22.04, root, xvfb, no display of its own.
+#
+# WHY THE FIXTURE AND NOT GENERATED CODE
+#
+# The project is a known-debuggable fixture, staged by run.sh, not something the
+# agent wrote. That is deliberate: a red against generated code cannot tell you
+# whether the container cannot host a debugger or the agent produced a bad
+# project, and those have nothing to do with each other. This run isolates the
+# harness question. Putting the probe behind real generated output is worth doing
+# only after this is green — at which point a red genuinely does mean the product
+# produced something you cannot debug, which is the gate we actually want.
+#
+# WHAT EACH OUTCOME WOULD MEAN
+#
+#   exit 0   a breakpoint was hit in a container. The gate is viable end to end.
+#   exit 1   the probe ran and rendered a product verdict against a fixture we
+#            KNOW is good — so a red here is a container finding, not a product
+#            one, and the verdict's outcome field says which of launchConfig /
+#            appFailedToStart / breakpointNotHit it was.
+#   exit 3   the probe could not run. Harness fault; read the fingerprint.
+#
+# That third column is why the verdict discriminates six outcomes rather than
+# two: against a known-good fixture, `breakpointNotHit` and `appFailedToStart`
+# are diagnoses of the container, and they are different diagnoses.
+
+promptSteps:
+  - text: |
+      Reply with exactly the word: ready
+
+      Do not create, modify or read any files. Do not call any tools.
+    assertions:
+      # Liveness sentinel — must come first, and every stimulus needs one.
+      - comment: Sentinel; session data must exist or the checks below are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      # Folded in from `debug-probe-smoke` rather than spending a run of its own:
+      # installation is already settled by 2026082620311350, so if this fails now
+      # it is unambiguously the assertion or the write, not installation.
+      #
+      # `exec:` runs with cwd set to the workspace, so this stays relative — the
+      # runner uses a worktree path rather than /workspace on some routes.
+      - comment: The probe extension installed and activated
+        exec: test -f .eval/probe.log
+
+      # THE question. The grader maps the probe's verdict onto the exit-code
+      # contract: 0 hit, 1 product-shaped failure, 3 harness fault. Note that
+      # against a KNOWN-GOOD fixture a "product-shaped" failure is really a
+      # container finding — see the header.
+      - comment: A breakpoint is hit in the debuggable fixture
+        exec: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-debug-breakpoint.ts
+
+      # Non-asserting, so it can never fail the run or change the assertion
+      # count. Read this FIRST when anything above is red. The verdict carries
+      # the timeline, the adapter's setBreakpoints responses, the debuggee's
+      # stdout/stderr and the resolved breakpoint location — which is the
+      # difference between "the debugger does not work in a container" and a
+      # specific, fixable reason it did not.
+      - comment: Fingerprint; probe breadcrumb and full debug verdict
+        assertZeroExitCode: false
+        exec: 'echo "--- breadcrumb ---"; cat .eval/probe.log 2>&1 || echo "NO PROBE LOG"; echo "--- verdict ---"; cat .eval/debug-verdict.json 2>&1 || echo "NO VERDICT"; echo "--- node ---"; node --version 2>&1'

--- a/evals/msbench/config/stimuli/debug-breakpoint-node.yaml
+++ b/evals/msbench/config/stimuli/debug-breakpoint-node.yaml
@@ -40,7 +40,7 @@ promptSteps:
       Do not create, modify or read any files. Do not call any tools.
     assertions:
       # Liveness sentinel — must come first, and every stimulus needs one.
-      - comment: Sentinel; session data must exist or the checks below are vacuous
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
         query: SELECT COUNT(*) > 0 FROM llm_responses
 
       # Folded in from `debug-probe-smoke` rather than spending a run of its own:

--- a/evals/msbench/config/stimuli/debug-probe-smoke.yaml
+++ b/evals/msbench/config/stimuli/debug-probe-smoke.yaml
@@ -48,13 +48,21 @@ promptSteps:
       - comment: Sentinel; session data must exist or the checks below are vacuous
         query: SELECT COUNT(*) > 0 FROM llm_responses
 
-      # THE question. The probe writes `.eval/probe.log` as the first thing it
-      # does on activation, before it reads its spec or does anything that could
-      # fail, precisely so that "installed and activated" is observable on its
-      # own. With no `debug-probe.json` in the workspace the probe then idles, so
-      # this run exercises installation and activation and nothing else.
+      # THE question — ANSWERED YES by run 2026082620311350 (2026-08-25). Retained
+      # as a regression check, not as an open question.
+      #
+      # Asserted through `exec:` rather than the `files` table. The first version
+      # of this used `SELECT ... FROM files WHERE path LIKE '%.eval/probe.log'`
+      # and could never have passed: `files` holds tracked file *contents* scoped
+      # per step, not a filesystem listing, and the probe writes its breadcrumb
+      # from the extension host before the first turn. See the README section
+      # "What the `files` table can and cannot see".
+      #
+      # `exec:` runs with cwd set to the workspace, so this is relative rather
+      # than hardcoding /workspace — the runner uses a worktree path on some
+      # routes.
       - comment: The second extension installed and activated alongside our VSIX
-        query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.eval/probe.log'
+        exec: test -f .eval/probe.log
 
       # Non-asserting, exactly like the environment fingerprint the other
       # stimuli carry: `assertZeroExitCode: false` records output into the `exec`

--- a/evals/msbench/config/stimuli/debug-probe-smoke.yaml
+++ b/evals/msbench/config/stimuli/debug-probe-smoke.yaml
@@ -1,0 +1,68 @@
+# phase: probe-smoke
+#
+# Stimulus `debug-probe-smoke` — the cheapest run that can answer one question.
+#
+#   Does a SECOND extension install and activate alongside our product VSIX?
+#
+# That is the only claim in the debug-breakpoint gate's design that could not be
+# settled locally. `installExtensions` concatenates across config layers rather
+# than replacing — that is how our VSIX already rides alongside
+# `github.copilot-chat` — so a second `mode: vsix` entry *should* install
+# cleanly. "Should" is doing a lot of work in that sentence, and it is load
+# bearing for the whole gate, so it gets one small run of its own.
+#
+# WHY THIS IS DELIBERATELY TINY
+#
+# The agent does essentially nothing: one trivial prompt, no product agent, no
+# artifacts. The evidence this run collects is produced by the extension host
+# during workspace setup, before the first turn — so paying for a real product
+# run to obtain it would be paying for the wrong thing, and would couple the
+# answer to whether the agent happened to behave that day.
+#
+# The rule this follows: a run that tests infrastructure should be able to fail
+# for exactly one reason.
+#
+# WHAT WOULD MAKE THIS RUN RED, AND WHAT THAT WOULD MEAN
+#
+#   assertion 2 red   the probe never activated. Either the second VSIX did not
+#                     install (installExtensions does NOT concatenate the way we
+#                     believe), or it installed and failed to activate. The
+#                     non-asserting fingerprint below separates those two.
+#
+# Note there is no assertion here about a breakpoint being hit. That is the next
+# run, not this one, and it is gated on this one passing: asserting it now would
+# conflate "the probe is installed" with "the debugger works in a container",
+# and a red result would not say which.
+
+promptSteps:
+  - text: |
+      Reply with exactly the word: ready
+
+      Do not create, modify or read any files. Do not call any tools.
+    assertions:
+      # Liveness sentinel — must come first, and every stimulus needs one.
+      # A run that dies before the session database is populated would otherwise
+      # be indistinguishable from one that passed, because the check below is
+      # about a file the *extension host* wrote rather than anything the agent
+      # did — it would happily pass on a run where the agent never spoke.
+      - comment: Sentinel; session data must exist or the checks below are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      # THE question. The probe writes `.eval/probe.log` as the first thing it
+      # does on activation, before it reads its spec or does anything that could
+      # fail, precisely so that "installed and activated" is observable on its
+      # own. With no `debug-probe.json` in the workspace the probe then idles, so
+      # this run exercises installation and activation and nothing else.
+      - comment: The second extension installed and activated alongside our VSIX
+        query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.eval/probe.log'
+
+      # Non-asserting, exactly like the environment fingerprint the other
+      # stimuli carry: `assertZeroExitCode: false` records output into the `exec`
+      # table without generating a check, so it can never fail the run or change
+      # the assertion count. Read this FIRST when the assertion above is red —
+      # "the VSIX was never staged", "it was staged but did not install" and "it
+      # installed but did not activate" are indistinguishable from the outside
+      # and have completely different fixes.
+      - comment: Fingerprint; extension inventory and probe breadcrumb
+        assertZeroExitCode: false
+        exec: 'ls -la /agent/assets/extensions/ 2>&1; echo "--- installed ---"; ls -la ~/.vscode-server/extensions ~/.vscode/extensions 2>&1 | head -40; echo "--- breadcrumb ---"; cat /workspace/.eval/probe.log 2>&1 || echo "NO PROBE LOG"'

--- a/evals/msbench/config/stimuli/debug-probe-smoke.yaml
+++ b/evals/msbench/config/stimuli/debug-probe-smoke.yaml
@@ -45,7 +45,7 @@ promptSteps:
       # be indistinguishable from one that passed, because the check below is
       # about a file the *extension host* wrote rather than anything the agent
       # did — it would happily pass on a run where the agent never spoke.
-      - comment: Sentinel; session data must exist or the checks below are vacuous
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
         query: SELECT COUNT(*) > 0 FROM llm_responses
 
       # THE question — ANSWERED YES by run 2026082620311350 (2026-08-25). Retained
@@ -61,7 +61,7 @@ promptSteps:
       # `exec:` runs with cwd set to the workspace, so this is relative rather
       # than hardcoding /workspace — the runner uses a worktree path on some
       # routes.
-      - comment: The second extension installed and activated alongside our VSIX
+      - comment: The probe extension installed and activated
         exec: test -f .eval/probe.log
 
       # Non-asserting, exactly like the environment fingerprint the other

--- a/evals/msbench/run.sh
+++ b/evals/msbench/run.sh
@@ -45,6 +45,9 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${HERE}/../.." && pwd)"
 ASSETS="${HERE}/assets"
 VSIX_DEST="${ASSETS}/extensions/vscode-azureresourcegroups.vsix"
+# The test-only debug probe extension, built from source alongside the product.
+PROBE_SRC="${REPO_ROOT}/evals/debug-probe/extension"
+PROBE_DEST="${ASSETS}/extensions/cor-debug-probe.vsix"
 
 # Borrowed purely for its container image; user-overrides.yaml replaces its
 # prompt and assertions wholesale. Swapping this for a heavier instance is how
@@ -144,6 +147,41 @@ case "$VSIX_LISTING" in
 esac
 
 log "Staged $(basename "$BUILT_VSIX" 2>/dev/null || basename "$VSIX_DEST") ($(du -h "$VSIX_DEST" | cut -f1))"
+
+# --- build + stage the debug probe -------------------------------------------
+#
+# A second, test-only extension (evals/debug-probe) that rides alongside the
+# product VSIX. It is inert unless a stimulus writes `debug-probe.json` into the
+# workspace, so it is built and installed on every run rather than conditionally.
+#
+# This is the one thing under evals/ that needs compiling: the graders run
+# straight off .ts via Node's type stripping, but the VS Code extension host
+# cannot strip types, so the probe must ship as emitted JavaScript.
+
+if [ "$SKIP_BUILD" -eq 0 ]; then
+    log "Building debug probe VSIX"
+    ( cd "$PROBE_SRC" && [ -d node_modules ] || npm install )
+    ( cd "$PROBE_SRC" && npm run package >/dev/null )
+fi
+
+BUILT_PROBE="${PROBE_SRC}/cor-debug-probe.vsix"
+if [ -f "$BUILT_PROBE" ]; then
+    mkdir -p "$(dirname "$PROBE_DEST")"
+    cp "$BUILT_PROBE" "$PROBE_DEST"
+fi
+[ -f "$PROBE_DEST" ] || die "No debug probe VSIX at ${PROBE_DEST}. Run without --skip-build."
+
+# The probe's package.json points main at out/extension.js. If `npm run package`
+# ran without compiling, the VSIX packages cleanly and then fails to activate in
+# the container — which looks exactly like the extension not being installed at
+# all, the very thing this gate exists to distinguish.
+PROBE_LISTING="$(unzip -l "$PROBE_DEST")"
+case "$PROBE_LISTING" in
+    *extension/out/extension.js*) ;;
+    *) die "Debug probe VSIX has no out/extension.js — run 'npm run compile' in evals/debug-probe/extension" ;;
+esac
+
+log "Staged $(basename "$PROBE_DEST") ($(du -h "$PROBE_DEST" | cut -f1))"
 
 # --- stage the graders and build the config ----------------------------------
 #

--- a/evals/msbench/run.sh
+++ b/evals/msbench/run.sh
@@ -48,6 +48,10 @@ VSIX_DEST="${ASSETS}/extensions/vscode-azureresourcegroups.vsix"
 # The test-only debug probe extension, built from source alongside the product.
 PROBE_SRC="${REPO_ROOT}/evals/debug-probe/extension"
 PROBE_DEST="${ASSETS}/extensions/cor-debug-probe.vsix"
+# The known-debuggable project the breakpoint stimulus runs against. Same fixture
+# evals/debug-probe certifies with, so green here and green locally mean the same.
+FIXTURE_SRC="${REPO_ROOT}/evals/grader-certification/reference-node-fullstack"
+FIXTURE_DEST="${ASSETS}/fixtures/reference-node-fullstack"
 
 # Borrowed purely for its container image; user-overrides.yaml replaces its
 # prompt and assertions wholesale. Swapping this for a heavier instance is how
@@ -182,6 +186,25 @@ case "$PROBE_LISTING" in
 esac
 
 log "Staged $(basename "$PROBE_DEST") ($(du -h "$PROBE_DEST" | cut -f1))"
+
+# --- stage the debug fixture -------------------------------------------------
+#
+# The breakpoint stimulus needs a project that is known to be debuggable, so the
+# run answers "can a debugger work in this container" rather than "did the agent
+# write a good project this time". Those are different questions and only one of
+# them is about the harness.
+#
+# Copied rather than generated: this is the same fixture `evals/debug-probe`
+# certifies against locally, so a green run here and a green certification mean
+# the same thing.
+log "Staging debug fixture"
+rm -rf "$FIXTURE_DEST"
+mkdir -p "$(dirname "$FIXTURE_DEST")"
+cp -R "$FIXTURE_SRC" "$FIXTURE_DEST"
+# A stale .eval from a local certification run would seed the container with a
+# verdict nobody produced there, which is the most misleading artifact possible.
+rm -rf "${FIXTURE_DEST}/.eval" "${FIXTURE_DEST}/node_modules" "${FIXTURE_DEST}/debug-probe.json"
+[ -f "${FIXTURE_DEST}/.vscode/launch.json" ] || die "Debug fixture has no .vscode/launch.json at ${FIXTURE_DEST}"
 
 # --- stage the graders and build the config ----------------------------------
 #

--- a/evals/msbench/stage-graders.ts
+++ b/evals/msbench/stage-graders.ts
@@ -58,6 +58,11 @@ const ENTRYPOINTS = [
     'evals/graders/validate-debug-config.ts',
     'evals/graders/validate-debug-gate.ts',
     'evals/graders/validate-debug-artifacts.ts',
+    // Reads the verdict written by the debug probe extension. Its only non-grader
+    // import is `debug-probe/extension/src/verdict.ts`, the contract the probe and
+    // the grader share; the import-graph walk stages that automatically, which is
+    // what keeps the two from drifting.
+    'evals/graders/validate-debug-breakpoint.ts',
 ];
 
 // Import specifiers are found by a small tokenizer in `importScanner.ts`, not by a


### PR DESCRIPTION
Stacked on #1717, which added the debug-breakpoint gate but deliberately left it unwired while several sessions were editing `msbench/config/`. **Review #1717 first**; this PR is the connective tissue.

## What this wires

- **`run.sh`** builds and stages `cor-debug-probe.vsix` alongside the product VSIX, and checks the package actually contains `out/extension.js`. A probe packaged without compiling looks perfectly valid and then fails to activate — which from outside the container is indistinguishable from never having been installed.
- **`config/base.yaml`** installs it as a second `installExtensions` entry. That key **concatenates across config layers rather than replacing**, which is how our VSIX already rides alongside `github.copilot-chat`; the probe is its second user, and confirming that is the point of the run below.
- **`stage-graders.ts`** gains the grader as an entrypoint. Its import-graph walk stages the shared `verdict.ts` contract automatically — which is exactly what stops the probe and the grader from drifting.

The probe stays **inert unless the workspace contains `debug-probe.json`**, so it installs on every run and stimuli opt in. Existing stimuli are unaffected; all still build.

## Two fixes the wiring forced

Both found by running it rather than reading it.

**The trigger stopped firing once the socket connected.** If the app was listening before js-debug had bound the breakpoint, the first request sailed straight through and nothing ever hit the breakpoint again. That made the gate **intermittently red against a working project** — a false product failure, and the worst kind, because it is indistinguishable from a real one. Certification caught it: known-good went `breakpointNotHit` on a re-run of a case that had passed three times. The trigger now keeps driving until execution actually stops. 3/3 clean re-runs after the fix; 16/16 certification.

**The probe now watches for its spec** instead of only reading it at activation. Whether the config's `script:` preamble seeds the workspace before or after the extension host finishes starting is not observable from outside the container, and guessing wrong would mean the probe reads nothing, idles, and writes no verdict — which reads as "never installed" rather than "raced".

## The run this is asking for

`debug-probe-smoke` is the smallest run that can answer the one claim in this design that could not be settled locally: **does a second extension install and activate alongside ours?**

Its `probe-smoke` phase sets no `chatMode` and seeds no agent, so the agent does essentially nothing — one trivial prompt, no artifacts. The evidence is written by the extension host during workspace setup, before the first turn, so paying for a product run to obtain it would be paying for the wrong thing and would couple the answer to whether the agent behaved that day.

Two assertions: the liveness sentinel, and `.eval/probe.log` exists. Plus a non-asserting fingerprint (`assertZeroExitCode: false`, like the other stimuli carry) that separates *never staged* from *staged but not installed* from *installed but not activated* — three failures that look identical from the outside and have completely different fixes.

**There is deliberately no breakpoint assertion.** That is the next run, gated on this one. Asserting it now would conflate "the probe is installed" with "the debugger works in a container", and a red result would not say which.

## Verified locally

- `npm run typecheck` clean
- `certify.ts` 16/16 (11 offline + 5 live in real VS Code)
- config builds for `photo-app-requirements`, `plan-generation-task-app`, `debug-probe-smoke`
- `stage-graders.ts` stages the grader and pulls `verdict.ts` across with it
- probe VSIX packages at 30 KB and contains `out/extension.js`
- `run.sh` syntax-checked

**No MSBench run submitted.**

## `--user-data-dir` length, as requested

Documented in both READMEs rather than configured, because MSBench chooses that path, not us. VS Code binds a Unix domain socket inside it and `sun_path` caps at ~104 bytes; exceed it and VS Code starts, opens no window, writes zero log lines, and hangs until killed. It cost a day locally. Written down so the next person recognises the symptom instead of suspecting their extension.


## Third fix: port squatters (added after review feedback from the runtime-gates work)

Their reviewer found a process squatting on 7071 being accepted as the application under test — a crash-on-boot mutation went green and a stranger's 404 was reported as a product failure. The same hazard lands harder here, because this probe would blame the product for it in **two** different ways:

| squatter on | probe concludes | exit |
| --- | --- | --- |
| the trigger port | it served the request, so the breakpoint was never reached ⇒ `breakpointNotHit` | 1 |
| the inspector port | node never started ⇒ `appFailedToStart` | 1 |

Both wrong, and neither looks unusual. Both ports are now checked **before** launch, returning `probeError` (exit 3). Afterwards is too late: once the run has happened a squatter is indistinguishable from a broken project.

The check **connects rather than binds** — which is the part their first fix got wrong, and worth repeating because it is counter-intuitive: a bind test against `127.0.0.1` reports the port free while a squatter holds `0.0.0.0` on macOS.

The inspector port is the one nothing else can be done about. The reference fixture pins `--inspect=9229`; a pinned port collides across concurrent runs and survives a crashed earlier session, and this probe **cannot remap it**, because VS Code reads `launch.json` directly and is handed only a configuration *name*. Detecting it and declining is the only honest option, and it is why certification runs its cases strictly sequentially. A stack template emitting a hardcoded inspector port should be fixed at the source rather than worked around in either harness.

Certified by `mutation-port-squatted`, which holds `0.0.0.0:7071` from a separate process — `spawnSync` blocks the certifier's event loop, so an in-process listener would never accept the connection — and requires exit 3. **Without the guard that case produces `breakpointNotHit`, exit 1: a false product failure.** Suite is now 17/17.


## Why this needs adversarial testing, not more certification

Three bugs in this PR — the trigger that stopped firing, the read-once spec, and the port squatter — share a property worth naming:

**My certification suite agreed with itself at 16/16 while the trigger defect was live inside it.**

Certification tells you the probe is consistent with its own expectations. It does not tell you the probe is correct. Every one of these was found by an adversarial condition — a re-run that happened to lose a race, an ordering we couldn't observe, a port held by a stranger — and none by the happy path, which was green throughout.

This is now three independent instances across three sessions in one day, each found the same way. That's the argument for building the adversarial layer deliberately rather than hoping re-runs surface things by luck.


## Result of the run this PR asked for: `2026082620311350`

**The question is answered: yes.** A second extension installs, activates, and sees a trusted workspace in-container. VS Code's own `extension-host.log`:

```
[05:53:19.704Z] [cor-debug-probe] activated; trusted=true; folder=/workspace
[05:53:22.033Z] [ext-drive:INFO] Extension already active: ms-azuretools.cor-debug-probe
```

`installExtensions` concatenation is now settled by observation rather than inference, which was load-bearing for more than this gate. Cost: 17,016 tokens, 1 step.

**The run still went red, and the red was mine.** The assertion asked the `files` table for a path an extension had written. `files` is not a filesystem listing — it holds tracked file *contents* scoped per step, and the harness appends `AND stepIndex = :stepIndex`. The entire table for that run was `.gitkeep` and `.gitignore`. The assertion could never have passed, and the run's own fingerprint printed the file it claimed was absent.

That is the class of defect this gate exists to prevent, shipped into the run meant to validate the guards against it. The trap isn't carelessness — **`files` reads like `find` and isn't, so the abstraction lies at the point of use.** Fixed to `exec: test -f .eval/probe.log`, and the README now states the rule flatly with this run as the worked example.

Two designs from this PR paid for themselves on first contact: the **fingerprint** turned a re-run into a ten-minute read, and the **spec watcher** was load-bearing rather than precautionary — the probe activated at 05:53:19 to an empty workspace, so the read-once version would have written nothing at all.

## Adds `debug-breakpoint-node`

The run that answers what's actually left: **can a debugger reach a breakpoint inside this container?** Against the staged known-debuggable fixture, not generated code — a red against generated code cannot distinguish "the container cannot host a debugger" from "the agent wrote a bad project". The liveness assertion is folded in rather than given its own run, since installation is settled.

The generated phase script was verified by executing it against a copy of the fixture: the heredoc survives the YAML block scalar, the JSON parses, and the pattern resolves to `src/server.js:50`. A broken heredoc would have cost a run.


## The breakpoint run: **GREEN**. `2026082623215161`

**A breakpoint was hit inside the MSBench container.** 3/3 assertions, `resolved: true`, 17,525 tokens, ~7 seconds from probe activation to stop.

```
  stopped at /workspace/src/server.js:50 in <anonymous>
  locals in scope: request, requestUrl, response, this
PASS: a breakpoint is hit in the generated project
```

js-debug launches a process, binds a breakpoint and stops on it under xvfb-as-root on Ubuntu 22.04 with Node v22.22.2. The gate is viable end to end, in the only place it could ever have existed.

Two things in the verdict's timeline are worth reading, because both are decisions from this PR being exercised in the container rather than on a laptop:

```
06:30:00.999  setBreakpoints response: [{"verified":false,"message":"Unbound breakpoint"}]
06:30:01.074  startDebugging returned true
06:30:01.581  trigger connected after 2 attempt(s)
06:30:01.589  stopped: reason=breakpoint
```

**`verified: false` on the breakpoint that was then hit 0.6s later** — exactly as locally. Gating on `verified === true`, the obvious check, would have produced a red here against a working project.

**The trigger connected on attempt 2, not attempt 1.** The app was not yet listening when the first request went out. A single-shot trigger would have reported `appFailedToStart` against a project that starts fine.

The port guard also ran clean and is visible in the timeline (`trigger port 127.0.0.1:7071 is free`, `inspector port 127.0.0.1:9229 is free`), so the run is known not to have been graded against a squatter.

### One caveat, in my own words from earlier in this PR

**This is n=1, and a single green run cannot distinguish *works* from *got lucky*.** The 17/17 local mutation suite is evidence about the *gate*; it says nothing about how reliably this container hosts a debugger. Timing-sensitive paths are exactly where that distinction bites — and this run's own timeline shows the trigger needing a retry, which is the kind of margin that varies with load. Before this gate is trusted against real generated projects, it deserves repeat runs to establish a pass rate rather than a single green.
