### PR TITLE
Make a project type a data file: the stack schema

### DIFF
--- a/.github/workflows/agent-contracts.yml
+++ b/.github/workflows/agent-contracts.yml
@@ -69,6 +69,14 @@ jobs:
         run: npm run certify
         working-directory: evals
 
+      # Same idea one layer up: prove the stack schema still rejects the sixteen
+      # broken stack files it claims to reject. A schema that quietly accepts
+      # everything would let a stack requiring a binary the container does not
+      # have reach a paid run, which is the cost this check exists to avoid.
+      - name: Check stack schema
+        run: npm run stacks:check
+        working-directory: evals
+
       # Run through the evals package so the spec is actually linted: a bare
       # `vally lint` at the repo root discovers no skills and silently passes.
       - name: Lint eval specs

--- a/evals/check-stacks.ts
+++ b/evals/check-stacks.ts
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Check the stack schema — and, more importantly, check that the check works.
+ *
+ * The house rule this is built to satisfy: **a validator is not done until a
+ * deliberately broken fixture makes it fail.** This suite has repeatedly shipped
+ * things that looked fine and tested nothing — a timeout that could not fire, a
+ * `COUNT(*) = 0` trivially true against an empty table, a gate 0-for-16 while
+ * reporting healthy. A schema validator is an easy addition to that list: one
+ * that accepts everything passes every test written only against good files.
+ *
+ * So there are two halves, and the second is the real one:
+ *
+ *   1. Every real stack, and the container inventory, must load.
+ *   2. Every file under `config/__fixtures__/` must be **rejected with the exact
+ *      code it declares** in its `# expect:` header.
+ *
+ * Asserting the code rather than merely "it threw" is what makes each fixture
+ * prove its own rule. A validator broken so that it rejects everything would
+ * sail through a suite that only checked for a throw; here it fails on every
+ * fixture at once and names each one.
+ *
+ * ## Three vacuity traps, closed explicitly
+ *
+ * Each of these has bitten this repo:
+ *
+ *   - An empty fixture directory makes "every fixture was rejected" trivially
+ *     true, so the count is asserted non-zero *and* equal to the files present.
+ *   - An empty stacks directory makes "every stack is valid" trivially true, so
+ *     that is asserted non-zero too.
+ *   - A fixture with no `# expect:` header would be silently skipped, so a
+ *     missing header is itself a failure.
+ *
+ * ## The ratchet
+ *
+ * A rule with no fixture is unproven, and unproven is indistinguishable from
+ * broken. Rather than claim otherwise, this reports how many of the validators'
+ * error codes are actually exercised, lists the ones that are not, and refuses
+ * to let that number fall (`MIN_PROVEN_CODES`). Not every code will ever have a
+ * fixture — several are plain type checks — but the count may only go up, so
+ * deleting a fixture is a failure rather than a silence.
+ *
+ * And one process trap: nothing here is piped. A pipe discards the exit status
+ * of its left-hand side, which is how a broken check came to report success.
+ *
+ * Runs straight off source via Node's built-in type stripping — no build step.
+ *
+ * Usage: npm run stacks:check
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ConfigValidationError } from './src/configValidation.ts';
+import { countAsserted, loadContainerInventory } from './src/containerInventory.ts';
+import { loadStack } from './src/stack.ts';
+import type { StackLoadOptions } from './src/stack.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CONFIG = join(HERE, 'msbench', 'config');
+const STACKS = join(CONFIG, 'stacks');
+const FIXTURES = join(CONFIG, '__fixtures__');
+const PHASES = join(CONFIG, 'phases');
+const CONTAINER = join(CONFIG, 'container.yaml');
+
+/** The validator sources whose error codes the fixtures are measured against. */
+const VALIDATOR_SOURCES = ['src/stack.ts', 'src/containerInventory.ts'];
+
+/**
+ * The floor for proven error codes. **This number may only ever go up.**
+ *
+ * A ratchet rather than a target: it does not demand a fixture for every code
+ * (several are plain type checks whose fixture would prove little), but it does
+ * mean that deleting a fixture — or adding a judgment-carrying rule and
+ * forgetting to prove it — fails here instead of passing quietly.
+ */
+const MIN_PROVEN_CODES = 24;
+
+/** `# expect: <code>` in a fixture header — the rule that fixture exists to prove. */
+const EXPECT_DIRECTIVE = /^#\s*expect:\s*([A-Za-z][A-Za-z0-9]*)\s*$/m;
+
+/**
+ * Error codes as they appear in the validator sources.
+ *
+ * Codes reach `ConfigValidationError` by several paths — `reject(...)` directly,
+ * and as an argument to `requireObject` / `requireString` / `requireEnum` /
+ * `rejectUnknownKeys` — so matching call shapes one at a time would miss some.
+ * What every path has in common is that the code literal is immediately followed
+ * by the file argument, which is what this matches.
+ *
+ * A looser match on the prefix alone was tried first and was wrong: it counted
+ * `'containerApps'` (a hosting kind) and `'stackDeclaration'` (a discovery-chain
+ * source) as error codes, inflating the denominator and putting two names on the
+ * unproven list that no fixture could ever remove. A coverage number that cannot
+ * reach its own ceiling teaches people to ignore it.
+ */
+const CODE_LITERAL = /'([A-Za-z][A-Za-z0-9]*)',\s*(?:filePath|file)\b/g;
+
+const failures: string[] = [];
+
+function fail(message: string): void {
+    failures.push(message);
+    console.error(`  ✖ ${message}`);
+}
+
+function yamlFilesIn(directory: string): string[] {
+    return readdirSync(directory, { withFileTypes: true })
+        .filter(entry => entry.isFile() && entry.name.endsWith('.yaml'))
+        .map(entry => entry.name)
+        .sort();
+}
+
+/**
+ * Load a fixture and assert it is rejected with the code its header declares.
+ * Returns the proven code, or undefined when the fixture did not do its job.
+ */
+function expectRejection(directory: string, name: string, load: (path: string) => unknown): string | undefined {
+    const path = join(directory, name);
+    const expected = EXPECT_DIRECTIVE.exec(readFileSync(path, 'utf8'))?.[1];
+    if (!expected) {
+        fail(`${name} has no '# expect: <code>' header, so nothing about it is being checked`);
+        return undefined;
+    }
+    try {
+        load(path);
+        fail(`${name} was ACCEPTED; it must be rejected with ${expected}`);
+        return undefined;
+    } catch (error) {
+        if (!(error instanceof ConfigValidationError)) {
+            fail(`${name} threw something other than a validation error: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+            return undefined;
+        }
+        if (error.code !== expected) {
+            // The subtle failure this catches: a fixture rejected for the wrong
+            // reason proves the wrong rule, and would keep passing while the rule
+            // it was written for quietly stopped working.
+            fail(`${name} was rejected as ${error.code}, but exists to prove ${expected}`);
+            return undefined;
+        }
+        console.error(`  ✔ ${name} → ${error.code}`);
+        return error.code;
+    }
+}
+
+function checkFixtureDirectory(label: string, directory: string, load: (path: string) => unknown): string[] {
+    console.error(`\n${label}`);
+    const fixtures = yamlFilesIn(directory);
+    if (fixtures.length === 0) {
+        fail(`${label}: no fixtures found — the validator is unproven, which is the same as broken`);
+        return [];
+    }
+
+    const proven = fixtures
+        .map(name => expectRejection(directory, name, load))
+        .filter((code): code is string => code !== undefined);
+
+    // Equality, not `> 0`. "At least one fixture was rejected" is the same shape
+    // as the `COUNT(*) = 0` assertion that passed against an empty table.
+    if (proven.length !== fixtures.length) {
+        fail(`${label}: ${proven.length} of ${fixtures.length} fixtures were rejected as declared; every one must be`);
+    }
+    return proven;
+}
+
+/** Every error code the validators can emit, scanned from their sources. */
+function declaredCodes(): Set<string> {
+    const codes = new Set<string>();
+    for (const source of VALIDATOR_SOURCES) {
+        const text = readFileSync(join(HERE, source), 'utf8');
+        for (const match of text.matchAll(CODE_LITERAL)) {
+            codes.add(match[1]);
+        }
+    }
+    return codes;
+}
+
+function main(): void {
+    // ---- The container inventory -------------------------------------------
+    console.error('Container inventory');
+    const inventory = loadContainerInventory(CONTAINER);
+    const asserted = countAsserted(inventory);
+    console.error(`  ✔ ${inventory.binaries.size} binaries, verified ${inventory.verifiedOn}`);
+    // Printed on every run rather than buried in a comment. Most of that file is
+    // documentation repeated between humans, and a number that shows up each time
+    // is harder to keep believing than a sentence nobody rereads.
+    console.error(`  ! ${asserted} of ${inventory.binaries.size} rows are asserted, not measured — see container.yaml`);
+
+    const options: StackLoadOptions = { inventory, phasesDirectory: PHASES };
+
+    // ---- Half one: the real stacks must load -------------------------------
+    console.error('\nStacks');
+    const stackFiles = yamlFilesIn(STACKS);
+    if (stackFiles.length === 0) {
+        fail('no stacks found — "every stack is valid" is vacuously true with nothing to check');
+    }
+    for (const name of stackFiles) {
+        try {
+            const stack = loadStack(join(STACKS, name), options);
+            const gaps = stack.knownGaps.length === 0
+                ? 'no known gaps'
+                : `${stack.knownGaps.length} known gap(s): ${stack.knownGaps.map(gap => gap.reason).join(', ')}`;
+            console.error(`  ✔ ${stack.id} — ${stack.ecosystem}, ${gaps}`);
+        } catch (error) {
+            fail(`${name} should be valid but was rejected: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }
+
+    // ---- Half two: the broken fixtures must be rejected, by name -----------
+    const provenStack = checkFixtureDirectory(
+        'Stack rejection fixtures',
+        join(FIXTURES, 'stacks-invalid'),
+        path => loadStack(path, options),
+    );
+    const provenContainer = checkFixtureDirectory(
+        'Container rejection fixtures',
+        join(FIXTURES, 'container-invalid'),
+        path => loadContainerInventory(path),
+    );
+
+    // ---- The ratchet -------------------------------------------------------
+    const proven = new Set([...provenStack, ...provenContainer]);
+    const declared = declaredCodes();
+    const unproven = [...declared].filter(code => !proven.has(code)).sort();
+    console.error(`\nRule coverage: ${proven.size} of ${declared.size} error codes proven by a fixture.`);
+    if (unproven.length > 0) {
+        console.error(`  Unproven (mostly plain type checks; raising this is follow-up work):`);
+        console.error(`    ${unproven.join('\n    ')}`);
+    }
+    if (proven.size < MIN_PROVEN_CODES) {
+        fail(`rule coverage fell to ${proven.size}; MIN_PROVEN_CODES is ${MIN_PROVEN_CODES} and may only go up`);
+    }
+
+    console.error('');
+    if (failures.length > 0) {
+        console.error(`FAIL: ${failures.length} problem(s) above.`);
+        process.exit(1);
+    }
+    console.error(`PASS: ${stackFiles.length} stack(s) valid, ${proven.size} rules proven by ${provenStack.length + provenContainer.length} fixtures.`);
+}
+
+main();

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -428,6 +428,60 @@ shape that gets copy-pasted and then drifts.
 A stimulus picks its phase with a `# phase: <name>` directive in its header. Omitting it
 means `plan`, so a stimulus that predates the layer needs no change.
 
+### Stacks: a project type as data, not a fourth layer
+
+Every stimulus above is React + Azure Functions, hard-coded. Adding a Python or C#
+project that way means copying a YAML file and hand-editing its assertions, which is a
+fork rather than an addition. `config/stacks/<id>.yaml` is the fix: **a project type
+expressed as data.**
+
+A stack is deliberately **not** a fourth concatenated layer. The merge in
+`build-config.ts` is textual and guarded by "the three files must define disjoint
+top-level keys", while the two things a stack wants to control — the prompt and the gate
+wiring — both live *inside* `promptSteps`, which the stimulus owns. Concatenation cannot
+merge into a list, so a fourth layer would have to break that guard, and that guard is
+what stops a typo becoming a paid run that grades the wrong thing. A stack is therefore a
+fourth **input**: `build-config` will synthesise layer 3 from it, leaving the existing
+hand-written stimuli untouched.
+
+**A stack declares facts, not gates.** The obvious design — `gates: [...]` per stack — is
+a hand-maintained matrix that rots in the direction that looks safe (a gate quietly wired
+nowhere reads as a clean run), and it records a conclusion nobody can review without
+having read the gate. So a stack says `frontend: none`, and the gates that look at a
+frontend are not wired. Anyone can check that line against the prompt.
+
+The consequence worth knowing:
+
+> **An `outOfScope` NOT_APPLICABLE marker becomes a bug report against the stack schema.**
+> Under fact-derived wiring a gate is only ever attached when the stack declared the thing
+> it looks at, so `outOfScope` means the derivation is wrong or a stack lied. It is never
+> expected noise. `coverageGap` is unaffected and stays red on purpose — see
+> "Not-applicable, and the convention that got reversed".
+
+`config/container.yaml` records what the eval container actually has, in three states:
+`present`, `absent` (installable, with the command), and `unavailable` (`docker` — no
+practical path). A stack requiring an `absent` binary must declare the gap it causes; a
+stack requiring an `unavailable` one is refused outright. That turns "this stack needs
+something we do not have" into a millisecond-scale local error instead of a discovery made
+forty minutes into a run that has already been paid for.
+
+Most rows in that file are marked `evidence: asserted` — copied from documentation, not
+observed. `npm run stacks:check` prints the count on every run so the assumption stays
+visible.
+
+```
+npm run stacks:check
+```
+
+validates every stack and the inventory, **and** asserts that each of the twenty-four
+deliberately broken files under `config/__fixtures__/` is rejected with the exact error
+code its `# expect:` header names. The code is asserted rather than merely "it threw",
+because a validator broken so that it rejects everything would pass the weaker test — and
+a fixture rejected for the wrong reason proves the wrong rule. It also reports how many of
+the validators' error codes are exercised by a fixture and refuses to let that number
+fall, since a rule with no fixture is unproven and unproven is indistinguishable from
+broken.
+
 ## Running the real validators (`exec:`)
 
 Megan's `program` graders run as `exec:` assertions, so the contract is checked by the

--- a/evals/msbench/config/__fixtures__/container-invalid/absent-without-install.yaml
+++ b/evals/msbench/config/__fixtures__/container-invalid/absent-without-install.yaml
@@ -1,0 +1,8 @@
+# expect: containerBinaryInstallMissing
+# Absent with no install: sends the reader off to find out what everyone already
+# knew, which is the cost this file exists to remove.
+schemaVersion: 1
+verifiedOn: '2026-08-25'
+binaries:
+  node: { status: present, evidence: measured }
+  func: { status: absent, evidence: asserted }

--- a/evals/msbench/config/__fixtures__/container-invalid/bad-schema-version.yaml
+++ b/evals/msbench/config/__fixtures__/container-invalid/bad-schema-version.yaml
@@ -1,0 +1,5 @@
+# expect: containerInventorySchemaVersion
+schemaVersion: 2
+verifiedOn: '2026-08-25'
+binaries:
+  node: { status: present, evidence: measured }

--- a/evals/msbench/config/__fixtures__/container-invalid/bad-status.yaml
+++ b/evals/msbench/config/__fixtures__/container-invalid/bad-status.yaml
@@ -1,0 +1,6 @@
+# expect: containerBinaryStatus
+# "maybe" is the state this file was written to eliminate.
+schemaVersion: 1
+verifiedOn: '2026-08-25'
+binaries:
+  node: { status: maybe, evidence: measured }

--- a/evals/msbench/config/__fixtures__/container-invalid/bad-verified-on.yaml
+++ b/evals/msbench/config/__fixtures__/container-invalid/bad-verified-on.yaml
@@ -1,0 +1,6 @@
+# expect: containerInventoryVerifiedOn
+# A date nobody can compare against a run date is not a verification record.
+schemaVersion: 1
+verifiedOn: last Tuesday
+binaries:
+  node: { status: present, evidence: measured }

--- a/evals/msbench/config/__fixtures__/container-invalid/install-on-present.yaml
+++ b/evals/msbench/config/__fixtures__/container-invalid/install-on-present.yaml
@@ -1,0 +1,6 @@
+# expect: containerBinaryInstallOnPresent
+# Dead text: an install command for something already on PATH.
+schemaVersion: 1
+verifiedOn: '2026-08-25'
+binaries:
+  node: { status: present, evidence: measured, install: apt-get install node }

--- a/evals/msbench/config/__fixtures__/container-invalid/missing-evidence.yaml
+++ b/evals/msbench/config/__fixtures__/container-invalid/missing-evidence.yaml
@@ -1,0 +1,7 @@
+# expect: containerBinaryEvidence
+# Without evidence: a row copied from a README is indistinguishable from one
+# observed in the container.
+schemaVersion: 1
+verifiedOn: '2026-08-25'
+binaries:
+  node: { status: present }

--- a/evals/msbench/config/__fixtures__/container-invalid/unavailable-without-note.yaml
+++ b/evals/msbench/config/__fixtures__/container-invalid/unavailable-without-note.yaml
@@ -1,0 +1,7 @@
+# expect: containerBinaryNoteMissing
+# Refusing a stack outright needs a reason the reader can check.
+schemaVersion: 1
+verifiedOn: '2026-08-25'
+binaries:
+  node: { status: present, evidence: measured }
+  docker: { status: unavailable, evidence: asserted }

--- a/evals/msbench/config/__fixtures__/container-invalid/unknown-binary-key.yaml
+++ b/evals/msbench/config/__fixtures__/container-invalid/unknown-binary-key.yaml
@@ -1,0 +1,6 @@
+# expect: containerBinaryUnknownKey
+# `verison` is a typo; tolerating it would silently drop the version.
+schemaVersion: 1
+verifiedOn: '2026-08-25'
+binaries:
+  node: { status: present, evidence: measured, verison: '22' }

--- a/evals/msbench/config/__fixtures__/stacks-invalid/bad-port.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/bad-port.yaml
@@ -1,0 +1,26 @@
+# expect: stackPortValue
+# A port outside the legal range. The runtime gates move the app to a free port,
+# and a declaration they cannot apply means the gate cannot run at all.
+schemaVersion: 1
+id: bad-port
+name: Fixture
+ecosystem: python
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [python3]
+  start:
+    command: python3
+    args: [-m, uvicorn, main:app]
+    cwd: services/api
+    port:
+      value: 99999
+      remap: { kind: env, key: PORT }
+knownGaps: []
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/ecosystem-binary-missing.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/ecosystem-binary-missing.yaml
@@ -1,0 +1,19 @@
+# expect: stackEcosystemBinaryMissing
+# Declares a Python ecosystem without requiring python3, hiding the stack's most
+# basic requirement from the one check meant to run before money is spent.
+schemaVersion: 1
+id: ecosystem-binary-missing
+name: Fixture
+ecosystem: python
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [curl]
+knownGaps: []
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/functions-without-func.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/functions-without-func.yaml
@@ -1,0 +1,20 @@
+# expect: stackFunctionsRequiresFunc
+# A Functions app that does not admit it needs the Functions host. This is the
+# rule written directly from the injury: the requirement existed, was written
+# down nowhere a tool could read, and cost five red gates on every run.
+schemaVersion: 1
+id: functions-without-func
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: functions
+runtime:
+  binaries: [node, npm]
+knownGaps: []
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/gap-for-unrequired-binary.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/gap-for-unrequired-binary.yaml
@@ -1,0 +1,23 @@
+# expect: stackKnownGapBinaryNotRequired
+# Declares a gap for a binary this stack never needs. Nothing here could be red
+# for that reason, so the declaration can only mislead whoever reads it.
+schemaVersion: 1
+id: gap-for-unrequired-binary
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [node, npm]
+knownGaps:
+  - gates: [runtime-app-starts]
+    reason: functionsHostUnavailable
+    binary: func
+    tracking: this stack is not a Functions app and never calls func
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/health-without-api.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/health-without-api.yaml
@@ -1,0 +1,20 @@
+# expect: stackHealthPathWithoutApi
+# Two individually valid fields that cannot both be true. One of them is wrong,
+# and either way the derivation would wire the wrong gates without saying so.
+schemaVersion: 1
+id: health-without-api
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: none
+  datastore: none
+  hosting: appService
+  healthPath: /api/health
+runtime:
+  binaries: [node, npm]
+knownGaps: []
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/id-mismatch.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/id-mismatch.yaml
@@ -1,0 +1,19 @@
+# expect: stackIdFilenameMismatch
+# The id and the filename disagree, so one thing has two names and every report
+# that joins on either has to pick.
+schemaVersion: 1
+id: some-other-name
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [node, npm]
+knownGaps: []
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/invented-reason.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/invented-reason.yaml
@@ -1,0 +1,23 @@
+# expect: stackKnownGapReason
+# A reason code no grader emits. gate-health groups always-N/A gates by reason,
+# so an invented code produces a red that cannot be grouped with anything — which
+# is the situation the declaration exists to prevent.
+schemaVersion: 1
+id: invented-reason
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [node, npm]
+knownGaps:
+  - gates: [runtime-app-starts]
+    reason: somethingWentWrong
+    tracking: a code that reads fine and groups with nothing
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/missing-known-gaps.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/missing-known-gaps.yaml
@@ -1,0 +1,18 @@
+# expect: stackKnownGapsMissing
+# knownGaps is omitted rather than empty. `knownGaps: []` is a claim that there
+# are none; leaving it out is an oversight, and the two must not look the same.
+schemaVersion: 1
+id: missing-known-gaps
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [node, npm]
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/needs-docker.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/needs-docker.yaml
@@ -1,0 +1,19 @@
+# expect: stackBinaryUnavailable
+# Requires a binary marked unavailable. No declaration makes this stack runnable,
+# so it is refused rather than submitted.
+schemaVersion: 1
+id: needs-docker
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [node, npm, docker]
+knownGaps: []
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/needs-func-undeclared.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/needs-func-undeclared.yaml
@@ -1,0 +1,20 @@
+# expect: stackBinaryAbsentUndeclared
+# The live failure, as a fixture: requires func, which the container does not
+# have, and says nothing about it. This is exactly how five missing-binary reds
+# came to be read as five broken gates.
+schemaVersion: 1
+id: needs-func-undeclared
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: functions
+runtime:
+  binaries: [node, npm, func]
+knownGaps: []
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/overrides-model.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/overrides-model.yaml
@@ -1,0 +1,23 @@
+# expect: stackForeignKey
+# Reaches into base.yaml. modelSelector.id is half the CES queueing key, so this
+# would move runs into a different queue — invisible in the result, unrecoverable
+# afterwards.
+schemaVersion: 1
+id: overrides-model
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [node, npm]
+knownGaps: []
+phases: [plan]
+modelSelector:
+  id: some-other-model
+  vendor: copilot

--- a/evals/msbench/config/__fixtures__/stacks-invalid/prompt-names-rails.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/prompt-names-rails.yaml
@@ -1,0 +1,19 @@
+# expect: stackPromptNamesRails
+# The prompt describes the machinery instead of the app, so the baseline arm —
+# plain Copilot, no guided flow — could not reuse it without a rewrite per stack.
+schemaVersion: 1
+id: prompt-names-rails
+name: Fixture
+ecosystem: node
+prompt: |
+  Build a warehouse inventory API. Start by writing requirements.json, then
+  generate project-plan.md and scaffold from it.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [node, npm]
+knownGaps: []
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/stale-gap-binary-present.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/stale-gap-binary-present.yaml
@@ -1,0 +1,24 @@
+# expect: stackKnownGapBinaryPresent
+# The slow failure this schema is most afraid of: a gap that was true once. The
+# binary is in the container now, but the entry still explains away every red the
+# gate produces — suppressing a real failure for as long as nobody rereads it.
+schemaVersion: 1
+id: stale-gap-binary-present
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [node, npm]
+knownGaps:
+  - gates: [runtime-app-starts]
+    reason: ecosystemNotSupported
+    binary: node
+    tracking: stale — node has been present all along
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/typo-in-project-key.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/typo-in-project-key.yaml
@@ -1,0 +1,20 @@
+# expect: stackProjectUnknownKey
+# `frontent` is a typo. In a permissive schema it would leave `frontend` at its
+# default and quietly change which gates are wired — invisible in review, and
+# expensive in a run that has already been paid for.
+schemaVersion: 1
+id: typo-in-project-key
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontent: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [node, npm]
+knownGaps: []
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/unknown-binary.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/unknown-binary.yaml
@@ -1,0 +1,20 @@
+# expect: stackBinaryUnknown
+# Requires something container.yaml says nothing about. An unlisted binary is an
+# unanswered question, and the whole point is that it gets answered before a run
+# rather than during one.
+schemaVersion: 1
+id: unknown-binary
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [node, npm, rustc]
+knownGaps: []
+phases: [plan]

--- a/evals/msbench/config/__fixtures__/stacks-invalid/unknown-phase.yaml
+++ b/evals/msbench/config/__fixtures__/stacks-invalid/unknown-phase.yaml
@@ -1,0 +1,19 @@
+# expect: stackPhaseUnknown
+# Names a phase with no config/phases/<p>.yaml. Caught here rather than after the
+# config has been built and submitted.
+schemaVersion: 1
+id: unknown-phase
+name: Fixture
+ecosystem: node
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API.
+project:
+  frontend: none
+  api: http
+  datastore: none
+  hosting: appService
+runtime:
+  binaries: [node, npm]
+knownGaps: []
+phases: [plan, deploy]

--- a/evals/msbench/config/container.yaml
+++ b/evals/msbench/config/container.yaml
@@ -1,0 +1,131 @@
+# What the MSBench container actually has on PATH.
+#
+# This file exists so that "this stack needs a binary we do not have" is a
+# millisecond-scale error on a developer machine, instead of a discovery made
+# forty minutes into a run that has already been paid for.
+#
+# Three states, and the third is the one that earns the file:
+#
+#   present      — on PATH. Nothing to do.
+#   absent       — not on PATH, but installable in the run preamble. `install:`
+#                  carries the command, so the resulting NOT_APPLICABLE red is
+#                  one actionable line rather than an investigation. A stack may
+#                  require one of these only if it also declares the matching
+#                  `knownGaps` entry, which is what keeps the red *expected*
+#                  rather than mysterious.
+#   unavailable  — there is no practical path to having it here. A stack that
+#                  requires one is rejected outright; no run is submitted.
+#
+# ## `evidence:` — read this before trusting a row
+#
+# Every row says whether it was **measured** in the container or merely
+# **asserted** from documentation. Most of this file is currently `asserted`:
+# it comes from the project brief and from msbench/README.md, both of which are
+# prose written by people (including us) repeating each other. Prose is how an
+# assumption survives being wrong.
+#
+# Making a row `measured` costs nothing. Every stimulus already ends with an
+# `Environment fingerprint for triage` exec: assertion that runs shell in the
+# container with `assertZeroExitCode: false` — recorded, never asserted on.
+# Extending that line with:
+#
+#   command -v pip3 go dotnet docker azd func; python3 -m ensurepip --version
+#
+# makes the next run anybody submits, for any reason, return the real inventory
+# as a free rider. Until that lands, treat every `asserted` row as a hypothesis
+# and say so out loud when quoting it.
+#
+# Consumed by evals/src/containerInventory.ts. Checked by `npm run stacks:check`.
+
+schemaVersion: 1
+
+# Bumped whenever a row moves between statuses or gains measurement.
+verifiedOn: '2026-08-25'
+
+binaries:
+  # Measured: msbench/README.md records "Verified in the container: Node
+  # v22.22.2 on Linux x86_64", which is past the 22.18 cutoff where TypeScript
+  # type-stripping is on by default. That is why the graders run off source.
+  node:
+    status: present
+    version: 22.22.2
+    evidence: measured
+
+  npm:
+    status: present
+    evidence: asserted
+
+  # Present, but see `pip` below — a Python interpreter you cannot install
+  # packages into runs the standard library and nothing else, which is the
+  # single fact standing between us and a Python stack.
+  python3:
+    status: present
+    version: '3.10'
+    evidence: asserted
+
+  az:
+    status: present
+    evidence: asserted
+
+  git:
+    status: present
+    evidence: asserted
+
+  make:
+    status: present
+    evidence: asserted
+
+  gcc:
+    status: present
+    evidence: asserted
+
+  curl:
+    status: present
+    evidence: asserted
+
+  # The most consequential row in the file. Every stimulus we run today is Azure
+  # Functions, so all five runtime-* gates emit `functionsHostUnavailable` on
+  # every single run — the 0-for-N pattern that gate-health.ts exists to flag,
+  # except here the gates are fine and the container is the problem.
+  func:
+    status: absent
+    install: npm install -g azure-functions-core-tools@4 --unsafe-perm true
+    evidence: asserted
+
+  # `install: unverified` means: we believe it is absent, and we have not
+  # established that installing it works. That is deliberately not the same as
+  # `unavailable` — it is an unanswered question, not a closed door, and a stack
+  # requiring one should expect to answer it before the schema will let it run.
+  pip:
+    status: absent
+    install: unverified
+    evidence: asserted
+
+  dotnet:
+    status: absent
+    install: unverified
+    evidence: asserted
+
+  go:
+    status: absent
+    install: unverified
+    evidence: asserted
+
+  azd:
+    status: absent
+    install: unverified
+    evidence: asserted
+
+  java:
+    status: absent
+    install: unverified
+    evidence: asserted
+
+  # The closed door. Not merely missing: a container runtime inside the eval
+  # container is not practically installable, so a stack whose datastore needs
+  # one (the `datastoreRequiresContainer` reason code) cannot be made to work by
+  # trying harder. Rejected at build time rather than discovered at runtime.
+  docker:
+    status: unavailable
+    note: a container runtime is not practically installable inside the MSBench container
+    evidence: asserted

--- a/evals/msbench/config/stacks/node-express-postgres.yaml
+++ b/evals/msbench/config/stacks/node-express-postgres.yaml
@@ -1,0 +1,78 @@
+# The second stack, and the one that proves the schema is a schema rather than a
+# hypothesis with one instance in it.
+#
+# It differs from react-functions-postgres on four axes the derivation actually
+# reads — hosting, frontend, start-command rung, and the routes it contracts for
+# — rather than on its name.
+#
+# ## Why this one, out of everything we could have added
+#
+# Every stimulus today is Azure Functions and the container has no `func`, so all
+# five runtime-* gates have never once run. An Express app starts from
+# package.json `scripts.start`, which src/runtime/runtimeTarget.ts already
+# resolves and evals/grader-certification/reference-node-fullstack already
+# certifies. So the second stack buys the suite its **first real runtime signal**
+# as a side effect of proving the schema — two results for one piece of work.
+#
+# ## What it does not buy, stated before anyone is disappointed
+#
+# `runtime-crud` cannot run here, and the schema is how we found that out at
+# authoring time rather than after paying for a run: the CRUD probe refuses to
+# exercise a round-trip through a datastore that needs a server, because there is
+# no Docker in the container. That is declared below. `runtime-app-starts` and
+# `runtime-health` do run, which is two more than today.
+
+schemaVersion: 1
+id: node-express-postgres
+name: Express API on App Service with PostgreSQL
+ecosystem: node
+
+# Note what this prompt does not say: anything about how it will be built. No
+# artifact names, no agent names, no mention of the guided flow. That is a rule
+# the validator enforces, and the reason is a second axis we will want later —
+# the baseline arm, where plain Copilot builds the same project from a
+# hand-written prompt so we can measure what the guided flow is worth. A prompt
+# that describes only the app is usable by both arms unchanged.
+prompt: |
+  I need a backend API for tracking warehouse inventory — products, quantities
+  and locations. No UI, just the API. It should expose a health endpoint and
+  routes to list and create items, store the data in PostgreSQL, and run on
+  Azure App Service.
+
+project:
+  # Three frontend-shaped gates have nothing to look at here, and this single
+  # line is what unwires them. That is the whole idea: a fact anyone can check
+  # against the prompt, rather than a list of gate names nobody can review.
+  frontend: none
+  api: http
+  datastore: postgres
+  hosting: appService
+  # Both routes are declared because the prompt asks for both. This has a
+  # consequence worth stating: today a scaffold that forgets its health endpoint
+  # makes runtime-health report `noHealthPathDeclared`, which is classed
+  # outOfScope — so **an agent that ships no health endpoint currently gets a
+  # pass**. Declaring it here turns that silent pass into a real verdict.
+  healthPath: /api/health
+  collectionRoute: /api/items
+
+runtime:
+  binaries: [node, npm]
+  # No `start:` block, for the same reason as the other stack: rungs 1 and 2 of
+  # the discovery chain answer correctly for Node, and a declared command would
+  # replace working discovery with a guess about the layout the agent picks.
+
+knownGaps:
+  - gates: [runtime-crud]
+    reason: datastoreRequiresContainer
+    # Deliberately no `binary:`. The missing piece is a PostgreSQL *server*, not
+    # a binary this stack runs, and `docker` is marked unavailable in
+    # config/container.yaml — listing it under runtime.binaries would (correctly)
+    # get this stack refused outright.
+    tracking: >-
+      A CRUD round-trip needs a database server and the eval container has no
+      Docker, which is not practically installable there. Closing this needs
+      either a managed test database reachable from the container or a stack
+      variant that persists in memory — the latter is one data file, which is
+      the point of the schema.
+
+phases: [plan]

--- a/evals/msbench/config/stacks/react-functions-postgres.yaml
+++ b/evals/msbench/config/stacks/react-functions-postgres.yaml
@@ -1,0 +1,61 @@
+# The suite as it exists today, written down as data for the first time.
+#
+# Every stimulus we run is this shape — React frontend, Azure Functions backend,
+# a relational store — and none of them said so anywhere a tool could read. That
+# is why all five runtime-* gates have been red on every run and nobody could
+# point at the one-line cause.
+#
+# This file changes no run. It exists so the second stack has something to differ
+# from, and so the `func` problem is stated in a place that can refuse things.
+
+schemaVersion: 1
+id: react-functions-postgres
+name: React frontend with an Azure Functions API and PostgreSQL
+ecosystem: node
+
+# Mirrors config/stimuli/photo-app-requirements.yaml, the default stimulus, word
+# for word in substance. Note what it does NOT ask for: a health endpoint, or a
+# list/create route. That silence is deliberate and is reflected in `project:`
+# below — declaring a contract the prompt never asked for would grade the agent
+# against a requirement nobody gave it.
+prompt: |
+  I'd like to create an app where you can upload photos and they get stored
+  with metadata like who uploaded them and when. I want a nice React frontend
+  and an Azure Functions backend with PostgreSQL for the data. Make it with
+  full test coverage.
+
+project:
+  frontend: spa
+  api: http
+  datastore: postgres
+  hosting: functions
+  # healthPath and collectionRoute are deliberately absent: the prompt does not
+  # ask for either, so the gates that look for them have nothing to grade here.
+
+runtime:
+  # `func` is listed even though it is missing, which is the point. Listing it is
+  # what makes the container check notice, and what makes the gap below required
+  # rather than optional.
+  binaries: [node, npm, func]
+  # No `start:` block. Rungs 1 and 2 of the discovery chain in
+  # src/runtime/runtimeTarget.ts (launch.json, then package.json `scripts.start`)
+  # answer correctly for a Node project, and a declared start command here would
+  # have to guess the directory layout the agent picks — replacing working
+  # discovery with an assumption. Rung 0 earns its keep on stacks where rungs 1
+  # and 2 structurally cannot answer, which means the non-Node ones.
+
+knownGaps:
+  # The 0-for-N story, in data. These three gates are wired (the project has a
+  # frontend and an app to start), they have a real question to ask, and they
+  # cannot ask it because the Functions host is not in the container. They stay
+  # red on purpose: "we are not testing something we claim to test" is true, and
+  # a green here would be a lie that no later report could undo.
+  - gates: [runtime-app-starts, runtime-frontend, runtime-frontend-api]
+    reason: functionsHostUnavailable
+    binary: func
+    tracking: >-
+      Install azure-functions-core-tools in the run preamble (see the install
+      command in config/container.yaml). Until then every Functions stack pays
+      three reds per run for a missing binary.
+
+phases: [plan]

--- a/evals/package.json
+++ b/evals/package.json
@@ -12,6 +12,7 @@
         "typecheck": "tsc --noEmit -p tsconfig.json",
         "imports:self-test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON msbench/importScanner.ts --self-test",
         "certify": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON src/graderCertification.ts",
+        "stacks:check": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON check-stacks.ts",
         "regrade": "node --disable-warning=ExperimentalWarning msbench/regrade.ts",
         "gate-health": "node --disable-warning=ExperimentalWarning msbench/gate-health.ts",
         "ci:local": "node ci-local.ts",

--- a/evals/src/configValidation.ts
+++ b/evals/src/configValidation.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * The rejection contract shared by the stack schema and the container inventory.
+ *
+ * `src/scenario.ts` is the precedent for hand-written validation here, and this
+ * follows it in every respect but one: a rejection carries a **stable `code`**
+ * alongside its prose.
+ *
+ * That is not decoration. The house rule is that a check is not done until a
+ * deliberately broken fixture makes it fail, and a fixture asserting only "it
+ * threw" is satisfied by a validator that throws for the wrong reason — a typo
+ * in the validator that rejects every file would pass such a test suite
+ * completely. `npm run stacks:check` asserts the *code*, so each fixture proves
+ * the specific rule it was written for, and a rule that stops working is a red
+ * naming itself rather than a silence.
+ *
+ * The prose still matters, and is written for the person who hits it: it says
+ * what to do, not merely what is wrong. A validator that only says "invalid"
+ * has moved the investigation rather than removed it.
+ */
+
+/** A configuration file was rejected. `code` is the stable identity of the rule. */
+export class ConfigValidationError extends Error {
+    readonly code: string;
+    readonly file: string;
+
+    constructor(code: string, file: string, message: string) {
+        super(`[${code}] ${file}: ${message}`);
+        this.name = 'ConfigValidationError';
+        this.code = code;
+        this.file = file;
+    }
+}
+
+export function reject(code: string, file: string, message: string): never {
+    throw new ConfigValidationError(code, file, message);
+}
+
+/** Narrow an unknown parsed YAML document to a plain object, or reject. */
+export function requireObject(value: unknown, code: string, file: string, what: string): Record<string, unknown> {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        reject(code, file, `${what} must be a YAML mapping.`);
+    }
+    return value as Record<string, unknown>;
+}
+
+export function requireString(value: unknown, code: string, file: string, what: string): string {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+        reject(code, file, `${what} must be a non-empty string.`);
+    }
+    return value;
+}
+
+/**
+ * Reject any key the schema does not define.
+ *
+ * Deliberately strict, and the reason is specific to this suite: an unrecognised
+ * key is almost always a typo, and a typo in a *permissive* schema is silent —
+ * `frontent: none` would leave `frontend` at its default and quietly change
+ * which gates are wired. That failure is invisible in review and expensive in a
+ * paid run, so it is spelled as an error while it still costs nothing.
+ */
+export function rejectUnknownKeys(
+    object: Record<string, unknown>,
+    known: readonly string[],
+    code: string,
+    file: string,
+    what: string,
+): void {
+    const unknown = Object.keys(object).filter(key => !known.includes(key));
+    if (unknown.length > 0) {
+        reject(
+            code,
+            file,
+            `${what} has ${unknown.length === 1 ? 'an unrecognised key' : 'unrecognised keys'}: ${unknown.join(', ')}. `
+            + `Known keys are: ${[...known].sort().join(', ')}. An unrecognised key is usually a typo, and a typo that `
+            + `is tolerated here changes which gates are wired without saying so.`,
+        );
+    }
+}
+
+export function requireEnum<T extends string>(
+    value: unknown,
+    allowed: readonly T[],
+    code: string,
+    file: string,
+    what: string,
+): T {
+    if (typeof value !== 'string' || !allowed.includes(value as T)) {
+        reject(code, file, `${what} must be one of: ${allowed.join(', ')}. Found: ${JSON.stringify(value)}.`);
+    }
+    return value as T;
+}

