### PR TITLE
Refuse to audit a run MSBench has not marked complete

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -1156,6 +1156,26 @@ credits passes it never earned. **Seven of twenty-six instances in the corpus ar
 
 ### Why this has to be mechanical
 
+One failure shape underlies most of what this tool looks for, and it is worth stating
+directly because it tells you what to look for rather than what once happened:
+
+> **A number that is arithmetically correct, answering a wider question than it measured.**
+
+Three separate defects found while building these gates were all this shape:
+
+| Where | The number | What it actually measured |
+| --- | --- | --- |
+| A gate not applicable on every stack | `16/16 passed` | Nothing. An N/A grader exited 0 and was scored as a pass. |
+| A stranded-content check | `clean — fully merged` | Insertions only — a lost *deletion* reported success. |
+| A pass rate including N/A results | `100%` | The applicable observations, silently reweighted by the inapplicable ones. |
+
+None is a bug in the arithmetic. Each is a verdict over a wider domain than the evidence
+covers, and in every case the fix was the same move: **make the output claim only what it
+knows**. That is why `rate` prints `n/a` rather than `100%`, why N/A is its own bucket, and
+why the out-of-scope section says *for the stacks observed*.
+
+#### And why it is computed rather than judged
+
 The argument for automating any of this is not that people are careless. It is narrower and
 less comfortable than that.
 
@@ -1174,6 +1194,13 @@ output.** Not evidence they lacked — evidence they had printed, and read past:
 The pattern is not fatigue. **A plausible mechanism is more satisfying than an unexplained
 observation**, so the mechanism gets adopted and the observation gets quietly re-read to
 fit. Every one of those five hypotheses was mechanically sound and predicted the symptom.
+
+The method that actually produced every genuine finding here is duller than insight: **run
+the thing before believing it.** The pre-registered test, the filesystem birth times that
+ended the argument, the checks re-run against a second case. It needs no cleverness and is
+available to anyone. Its corollary is the half that keeps being missed — *having the
+evidence is not the same as having read it*. All four of those participants ran the thing;
+they read past the answer.
 
 That is the same failure this tool exists to catch, one level up. A gate that has failed 16
 times looks routine; nothing about a routine-looking thing invites inspection, which is

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -1154,6 +1154,63 @@ credits passes it never earned. **Seven of twenty-six instances in the corpus ar
 > trend-plotting historical runs should assume the older half of the corpus is
 > contaminated in both directions.
 
+### Why this has to be mechanical
+
+The argument for automating any of this is not that people are careless. It is narrower and
+less comfortable than that.
+
+Over one afternoon of building these gates, **four separate participants across three
+sessions reached a confident conclusion while the disconfirming evidence was in their own
+output.** Not evidence they lacked — evidence they had printed, and read past:
+
+- A run was declared to have a member-order bug; the timestamp disproving it was in the
+  same `ls` output as the claim.
+- A check was proposed for detecting stranded commits; the line disproving it (`all nine
+  commits listed, because a squash rewrites them`) had been printed one step earlier.
+- A refined version of that check was proposed after testing only the case where it works.
+- The `unzip -l` listing used to explain a 25-minute-old read described the archive as it
+  existed *after* the read.
+
+The pattern is not fatigue. **A plausible mechanism is more satisfying than an unexplained
+observation**, so the mechanism gets adopted and the observation gets quietly re-read to
+fit. Every one of those five hypotheses was mechanically sound and predicted the symptom.
+
+That is the same failure this tool exists to catch, one level up. A gate that has failed 16
+times looks routine; nothing about a routine-looking thing invites inspection, which is
+precisely why nobody inspected it. *"It looked routine"* was also the reason a branch got
+squash-merged while it was still receiving commits, losing a commit for thirty minutes.
+
+So the verdicts here are deliberately computed rather than judged, the report states how
+many runs each one rests on, and it refuses to editorialise below a threshold. Not because
+judgement is bad, but because judgement is exactly what stops being applied to things that
+look fine.
+
+#### A related check, and what it does not know
+
+After a squash merge, this finds content on a branch that did not make it in. `git log
+feat/CoR..<branch>` does **not** work — a squash rewrites every commit, so it lists the
+whole branch every time, which is an alarm that always fires:
+
+```bash
+base=$(git merge-base origin/feat/CoR "$BR")
+touched=$(git diff --name-only "$base" "$BR")
+git diff --numstat origin/feat/CoR "$BR" -- $touched |
+  awk '$1>0 {s+=$1; print "  +"$1"\t"$3} END {print (s ? "STRANDED "s : "no additive content stranded")}'
+```
+
+Restricting to files the branch touched matters: without it, lines that *other* merged PRs
+deleted show up as insertions on any stale branch — 80 reported against 62 real, in the
+case this was built for.
+
+Two limits, both stated rather than fixed, because a second noisy column would be worse:
+
+- **It counts insertions only, so a lost *deletion* reports success.** That is why the
+  success string says `no additive content stranded` and not `clean` — the check examined
+  half the branch and must not render a verdict on all of it.
+- **Non-zero is a reason to look, not a finding.** Content a later PR legitimately
+  superseded is indistinguishable from content a squash dropped. Of three real non-zero
+  results, two were benign.
+
 ### Not-applicable, and the convention that got reversed
 
 The fidelity and runtime gates emit a machine-readable marker on stderr:

--- a/evals/msbench/gate-health.ts
+++ b/evals/msbench/gate-health.ts
@@ -421,7 +421,53 @@ function diagnoseEmptyExtraction(runId: string): string {
         'was not loaded — treat this as a bug in this tool or in extraction, NOT as a corpus fact.';
 }
 
-/** The cached archive MSBench keeps per run, if this machine has it. */
+/**
+ * Whether MSBench considers this run finished, from `results.json`'s `timestamps.completed`.
+ *
+ * This is the primary guard against auditing a run that has not finished, and it exists because a
+ * real incident was misdiagnosed twice before the mechanism was found. A run was audited ~50s
+ * before it even initialized and ~5 minutes before it completed; extraction succeeded, exited 0,
+ * and produced run metadata with no instance output. Two plausible mechanisms were proposed and
+ * investigated — an order-dependent archive reader, and non-atomic blob reconciliation — and both
+ * were wrong. The run was simply still executing.
+ *
+ * A blob-presence check does not catch this: the absence was total, so there was nothing partial to
+ * detect. `timestamps.completed` fires deterministically whether the read is five seconds early or
+ * five hours early, and it is already written by the CLI, so it costs nothing.
+ *
+ * Returns undefined when there is no cached `results.json` to consult — an explicitly extracted
+ * directory, typically — in which case the run is audited rather than skipped, because refusing to
+ * audit data someone handed us directly would be worse than the risk.
+ */
+function runCompletedAt(runId: string): string | undefined {
+    if (!/^\d+$/u.test(runId)) {
+        return undefined;
+    }
+    for (const root of msbenchRunRoots()) {
+        const parsed = readJson<{ timestamps?: { completed?: string } }>(join(root, runId, 'results.json'));
+        if (parsed) {
+            return parsed.timestamps?.completed;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * `results.json` exists but carries no completion timestamp: the run is still executing, or died
+ * without recording one. Either way its results are not a result yet.
+ */
+function isIncompleteRun(runId: string): boolean {
+    if (!/^\d+$/u.test(runId)) {
+        return false;
+    }
+    for (const root of msbenchRunRoots()) {
+        const path = join(root, runId, 'results.json');
+        if (existsSync(path)) {
+            return runCompletedAt(runId) === undefined;
+        }
+    }
+    return false;
+}
 function runArchivePath(runId: string): string | undefined {
     if (!/^\d+$/u.test(runId)) {
         return undefined;
@@ -979,6 +1025,10 @@ function printPreamble(runs: string[], instances: number, voidInstances: number,
     readerFaults: string[], skipped: string[]): void {
     console.log('');
     console.log('Gate health — auditing the instrument, not the product');
+    // Stamped because this report describes a corpus that changes underneath it. A stale reading of
+    // a transient condition is what made a still-running run look like a permanent anomaly, and
+    // cost several round trips to unpick. It costs nothing to say when the data was read.
+    console.log(`Read at ${new Date().toISOString()}`);
     console.log(`${runs.length} run(s), ${instances} instance(s). Verdicts below ${minRuns} runs are marked low confidence.`);
     if (readerFaults.length > 0) {
         // Loud, and deliberately separate from a pending run: this says the numbers below are
@@ -1045,6 +1095,14 @@ async function main(): Promise<void> {
     let voidInstances = 0;
 
     for (const { runId, dir } of roots) {
+        // Primary guard: never audit a run MSBench has not marked complete. Checked before the
+        // instance scan, because an unfinished run legitimately has no instances and must not be
+        // reported as though that were a fact about the corpus.
+        if (isIncompleteRun(runId)) {
+            log(`  ! ${runId}: skipped — no timestamps.completed in results.json; the run has not finished`);
+            skipped.push(runId);
+            continue;
+        }
         const instances = findInstances(dir);
         if (instances.length === 0) {
             // Never just shrug and continue: a dropped run under-reports coverage invisibly, and it
@@ -1086,9 +1144,12 @@ async function main(): Promise<void> {
 
     if (options.json) {
         console.log(JSON.stringify({
+            readAt: new Date().toISOString(),
             runs: auditedRuns,
             instances: instanceCount,
             voidInstances,
+            readerFaults,
+            skipped,
             minRuns: options.minRuns,
             gates: rows.map(({ gate, tally, verdict, confident }) => ({
                 gate,


### PR DESCRIPTION
Follow-up to #1718. That PR was squash-merged at 06:22:29Z; this commit was pushed at 06:23 and **missed the merge by about thirty seconds**. Everything else from the branch landed.

It is the one change that addresses what actually happened in the incident #1718 documents, so it should not be lost.

## What it adds

**1. Refuse to audit a run MSBench has not marked complete.**

`results.json` carries `timestamps.completed`. If it is absent, the run has not finished, and it is skipped rather than reported.

**2. Stamp the report with when it read.**

```
Gate health — auditing the instrument, not the product
Read at 2026-08-26T06:24:16.964Z
25 run(s), 30 instance(s). …
```

Also in `--json` as `readAt`, alongside the `readerFaults` and `skipped` run lists.

## Why — the incident this closes

A run was audited **before it had finished**. Extraction succeeded, exited 0, and produced run metadata with no instance output. The tool correctly said `no instances found`.

Two mechanisms were then proposed across three sessions, investigated, and **both were wrong**: an order-dependent archive reader, and non-atomic blob reconciliation. A third (partial mid-stream download) and a fourth (sensitivity to member type or size) followed. Five hypotheses, all mechanically plausible, all predicting the symptom.

The actual cause, from `results.json`:

| | |
| --- | --- |
| `timestamps.initialized` | `22:24:21` |
| `timestamps.completed` | `22:28:22` |
| The read | `~22:23:30` |

The read happened **before the run had even initialized**, and about five minutes before it completed. The run was simply still executing. There was no anomaly to explain — the archive served at that moment genuinely had no output blob in it.

Every wrong hypothesis, mine included, shared one error worth naming:

> **When explaining an observation of a mutable artifact, the artifact you can inspect now is not the artifact that was observed.**

All five reasoned about the *final* four-member archive to explain a read that happened while it was a three-member archive. A corpus auditor is the tool most exposed to that mistake, which is why both halves of this change are here.

## Why `timestamps.completed` and not the blob-presence check

#1718 already added a loader-fault cross-check: an archive containing `*-output.zip` while the extraction yields no instances is a loud reader fault. That guard is worth having and stays.

**It would not have caught this case.** The absence was *total*, not partial — there was nothing partial to detect. `timestamps.completed` fires deterministically whether the read is five seconds early or five hours early, requires nobody to be right about the mechanism, and is a field the CLI already writes.

The read timestamp is the other half. This report describes a corpus that changes underneath it; a 25-minute-stale reading of a transient condition is exactly what made a still-running run look like a permanent defect, and cost roughly six round trips across three sessions. It costs nothing to say when the data was read.

## Also: why the verdicts are computed rather than judged

A README section recording the pattern behind this incident, because it is the argument for the tool rather than an aside.

Over one afternoon, **four participants across three sessions reached a confident conclusion while the disconfirming evidence was in their own output** — a timestamp in the same `ls` listing as the claim it refuted; a commit list printed one step before a check was proposed that assumed the opposite; a refinement tested only against the case where it works; an archive listing describing the state *after* the read it was explaining.

Not fatigue. **A plausible mechanism is more satisfying than an unexplained observation**, so the mechanism gets adopted and the observation gets re-read to fit. All five hypotheses in this incident were mechanically sound and predicted the symptom.

That is this tool's own thesis one level up: a gate that has failed sixteen times *looks routine*, and nothing routine invites inspection. "It looked routine" is also why the branch was squash-merged while still receiving commits.

The section also documents the stranded-content check with the two things it cannot know — it counts insertions only, so a lost *deletion* reports success (hence the success string is `no additive content stranded`, not `clean`), and non-zero cannot distinguish superseded content from dropped content.

## Scope and verification

Two files: `evals/msbench/gate-health.ts` (+62/−1) and `evals/msbench/README.md`.

- Runs with no cached `results.json` — an explicitly `--extracted` directory, typically — are still audited. Refusing data handed over directly would be worse than the risk.
- Guard verified by removing `timestamps.completed` from a cached run: `! 2026082619460117: skipped — no timestamps.completed in results.json; the run has not finished`, then restored.
- `npm run typecheck` passes; full corpus re-run is unchanged at 25 runs / 30 instances / 46 gates, no verdicts moved.