--- a/evals/src/containerInventory.ts
+++ b/evals/src/containerInventory.ts
@@ -1,0 +1,151 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Load and validate `msbench/config/container.yaml` — what the eval container has.
+ *
+ * The point of turning this into data is that a stack declaring `binaries: [go]`
+ * can be refused *before* a run is submitted. The knowledge already existed; it
+ * lived in prose in a README and in people's heads, where it could not stop
+ * anything from happening.
+ *
+ * This module reads facts and makes no policy decisions. Whether an `absent`
+ * binary is acceptable is a question about a *stack* and is answered in
+ * `stack.ts`; whether the run is worth submitting is a question for a human.
+ */
+
+import { readFileSync } from 'node:fs';
+import { parse as parseYaml } from 'yaml';
+import { ConfigValidationError, reject, requireEnum, requireObject, requireString, rejectUnknownKeys } from './configValidation.ts';
+
+/**
+ * `absent` and `unavailable` are both "not on PATH", and the difference between
+ * them is the only thing a stack author needs from this file:
+ *
+ *   absent      — installable in the run preamble. Requiring it is allowed, at
+ *                 the price of declaring the gap it causes.
+ *   unavailable — no practical path. Requiring it is refused outright.
+ */
+export type BinaryStatus = 'present' | 'absent' | 'unavailable';
+const BINARY_STATUSES: readonly BinaryStatus[] = ['present', 'absent', 'unavailable'];
+
+/**
+ * Whether a row was observed in the container or copied from documentation.
+ *
+ * Carried per row rather than per file because the file is currently a mixture,
+ * and averaging that into a single sentence at the top is how "mostly verified"
+ * becomes "verified". A consumer that wants to report the difference can.
+ */
+export type Evidence = 'measured' | 'asserted';
+const EVIDENCE_VALUES: readonly Evidence[] = ['measured', 'asserted'];
+
+export interface BinaryFact {
+    name: string;
+    status: BinaryStatus;
+    version?: string;
+    /** For `absent`: the preamble command that would supply it, or `unverified`. */
+    install?: string;
+    /** For `unavailable`: why there is no path. */
+    note?: string;
+    evidence: Evidence;
+}
+
+export interface ContainerInventory {
+    schemaVersion: 1;
+    verifiedOn: string;
+    binaries: Map<string, BinaryFact>;
+    /** Absolute path of the file these facts came from, for error messages. */
+    sourcePath: string;
+}
+
+const ROOT_KEYS = ['schemaVersion', 'verifiedOn', 'binaries'] as const;
+const BINARY_KEYS = ['status', 'version', 'install', 'note', 'evidence'] as const;
+
+export function loadContainerInventory(filePath: string): ContainerInventory {
+    let text: string;
+    try {
+        text = readFileSync(filePath, 'utf8');
+    } catch {
+        throw new ConfigValidationError('containerInventoryMissing', filePath, 'the container inventory could not be read.');
+    }
+    return parseContainerInventory(text, filePath);
+}
+
+export function parseContainerInventory(text: string, filePath: string): ContainerInventory {
+    let parsed: unknown;
+    try {
+        parsed = parseYaml(text);
+    } catch (error) {
+        reject('containerInventoryUnparseable', filePath, `not valid YAML: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    const root = requireObject(parsed, 'containerInventoryNotObject', filePath, 'the container inventory');
+    rejectUnknownKeys(root, ROOT_KEYS, 'containerInventoryUnknownKey', filePath, 'the container inventory');
+
+    if (root.schemaVersion !== 1) {
+        reject('containerInventorySchemaVersion', filePath, 'schemaVersion must be 1.');
+    }
+    const verifiedOn = requireString(root.verifiedOn, 'containerInventoryVerifiedOn', filePath, 'verifiedOn');
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(verifiedOn)) {
+        reject('containerInventoryVerifiedOn', filePath, `verifiedOn must be an ISO date (YYYY-MM-DD). Found: ${verifiedOn}.`);
+    }
+
+    const binariesNode = requireObject(root.binaries, 'containerInventoryBinaries', filePath, 'binaries');
+    const binaries = new Map<string, BinaryFact>();
+    for (const [name, value] of Object.entries(binariesNode)) {
+        binaries.set(name, parseBinary(name, value, filePath));
+    }
+    if (binaries.size === 0) {
+        reject('containerInventoryBinaries', filePath, 'binaries must describe at least one binary.');
+    }
+
+    return { schemaVersion: 1, verifiedOn, binaries, sourcePath: filePath };
+}
+
+function parseBinary(name: string, value: unknown, filePath: string): BinaryFact {
+    const entry = requireObject(value, 'containerBinaryNotObject', filePath, `binaries.${name}`);
+    rejectUnknownKeys(entry, BINARY_KEYS, 'containerBinaryUnknownKey', filePath, `binaries.${name}`);
+
+    const status = requireEnum(entry.status, BINARY_STATUSES, 'containerBinaryStatus', filePath, `binaries.${name}.status`);
+    const evidence = requireEnum(entry.evidence, EVIDENCE_VALUES, 'containerBinaryEvidence', filePath, `binaries.${name}.evidence`);
+
+    // Each status carries the field that makes it actionable, and is rejected
+    // without it. An `absent` row with no `install:` is the shape that sends
+    // someone to go and find out what everybody else already knew, which is the
+    // cost this file was written to remove.
+    if (status === 'absent' && typeof entry.install !== 'string') {
+        reject(
+            'containerBinaryInstallMissing',
+            filePath,
+            `binaries.${name} is absent and must carry install: — either the preamble command that supplies it, `
+            + `or the literal 'unverified' to say we have not established one.`,
+        );
+    }
+    if (status === 'unavailable' && typeof entry.note !== 'string') {
+        reject(
+            'containerBinaryNoteMissing',
+            filePath,
+            `binaries.${name} is unavailable and must carry note: explaining why there is no path to having it. `
+            + `Refusing a stack outright needs a reason the reader can check.`,
+        );
+    }
+    if (status === 'present' && entry.install !== undefined) {
+        reject('containerBinaryInstallOnPresent', filePath, `binaries.${name} is present, so install: is dead text.`);
+    }
+
+    return {
+        name,
+        status,
+        version: typeof entry.version === 'string' ? entry.version : undefined,
+        install: typeof entry.install === 'string' ? entry.install : undefined,
+        note: typeof entry.note === 'string' ? entry.note : undefined,
+        evidence,
+    };
+}
+
+/** How many rows are documentation rather than observation. Reported, not enforced. */
+export function countAsserted(inventory: ContainerInventory): number {
+    return [...inventory.binaries.values()].filter(fact => fact.evidence === 'asserted').length;
+}

--- a/evals/src/stack.ts
+++ b/evals/src/stack.ts
@@ -1,0 +1,612 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * The stack schema: `msbench/config/stacks/<id>.yaml`.
+ *
+ * ## What a stack is, in one sentence
+ *
+ * A stack is **a project type expressed as data**, so that adding Python or C#
+ * to the suite is a file rather than a fork.
+ *
+ * Every stimulus today is React + Azure Functions, hard-coded, and adding a
+ * different project type means copying a YAML file and hand-editing eight
+ * assertions. That is the thing this replaces.
+ *
+ * ## The load-bearing idea: a stack declares facts, not gates
+ *
+ * The obvious design is `gates: [runtime-health, runtime-crud, ...]` per stack.
+ * It is the wrong shape, for two reasons that only get worse with time:
+ *
+ * 1. **It rots, in the direction that looks safe.** Thirty gates times N stacks
+ *    is a matrix maintained by hand, and adding gate 31 means editing every
+ *    stack file. The failure is a gate quietly not being wired anywhere — which
+ *    reads as a clean run, and is the `never-attempted` signal `gate-health.ts`
+ *    exists to catch.
+ * 2. **It records a conclusion without its premise.** "runtime-frontend does not
+ *    apply here" cannot be reviewed by anyone who has not read that gate.
+ *    `frontend: none` can be reviewed by anyone who has read the prompt.
+ *
+ * So a stack declares what the project *has* — `project:` — and applicability is
+ * computed from those facts against a central gate table. That derivation lands
+ * in the next PR; this file is the vocabulary it will read, and validating the
+ * vocabulary first is what makes that PR small.
+ *
+ * ## Why this makes `outOfScope` an alarm rather than noise
+ *
+ * A grader that cannot answer emits `NOT_APPLICABLE ... class=outOfScope` and
+ * exits 3. `outOfScope` means the gate should never have been wired to this
+ * stack. Under fact-derived wiring, a gate is only ever attached when the stack
+ * declared the thing it looks at — so:
+ *
+ *   **an `outOfScope` marker in a run is a bug report against this schema.**
+ *   It means the derivation is wrong, or a stack lied about its project. It is
+ *   never expected noise, and whoever sees the first one should treat it as a
+ *   defect here rather than as something to be explained away.
+ *
+ * That claim is deliberately falsifiable. If `outOfScope` markers keep arriving
+ * from correctly-written stacks, this design is wrong and should be replaced.
+ *
+ * ## What a stack may NOT decide
+ *
+ * A stack may only decide things no existing layer decides. `base.yaml` owns the
+ * model, the timeouts and the VSIX; `phases/<p>.yaml` owns the chat mode and the
+ * workspace seeding. Those are refused here rather than silently overridden —
+ * `modelSelector.id` is half the CES queueing key, so a stack quietly changing
+ * it would move runs into a different queue, which is undetectable from the
+ * result and unrecoverable after the fact.
+ *
+ * @see msbench/config/container.yaml — what the container has, and so what a stack may need.
+ * @see graders/graderHarness.ts — the exit-code and NOT_APPLICABLE contract this serves.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { Ecosystem } from './artifacts/scaffoldTree.ts';
+import { DATASTORE_NOT_APPLICABLE_CODES } from './artifacts/datastoreFidelity.ts';
+import { RUNTIME_NOT_APPLICABLE_CLASS } from './runtime/runtimeTarget.ts';
+import type { PortRemap } from './runtime/runtimeTarget.ts';
+import { ConfigValidationError, reject, requireEnum, requireObject, requireString, rejectUnknownKeys } from './configValidation.ts';
+import type { BinaryFact, ContainerInventory } from './containerInventory.ts';
+
+/**
+ * `Ecosystem` is imported rather than re-declared, so the stack vocabulary cannot
+ * drift from the one the fidelity analysers already speak — and `'go'` is added
+ * here, on purpose, to say something true: a Go project is *expressible* as a
+ * stack, and is *not* understood by those analysers. That gap is the whole story
+ * of a Go stack (see `knownGaps` below), and the type says it out loud.
+ */
+export type StackEcosystem = Ecosystem | 'go';
+const STACK_ECOSYSTEMS: readonly StackEcosystem[] = ['node', 'python', 'dotnet', 'go'];
+
+/** The binary each ecosystem cannot run without. Used for a coherence check. */
+const ECOSYSTEM_BINARY: Record<StackEcosystem, string> = {
+    node: 'node',
+    python: 'python3',
+    dotnet: 'dotnet',
+    go: 'go',
+};
+
+export type FrontendKind = 'none' | 'spa';
+export type ApiKind = 'none' | 'http';
+export type DatastoreKind = 'none' | 'postgres' | 'cosmos' | 'blob' | 'queue';
+export type HostingKind = 'appService' | 'functions' | 'containerApps';
+
+const FRONTEND_KINDS: readonly FrontendKind[] = ['none', 'spa'];
+const API_KINDS: readonly ApiKind[] = ['none', 'http'];
+const DATASTORE_KINDS: readonly DatastoreKind[] = ['none', 'postgres', 'cosmos', 'blob', 'queue'];
+const HOSTING_KINDS: readonly HostingKind[] = ['appService', 'functions', 'containerApps'];
+
+/**
+ * The facts gates are wired from.
+ *
+ * Every field answers "does this project have the thing some gate looks at?".
+ * A field that no gate would ever read does not belong here — it belongs in the
+ * prompt.
+ */
+export interface StackProject {
+    frontend: FrontendKind;
+    api: ApiKind;
+    datastore: DatastoreKind;
+    hosting: HostingKind;
+    /** The liveness endpoint, when there is one. Absent means the health gate has nothing to ask. */
+    healthPath?: string;
+    /** A list/create route, when there is one. Absent means the CRUD gate has nothing to ask. */
+    collectionRoute?: string;
+}
+
+/**
+ * Rung 0 of the start-command discovery chain in `runtime/runtimeTarget.ts`.
+ *
+ * That module already reserves `'stackDeclaration'` in `StartSource`,
+ * `PortSource` and `HealthPathSource` — this is the declaration those literals
+ * were waiting for. Consuming it is a later PR; the shape is fixed here so the
+ * two cannot be designed against different pictures of each other.
+ */
+export interface StackStart {
+    command: string;
+    args: string[];
+    /** Workspace-relative directory to run in. */
+    cwd: string;
+    port?: {
+        value: number;
+        remap?: PortRemap;
+    };
+}
+
+export interface StackRuntime {
+    /** Everything that must be on PATH for this stack's gates to run. */
+    binaries: string[];
+    start?: StackStart;
+}
+
+/**
+ * A gate that is wired, applies, and is expected to be red for a reason that is
+ * not the product's fault.
+ *
+ * This does **not** suppress anything. `coverageGap` reds are correct to stay
+ * red — they are a true statement that we are not testing something we claim to
+ * test — and hiding them would be the inflated-green failure in a new costume.
+ * What a declaration buys is *grouping*: gate-health can report "five gates red,
+ * all `functionsHostUnavailable`, declared" instead of "five gates broken".
+ *
+ * Every entry costs money on every run and returns no information, so an empty
+ * `knownGaps` is the goal and a growing one is a bill.
+ */
+export interface StackKnownGap {
+    /** Gate ids, as produced by `gateId()` — the grader filename minus `validate-`. */
+    gates: string[];
+    /** A reason code from the closed vocabulary the graders already emit. */
+    reason: string;
+    /** The absent binary this gap is caused by, when that is the cause. */
+    binary?: string;
+    /** Where the work to close this is tracked, or one line on why it is not. */
+    tracking: string;
+}
+
+export interface Stack {
+    schemaVersion: 1;
+    id: string;
+    name: string;
+    ecosystem: StackEcosystem;
+    prompt: string;
+    project: StackProject;
+    runtime: StackRuntime;
+    knownGaps: StackKnownGap[];
+    phases: string[];
+    sourcePath: string;
+}
+
+const ROOT_KEYS = ['schemaVersion', 'id', 'name', 'ecosystem', 'prompt', 'project', 'runtime', 'knownGaps', 'phases'] as const;
+const PROJECT_KEYS = ['frontend', 'api', 'datastore', 'hosting', 'healthPath', 'collectionRoute'] as const;
+const RUNTIME_KEYS = ['binaries', 'start'] as const;
+const START_KEYS = ['command', 'args', 'cwd', 'port'] as const;
+const PORT_KEYS = ['value', 'remap'] as const;
+const KNOWN_GAP_KEYS = ['gates', 'reason', 'binary', 'tracking'] as const;
+
+/**
+ * Keys owned by `base.yaml` and `phases/<p>.yaml`, refused with a specific
+ * message rather than a generic "unrecognised key".
+ *
+ * The generic message would be correct and would teach nothing. `modelSelector`
+ * is not a typo when someone writes it — it is someone reasonably assuming a
+ * stack can pick its model, and the reason they cannot is worth one sentence at
+ * the moment they try.
+ */
+const FOREIGN_KEYS: Record<string, string> = {
+    modelSelector: 'base.yaml owns the model, and modelSelector.id is half the CES queueing key — a stack changing it '
+        + 'would silently move runs into a different queue, which cannot be seen in the result or undone afterwards.',
+    timeouts: 'base.yaml owns the timeouts; they are a per-run budget derived from the job cap, not a per-stack knob.',
+    installExtensions: 'base.yaml owns the VSIX under test. A stack changing it would grade a different build.',
+    dangerouslyAutoApproveAllToolCalls: 'base.yaml owns it; without it the webview tools block on a confirmation nothing can answer.',
+    chatMode: 'phases/<phase>.yaml owns the agent under test. If a stack needs a different agent, it needs a different phase.',
+    script: 'phases/<phase>.yaml owns workspace seeding. Per-stack seed fixtures hang off the phase, not off this file.',
+    snapshotWorkspace: 'phases/<phase>.yaml owns it, because whether snapshotting is affordable is a property of the phase.',
+    promptSteps: 'a stack supplies `prompt:`; build-config assembles promptSteps from it together with the derived assertions.',
+};
+
+/**
+ * Machinery names that must not appear in a prompt.
+ *
+ * We will eventually need a **baseline arm** — the same project built by plain
+ * Copilot with no Rails documents or tools — to measure what Rails is actually
+ * worth. That arm crosses every stack, and it is only cheap if a stack's prompt
+ * describes *the app to build* rather than *the app to build, using the Rails
+ * flow*. A prompt naming `requirements.json` is unusable by the baseline arm and
+ * would have to be rewritten, per stack, later.
+ *
+ * Note what is deliberately NOT here: the bare word "rails". A Ruby on Rails
+ * stack is a perfectly plausible future project type, and a rule that made it
+ * unaddable would be a worse bug than the one it prevents. Only the phrase and
+ * the artifact names are matched.
+ */
+const RAILS_MACHINERY = [
+    'copilot on rails',
+    'on rails',
+    'requirements.json',
+    'project-plan.md',
+    'deployment-plan.md',
+    'vscode-debug-plan.md',
+    'azure-project-plan',
+    'open_requirements_view',
+];
+
+/** The union of every NOT_APPLICABLE reason code the graders can emit today. */
+export function knownReasonCodes(): Set<string> {
+    // Composed from the gate families rather than re-typed, so a family adding a
+    // code does not need this file edited — and a family *removing* one turns a
+    // stale stack declaration into a build error instead of a lie.
+    //
+    // One family is missing on purpose: `FIDELITY_NOT_APPLICABLE` is declared
+    // inside `graders/validate-service-fidelity.ts`, and importing a grader
+    // *executes* it (every grader calls runGrader* at module top level). Its only
+    // code today is `ecosystemNotSupported`, which the runtime table already
+    // carries, so nothing is lost — but that is luck, not design. See the note on
+    // grader importability in the PR description.
+    return new Set([
+        ...Object.keys(RUNTIME_NOT_APPLICABLE_CLASS),
+        ...Object.keys(DATASTORE_NOT_APPLICABLE_CODES),
+    ]);
+}
+
+export interface StackLoadOptions {
+    inventory: ContainerInventory;
+    /** Directory holding `<phase>.yaml`, so a stack cannot name a phase that does not exist. */
+    phasesDirectory: string;
+}
+
+export function loadStack(filePath: string, options: StackLoadOptions): Stack {
+    let text: string;
+    try {
+        text = readFileSync(filePath, 'utf8');
+    } catch {
+        throw new ConfigValidationError('stackUnreadable', filePath, 'the stack file could not be read.');
+    }
+    return parseStack(text, filePath, options);
+}
+
+export function parseStack(text: string, filePath: string, options: StackLoadOptions): Stack {
+    let parsed: unknown;
+    try {
+        parsed = parseYaml(text);
+    } catch (error) {
+        reject('stackUnparseable', filePath, `not valid YAML: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    const root = requireObject(parsed, 'stackNotObject', filePath, 'a stack');
+
+    // Foreign keys are checked before unknown keys, so the specific explanation
+    // wins over the generic one.
+    for (const [key, why] of Object.entries(FOREIGN_KEYS)) {
+        if (key in root) {
+            reject('stackForeignKey', filePath, `a stack may not set '${key}'. ${why}`);
+        }
+    }
+    rejectUnknownKeys(root, ROOT_KEYS, 'stackUnknownKey', filePath, 'a stack');
+
+    if (root.schemaVersion !== 1) {
+        reject('stackSchemaVersion', filePath, 'schemaVersion must be 1.');
+    }
+
+    const id = requireString(root.id, 'stackId', filePath, 'id');
+    if (!/^[a-z0-9][a-z0-9-]+$/.test(id)) {
+        reject('stackId', filePath, `id must be kebab-case. Found: ${id}.`);
+    }
+    // The filename is the identity everything else joins on — the CLI flag, the
+    // generated config header, and eventually the run record. An id that differs
+    // from its filename means two names for one thing, and every report has to
+    // pick one.
+    const expected = basename(filePath).replace(/\.yaml$/, '');
+    if (id !== expected) {
+        reject('stackIdFilenameMismatch', filePath, `id '${id}' must match the filename '${expected}.yaml'.`);
+    }
+
+    const name = requireString(root.name, 'stackName', filePath, 'name');
+    const ecosystem = requireEnum(root.ecosystem, STACK_ECOSYSTEMS, 'stackEcosystem', filePath, 'ecosystem');
+    const prompt = parsePrompt(root.prompt, filePath);
+    const project = parseProject(root.project, filePath);
+    const runtime = parseRuntime(root.runtime, filePath);
+    const knownGaps = parseKnownGaps(root.knownGaps, filePath);
+    const phases = parsePhases(root.phases, filePath, options.phasesDirectory);
+
+    checkEcosystemBinary(ecosystem, runtime, filePath);
+    checkHostingBinary(project, runtime, filePath);
+    checkBinariesAgainstContainer(runtime, knownGaps, options.inventory, filePath);
+    checkKnownGapsAreLive(runtime, knownGaps, options.inventory, filePath);
+
+    return { schemaVersion: 1, id, name, ecosystem, prompt, project, runtime, knownGaps, phases, sourcePath: filePath };
+}
+
+function parsePrompt(value: unknown, filePath: string): string {
+    const prompt = requireString(value, 'stackPrompt', filePath, 'prompt');
+    // A one-word prompt is not a project description, and the failure it causes
+    // is a whole run of the agent guessing.
+    if (prompt.trim().length < 40) {
+        reject('stackPrompt', filePath, 'prompt must actually describe a project (at least 40 characters).');
+    }
+    const lowered = prompt.toLowerCase();
+    const found = RAILS_MACHINERY.filter(token => lowered.includes(token));
+    if (found.length > 0) {
+        reject(
+            'stackPromptNamesRails',
+            filePath,
+            `prompt names Rails machinery (${found.join(', ')}). A prompt must describe the app to build and nothing `
+            + `about how it will be built, so the same text can drive the baseline arm — plain Copilot, no Rails `
+            + `documents or tools — without being rewritten per stack.`,
+        );
+    }
+    return prompt;
+}
+
+function parseProject(value: unknown, filePath: string): StackProject {
+    const node = requireObject(value, 'stackProjectNotObject', filePath, 'project');
+    rejectUnknownKeys(node, PROJECT_KEYS, 'stackProjectUnknownKey', filePath, 'project');
+
+    const frontend = requireEnum(node.frontend, FRONTEND_KINDS, 'stackProjectFrontend', filePath, 'project.frontend');
+    const api = requireEnum(node.api, API_KINDS, 'stackProjectApi', filePath, 'project.api');
+    const datastore = requireEnum(node.datastore, DATASTORE_KINDS, 'stackProjectDatastore', filePath, 'project.datastore');
+    const hosting = requireEnum(node.hosting, HOSTING_KINDS, 'stackProjectHosting', filePath, 'project.hosting');
+
+    const healthPath = parseOptionalRoute(node.healthPath, 'project.healthPath', filePath);
+    const collectionRoute = parseOptionalRoute(node.collectionRoute, 'project.collectionRoute', filePath);
+
+    // The `validateDataStoreAlignment` pattern from scenario.ts: two fields that
+    // cannot both be true. A stack claiming no API but naming an HTTP route has
+    // one of the two wrong, and either way the derivation would wire the wrong
+    // gates — silently, since both fields are individually valid.
+    if (api === 'none' && healthPath) {
+        reject('stackHealthPathWithoutApi', filePath, 'project.healthPath is set but project.api is none — an app with no API has no health endpoint.');
+    }
+    if (api === 'none' && collectionRoute) {
+        reject('stackRouteWithoutApi', filePath, 'project.collectionRoute is set but project.api is none — an app with no API has no routes.');
+    }
+
+    return { frontend, api, datastore, hosting, healthPath, collectionRoute };
+}
+
+function parseOptionalRoute(value: unknown, what: string, filePath: string): string | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    const route = requireString(value, 'stackRouteShape', filePath, what);
+    if (!route.startsWith('/')) {
+        reject('stackRouteShape', filePath, `${what} must be a path beginning with '/'. Found: ${route}.`);
+    }
+    return route;
+}
+
+function parseRuntime(value: unknown, filePath: string): StackRuntime {
+    const node = requireObject(value, 'stackRuntimeNotObject', filePath, 'runtime');
+    rejectUnknownKeys(node, RUNTIME_KEYS, 'stackRuntimeUnknownKey', filePath, 'runtime');
+
+    if (!Array.isArray(node.binaries) || node.binaries.length === 0
+        || node.binaries.some(entry => typeof entry !== 'string' || entry.length === 0)) {
+        reject('stackRuntimeBinaries', filePath, 'runtime.binaries must be a non-empty list of binary names.');
+    }
+    const binaries = node.binaries as string[];
+    const duplicates = binaries.filter((entry, index) => binaries.indexOf(entry) !== index);
+    if (duplicates.length > 0) {
+        reject('stackRuntimeBinaries', filePath, `runtime.binaries lists ${[...new Set(duplicates)].join(', ')} more than once.`);
+    }
+
+    return { binaries, start: node.start === undefined ? undefined : parseStart(node.start, filePath) };
+}
+
+function parseStart(value: unknown, filePath: string): StackStart {
+    const node = requireObject(value, 'stackStartNotObject', filePath, 'runtime.start');
+    rejectUnknownKeys(node, START_KEYS, 'stackStartUnknownKey', filePath, 'runtime.start');
+
+    const command = requireString(node.command, 'stackStartCommand', filePath, 'runtime.start.command');
+    if (node.args !== undefined && (!Array.isArray(node.args) || node.args.some(entry => typeof entry !== 'string'))) {
+        reject('stackStartArgs', filePath, 'runtime.start.args must be a list of strings.');
+    }
+    const cwd = requireString(node.cwd, 'stackStartCwd', filePath, 'runtime.start.cwd');
+    if (cwd.startsWith('/') || cwd.includes('..')) {
+        reject('stackStartCwd', filePath, `runtime.start.cwd must be workspace-relative and must not escape it. Found: ${cwd}.`);
+    }
+
+    return {
+        command,
+        args: (node.args as string[] | undefined) ?? [],
+        cwd,
+        port: node.port === undefined ? undefined : parsePort(node.port, filePath),
+    };
+}
+
+function parsePort(value: unknown, filePath: string): { value: number; remap?: PortRemap } {
+    const node = requireObject(value, 'stackPortNotObject', filePath, 'runtime.start.port');
+    rejectUnknownKeys(node, PORT_KEYS, 'stackPortUnknownKey', filePath, 'runtime.start.port');
+
+    const port = node.value;
+    if (typeof port !== 'number' || !Number.isInteger(port) || port < 1 || port > 65535) {
+        reject('stackPortValue', filePath, `runtime.start.port.value must be an integer between 1 and 65535. Found: ${JSON.stringify(port)}.`);
+    }
+    if (node.remap === undefined) {
+        return { value: port };
+    }
+
+    // Mirrors `PortRemap` in runtimeTarget.ts. The runtime gates move the app to
+    // a free port to avoid colliding with whatever else is on the machine, and a
+    // remap that cannot be applied means the gate cannot run at all.
+    const remapNode = requireObject(node.remap, 'stackPortRemap', filePath, 'runtime.start.port.remap');
+    const kind = requireEnum(remapNode.kind, ['env', 'arg'] as const, 'stackPortRemap', filePath, 'runtime.start.port.remap.kind');
+    if (kind === 'env') {
+        return { value: port, remap: { kind: 'env', key: requireString(remapNode.key, 'stackPortRemap', filePath, 'runtime.start.port.remap.key') } };
+    }
+    const index = remapNode.index;
+    if (typeof index !== 'number' || !Number.isInteger(index) || index < 0) {
+        reject('stackPortRemap', filePath, 'runtime.start.port.remap.index must be a non-negative integer.');
+    }
+    return { value: port, remap: { kind: 'arg', index } };
+}
+
+function parseKnownGaps(value: unknown, filePath: string): StackKnownGap[] {
+    if (value === undefined) {
+        reject('stackKnownGapsMissing', filePath, "knownGaps must be present. Write `knownGaps: []` to say there are none — an empty list is a claim, and an omitted one is an oversight.");
+    }
+    if (!Array.isArray(value)) {
+        reject('stackKnownGapsMissing', filePath, 'knownGaps must be a list.');
+    }
+
+    const reasons = knownReasonCodes();
+    return (value as unknown[]).map((entry, index) => {
+        const node = requireObject(entry, 'stackKnownGapNotObject', filePath, `knownGaps[${index}]`);
+        rejectUnknownKeys(node, KNOWN_GAP_KEYS, 'stackKnownGapUnknownKey', filePath, `knownGaps[${index}]`);
+
+        if (!Array.isArray(node.gates) || node.gates.length === 0
+            || node.gates.some(gate => typeof gate !== 'string' || !/^[a-z0-9][a-z0-9-]+$/.test(gate))) {
+            reject('stackKnownGapGates', filePath, `knownGaps[${index}].gates must be a non-empty list of kebab-case gate ids.`);
+        }
+        const reason = requireString(node.reason, 'stackKnownGapReason', filePath, `knownGaps[${index}].reason`);
+        if (!reasons.has(reason)) {
+            reject(
+                'stackKnownGapReason',
+                filePath,
+                `knownGaps[${index}].reason '${reason}' is not a reason code any grader emits. Known codes: `
+                + `${[...reasons].sort().join(', ')}. An invented code cannot be grouped by gate-health, so the red it `
+                + `describes would arrive unexplained — which is the situation the declaration exists to prevent.`,
+            );
+        }
+        // Prose, not a link, is allowed — but *something* is required. An
+        // undeclared owner is how a gap becomes permanent: nobody is wrong to
+        // ignore it, so everybody does.
+        const tracking = requireString(node.tracking, 'stackKnownGapTracking', filePath, `knownGaps[${index}].tracking`);
+
+        return {
+            gates: node.gates as string[],
+            reason,
+            binary: typeof node.binary === 'string' ? node.binary : undefined,
+            tracking,
+        };
+    });
+}
+
+function parsePhases(value: unknown, filePath: string, phasesDirectory: string): string[] {
+    if (!Array.isArray(value) || value.length === 0 || value.some(entry => typeof entry !== 'string')) {
+        reject('stackPhases', filePath, 'phases must be a non-empty list of phase names.');
+    }
+    const phases = value as string[];
+    for (const phase of phases) {
+        if (!existsSync(join(phasesDirectory, `${phase}.yaml`))) {
+            reject('stackPhaseUnknown', filePath, `phases names '${phase}', but config/phases/${phase}.yaml does not exist.`);
+        }
+    }
+    return phases;
+}
+
+/** A stack must require the interpreter or toolchain its ecosystem cannot run without. */
+function checkEcosystemBinary(ecosystem: StackEcosystem, runtime: StackRuntime, filePath: string): void {
+    const required = ECOSYSTEM_BINARY[ecosystem];
+    if (!runtime.binaries.includes(required)) {
+        reject(
+            'stackEcosystemBinaryMissing',
+            filePath,
+            `ecosystem is '${ecosystem}', so runtime.binaries must include '${required}'. Leaving it out would hide the `
+            + `stack's most basic requirement from the container check, which is the one check meant to run before money `
+            + `is spent.`,
+        );
+    }
+}
+
+/**
+ * A Functions stack must admit it needs `func`.
+ *
+ * This is the rule written directly from the injury. Every stimulus we run is
+ * Azure Functions, the container has no `func`, and all five runtime gates have
+ * therefore been red on every run — a fact nobody had written down anywhere a
+ * tool could read. Declaring `hosting: functions` without listing the binary
+ * would reproduce exactly that silence.
+ */
+function checkHostingBinary(project: StackProject, runtime: StackRuntime, filePath: string): void {
+    if (project.hosting === 'functions' && !runtime.binaries.includes('func')) {
+        reject(
+            'stackFunctionsRequiresFunc',
+            filePath,
+            "project.hosting is 'functions', so runtime.binaries must include 'func' — the Functions host is how such an "
+            + 'app starts at all. Listing it is what makes the container check notice it is missing.',
+        );
+    }
+}
+
+function checkBinariesAgainstContainer(
+    runtime: StackRuntime,
+    knownGaps: StackKnownGap[],
+    inventory: ContainerInventory,
+    filePath: string,
+): void {
+    const declaredBinaries = new Set(knownGaps.map(gap => gap.binary).filter((name): name is string => Boolean(name)));
+
+    for (const binary of runtime.binaries) {
+        const fact: BinaryFact | undefined = inventory.binaries.get(binary);
+        if (!fact) {
+            reject(
+                'stackBinaryUnknown',
+                filePath,
+                `runtime.binaries names '${binary}', which ${basename(inventory.sourcePath)} says nothing about. Add a row `
+                + `there first: an unlisted binary is an unanswered question, and the point of the check is that the `
+                + `question gets answered before a run rather than during one.`,
+            );
+        }
+        if (fact.status === 'unavailable') {
+            reject(
+                'stackBinaryUnavailable',
+                filePath,
+                `runtime.binaries requires '${binary}', which is unavailable in the eval container: ${fact.note}. `
+                + `This stack cannot run there, and no declaration makes it able to — so it is refused rather than `
+                + `submitted.`,
+            );
+        }
+        if (fact.status === 'absent' && !declaredBinaries.has(binary)) {
+            reject(
+                'stackBinaryAbsentUndeclared',
+                filePath,
+                `runtime.binaries requires '${binary}', which is absent from the eval container, and no knownGaps entry `
+                + `declares it (add one with binary: ${binary}). Install command: ${fact.install}. Without the `
+                + `declaration the resulting red arrives with no explanation attached, which is how five missing-binary `
+                + `failures get read as five broken gates.`,
+            );
+        }
+    }
+}
+
+/**
+ * A declaration that no longer describes anything is worse than no declaration.
+ *
+ * The failure being prevented is specific and slow: a binary gets installed in
+ * the preamble, the gap closes, and the `knownGaps` entry stays — so the gate's
+ * reds keep getting explained away by a reason that stopped being true. Both
+ * checks here catch that the moment the fact underneath changes.
+ */
+function checkKnownGapsAreLive(
+    runtime: StackRuntime,
+    knownGaps: StackKnownGap[],
+    inventory: ContainerInventory,
+    filePath: string,
+): void {
+    for (const [index, gap] of knownGaps.entries()) {
+        if (!gap.binary) {
+            continue;
+        }
+        if (!runtime.binaries.includes(gap.binary)) {
+            reject(
+                'stackKnownGapBinaryNotRequired',
+                filePath,
+                `knownGaps[${index}] declares a gap for '${gap.binary}', which this stack does not require. `
+                + `Nothing here would ever be red for that reason, so the declaration only misleads.`,
+            );
+        }
+        const fact = inventory.binaries.get(gap.binary);
+        if (fact?.status === 'present') {
+            reject(
+                'stackKnownGapBinaryPresent',
+                filePath,
+                `knownGaps[${index}] declares a gap for '${gap.binary}', but the container has it. Delete the entry — a `
+                + `stale gap keeps explaining reds with a reason that is no longer true, which suppresses a real failure `
+                + `for as long as nobody rereads it.`,
+            );
+        }
+    }
+}


### PR DESCRIPTION
Adding a Python or C# project to the eval suite today means copying a stimulus YAML and hand-editing eight assertions. That is a fork, not an addition. This is the schema that makes a stack a data file.

**It wires nothing and changes no run.** The only executable addition is a check that fails on bad data. The derivation that turns a stack into gate wiring is the next PR in the stack.

## Explain it like I'm 5

A "stack" is one kind of project we ask the agent to build — "React app with an Azure Functions backend", or "Express API with a database". Today that description lives nowhere; it is smeared across a prompt and eight hand-written assertions. This PR gives it one file:

```yaml
id: node-express-postgres
ecosystem: node
prompt: |
  I need a backend API for tracking warehouse inventory...
project:
  frontend: none        # <- this line unwires three frontend gates
  api: http
  datastore: postgres
  hosting: appService
runtime:
  binaries: [node, npm] # <- checked against what the container actually has
knownGaps: [...]        # <- gates we know will be red, and why
```

## The one design decision worth arguing about

A stack declares **facts**, not a list of gates.

The obvious design is `gates: [runtime-health, runtime-crud, ...]` per stack. It is the wrong shape twice over:

1. **It rots in the direction that looks safe.** 30 gates × N stacks is a matrix maintained by hand, and adding gate 31 means editing every stack. The failure mode is a gate quietly wired nowhere — which reads as a clean run, and is exactly the `never-attempted` signal `gate-health.ts` exists to catch.
2. **It records a conclusion without its premise.** "runtime-frontend does not apply here" cannot be reviewed by anyone who has not read that gate. `frontend: none` can be reviewed by anyone who has read the prompt.

### What that buys: `outOfScope` becomes an alarm

A grader that cannot answer emits `NOT_APPLICABLE ... class=outOfScope` and exits 3, meaning *this gate should never have been wired to this stack*. Under fact-derived wiring a gate is only ever attached when the stack declared the thing it looks at, so:

> **An `outOfScope` marker in a run is a bug report against this schema.** It means the derivation is wrong, or a stack lied about its project. It is never expected noise.

That is deliberately falsifiable. If `outOfScope` markers keep arriving from correctly-written stacks, this design is wrong and should be replaced. `coverageGap` is unaffected and stays red on purpose — it is a true statement that we are not testing something we claim to test.

## Container constraints, checked before the money is spent

`config/container.yaml` records what the eval container has, in three states:

| status | meaning | effect on a stack that needs it |
| --- | --- | --- |
| `present` | on PATH | fine |
| `absent` | installable in the preamble; `install:` carries the command | allowed **only** with a declared `knownGaps` entry |
| `unavailable` | no practical path (`docker`) | **refused outright**; no run submitted |

Most rows are marked `evidence: asserted` — they came from a brief and a README, not from observation. That count prints on every check run, because an assumption in a sentence nobody rereads is how this stays wrong. Making them `measured` costs nothing and is routed separately: the fingerprint `exec:` line every stimulus already runs (`assertZeroExitCode: false`) can carry `command -v pip3 go dotnet docker azd func` and return the real inventory as a free rider on the next run anyone submits.

## Two stacks, so the derivation has something to differ between

- **`react-functions-postgres`** — today's reality, written down for the first time. It declares the missing `func` binary that has kept five runtime gates red on every run, a fact that previously lived nowhere a tool could read.
- **`node-express-postgres`** — the second shape, and the first whose runtime gates can actually run: an Express app starts from `package.json` `scripts.start`, which `runtimeTarget` already resolves and `reference-node-fullstack` already certifies.

Two things surfaced while writing them, both at authoring time rather than after a paid run — which is the schema doing its job:

1. **Postgres costs us `runtime-crud`.** The CRUD probe refuses to exercise a round-trip through a datastore needing a server, and there is no Docker. Declared as a known gap. `runtime-app-starts` and `runtime-health` still run, which is two more than today.
2. **A missing health endpoint is currently a free pass.** `runtime-health` reports `noHealthPathDeclared`, classed `outOfScope`, when the workspace names no health path — so an agent that ships none is not failed for it. Declaring `healthPath` in the stack turns that silent pass into a real verdict.

## Proof the validation rejects

Twenty-four deliberately broken fixtures under `config/__fixtures__/`, each asserting the **exact error code** it must produce — not merely that it threw. A validator broken so that it rejects everything would pass the weaker test, and a fixture rejected for the wrong reason proves the wrong rule.

Three vacuity traps are closed explicitly, each of which has bitten us: an empty fixture directory (`rejected === total`, never `> 0`), an empty stacks directory, and a fixture with no `# expect:` header. Nothing is piped, because a pipe discards the exit status of its left-hand side.

Verified by regressing the validator four ways — output pasted rather than described:

```
REGRESSION 1: delete one rule (checkHostingBinary)
  ✖ functions-without-func.yaml was ACCEPTED; it must be rejected with stackFunctionsRequiresFunc
  ✖ 15 of 16 fixtures were rejected as declared; every one must be
  FAIL — EXIT=1

REGRESSION 2: make the validator reject everything with one code
  ✖ prompt-names-rails.yaml was rejected as stackNotObject, but exists to prove stackPromptNamesRails
  ✖ unknown-phase.yaml was rejected as stackNotObject, but exists to prove stackPhaseUnknown
  ✖ 0 of 16 fixtures were rejected as declared; every one must be
  FAIL: 19 problem(s)

REGRESSION 3: empty the fixture directory
  ✖ no rejection fixtures found — the validator is unproven, which is the same as broken
  FAIL — EXIT=1

REGRESSION 4: delete a single fixture (the coverage ratchet)
  Rule coverage: 23 of 62 error codes proven by a fixture.
  ✖ rule coverage fell to 23; MIN_PROVEN_CODES is 24 and may only go up
  FAIL — EXIT=1
```

Regression 2 is the one that matters: it is what proves asserting the *code* is doing real work rather than decorating a throw.

## A wart discovered, worth recording

Applicability has to be computable **without importing the graders**, because every grader calls `runGrader*` at module top level — importing one *executes* it. That is why the gate table in the next PR is a central data file rather than a declaration living next to each grader, and why one reason-code vocabulary (`FIDELITY_NOT_APPLICABLE`, declared inside `validate-service-fidelity.ts`) cannot be read by the validator. Its only code today is already covered elsewhere, so nothing is lost — but that is luck, not design. If anyone later tidies the graders to be importable, this is why it mattered.

## Verification

All five credential-free gates pass locally: `typecheck`, `stacks:check`, `drift`, `certify` (81/81), `lint`. The new `Check stack schema` CI step is picked up by `ci-local.ts` automatically, since it parses the workflow.

Base confirmed `feat/CoR` (`git merge-base --is-ancestor origin/feat/CoR HEAD`), 1 commit, 34 files. **No MSBench run was submitted.**

## Next in the stack

2. `gates.yaml` + the applicability derivation + `build-config --stack`, which also warns when every gate a run would execute is a known gap — a run pre-determined to teach us nothing, computable before the money is spent.
3. Rung 0 in `runtimeTarget` + the staged stack projection.
