### PR TITLE
Let the health gate fail for the thing it exists to check

### DIFF
--- a/evals/grader-certification/manifest.json
+++ b/evals/grader-certification/manifest.json
@@ -700,6 +700,15 @@
             "expectedCode": "frontendApiRouteMissing"
         },
         {
+            "id": "runtime-health-collection-removed",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "runtime-health",
+            "file": "api-test-collections",
+            "operation": "delete",
+            "expectedCode": "passed"
+        },
+        {
             "id": "runtime-crud-write-not-persisted",
             "tier": "offline",
             "fixture": "reference-node-fullstack",

--- a/evals/results/grader-certification/offline/report.json
+++ b/evals/results/grader-certification/offline/report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-26T06:21:07.991Z",
+  "generatedAt": "2026-08-26T07:55:45.905Z",
   "mode": "offline",
   "fixtures": [
     "sample-agent-output",
@@ -625,6 +625,16 @@
       "actual": [
         "frontendApiRouteMissing"
       ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "runtime-health-collection-removed",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "runtime-health",
+      "expected": "passed",
+      "actual": [],
       "passed": true,
       "durationMs": 0
     },

--- a/evals/results/grader-certification/offline/report.md
+++ b/evals/results/grader-certification/offline/report.md
@@ -3,7 +3,7 @@
 - Mode: `offline`
 - Fixtures: `sample-agent-output`, `reference-node-fullstack`, `reference-node-multiservice`, `reference-python-api`, `reference-dotnet-api`, `reference-go-unsupported`
 - Outcome: **PASSED**
-- Cases: 81/81 passed
+- Cases: 82/82 passed
 
 | Case | Fixture | Validator | Expected | Actual | Result |
 |---|---|---|---|---|---|
@@ -61,6 +61,7 @@
 | `runtime-health-route-missing` | `reference-node-fullstack` | `runtime-health` | `healthEndpointUnhealthy` | `healthEndpointUnhealthy` | PASS |
 | `runtime-frontend-not-served` | `reference-node-fullstack` | `runtime-frontend` | `frontendNotServed` | `frontendNotServed` | PASS |
 | `runtime-frontend-calls-missing-route` | `reference-node-fullstack` | `runtime-frontend-api` | `frontendApiRouteMissing` | `frontendApiRouteMissing` | PASS |
+| `runtime-health-collection-removed` | `reference-node-fullstack` | `runtime-health` | `passed` | `passed` | PASS |
 | `runtime-crud-write-not-persisted` | `reference-node-fullstack` | `runtime-crud` | `crudRoundTripLost` | `crudRoundTripLost` | PASS |
 | `golden-service-fidelity` | `reference-node-multiservice` | `service-fidelity` | `passed` | `passed` | PASS |
 | `golden-datastore-fidelity` | `reference-node-multiservice` | `datastore-fidelity` | `passed` | `passed` | PASS |

--- a/evals/src/runtime/runtimeGates.ts
+++ b/evals/src/runtime/runtimeGates.ts
@@ -33,7 +33,7 @@ import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { discoverFrontendDirectory } from '../artifacts/frontendScaffold.ts';
 import type { ArtifactValidationIssue, ArtifactValidationResult } from '../artifacts/validationTypes.ts';
-import type { NotApplicableReason } from './runtimeTarget.ts';
+import { declaresBackendContract, type NotApplicableReason } from './runtimeTarget.ts';
 import { acquireRuntimeSession, probe, type HttpProbeResponse, type RuntimeSession } from './runtimeSession.ts';
 
 export interface RuntimeValidationResult extends ArtifactValidationResult {
@@ -91,10 +91,23 @@ export interface HealthOptions {
  * "It's alive" — the signal every deployment probe depends on.
  *
  * A *declared* health path that does not answer is an unambiguous product failure: the
- * project committed to it in its own API test collection or debug plan. An *undeclared*
- * one is weaker, so conventional paths are tried and a total miss returns not-applicable
- * rather than a fabricated failure — unless the caller passes `requireHealth`, which is how
- * a stimulus that knows the stack promises a health endpoint gets a real verdict.
+ * project committed to it in its own integration plan, API test collection or debug plan.
+ *
+ * When nothing is declared, conventional paths are tried — and a total miss is **not**
+ * out-of-scope. By the time this runs the app is up and answering HTTP, so seven misses on
+ * a live server is positive evidence that no health endpoint was built, not an absence of
+ * anything to test. Whether that is the *product's* fault turns on whether it owed one:
+ * `.azure/integration-plan.md` is the hand-off artifact the scaffold agent must write, and
+ * `validateIntegrationPlanArtifact` already fails the agent when its Backend section names
+ * no health endpoint path. So its presence makes this a contract the product did not meet —
+ * exit 1 — and its absence leaves a gap we cannot attribute, which is a `coverageGap`
+ * rather than a shrug.
+ *
+ * This originally returned not-applicable in every no-declaration case, which made the gate
+ * unable to fail for the one thing it exists to check: a running app with no health
+ * endpoint scored green. That is the same defect as the retired `noProjectManifestFound` —
+ * a product failure wearing a not-applicable costume — and it survived the review that
+ * caught the other one.
  */
 export async function validateHealthEndpoint(workspaceRoot: string, options: HealthOptions = {}): Promise<RuntimeValidationResult> {
     const session = await acquireRuntimeSession(workspaceRoot);
@@ -144,10 +157,25 @@ export async function validateHealthEndpoint(workspaceRoot: string, options: Hea
             app.output(),
         );
     }
+
+    // The app is up and answering HTTP, and nothing at seven conventional paths responded.
+    // If it went through the scaffold flow it owed a health endpoint, so this is a contract
+    // the product did not meet rather than a question we cannot answer.
+    if (await declaresBackendContract(workspaceRoot)) {
+        return failure(
+            'healthEndpointMissing',
+            '$.health',
+            `the app is listening on ${app.baseUrl} but has no health endpoint: nothing is declared in its API test collections, `
+            + '.azure/integration-plan.md or .azure/vscode-debug-plan.md, and no conventional path answered. '
+            + `The project has an integration plan, whose Backend section is required to name a health endpoint path. Tried: ${attempts.join(', ')}.`,
+            app.output(),
+        );
+    }
     return notApplicable(
         'noHealthPathDeclared',
-        'the project declares no health path in its API test collections or debug plan, and no conventional path '
-        + `answered (tried ${attempts.join(', ')}). Pass --require-health to make this a failure.`,
+        `the app is listening on ${app.baseUrl} but no health endpoint answered (tried ${attempts.join(', ')}), and the workspace `
+        + 'has no .azure/integration-plan.md, so there is no record of it having promised one. The gate has a real question here '
+        + 'and no contract to check it against; pass --require-health to fail instead.',
     );
 }
 
@@ -636,9 +664,10 @@ function excerpt(body: string): string {
 
 function describeHealthSource(source: string | undefined): string {
     return source === 'apiTestCollection' ? 'the generated API test collection'
-        : source === 'debugPlan' ? 'the debug plan'
-            : source === 'stackDeclaration' ? 'the stack declaration'
-                : 'the project';
+        : source === 'integrationPlan' ? '.azure/integration-plan.md'
+            : source === 'debugPlan' ? 'the debug plan'
+                : source === 'stackDeclaration' ? 'the stack declaration'
+                    : 'the project';
 }
 
 function issue(code: string, target: string, message: string): ArtifactValidationIssue {

--- a/evals/src/runtime/runtimeTarget.ts
+++ b/evals/src/runtime/runtimeTarget.ts
@@ -47,7 +47,7 @@ export type PortSource =
     | 'undeclared';
 
 /** Where the health path came from. */
-export type HealthPathSource = 'stackDeclaration' | 'apiTestCollection' | 'debugPlan';
+export type HealthPathSource = 'stackDeclaration' | 'apiTestCollection' | 'integrationPlan' | 'debugPlan';
 
 /**
  * The closed vocabulary of not-applicable reasons, shared with the fidelity and
@@ -96,7 +96,6 @@ export type NotApplicableReason =
  */
 export const RUNTIME_NOT_APPLICABLE_CLASS: Record<NotApplicableReason, 'outOfScope' | 'coverageGap'> = {
     // This project has nothing for the gate to look at, and no remedy would change that.
-    noHealthPathDeclared: 'outOfScope',
     noFrontendDeclared: 'outOfScope',
     noFrontendApiCalls: 'outOfScope',
     noCollectionRouteDeclared: 'outOfScope',
@@ -105,6 +104,11 @@ export const RUNTIME_NOT_APPLICABLE_CLASS: Record<NotApplicableReason, 'outOfSco
     datastoreRequiresContainer: 'coverageGap',
     frontendDevServerUnsupported: 'coverageGap',
     ecosystemNotSupported: 'coverageGap',
+    // Reachable only on a *running* HTTP app that answered no conventional health path, so
+    // it is never "nothing to look at" — it is a missing feature we could not attribute,
+    // because the workspace carries no integration plan promising one. With that plan
+    // present the same evidence is a product failure, not an N/A.
+    noHealthPathDeclared: 'coverageGap',
 };
 
 /** How the port may be substituted, when the project lets us choose one. */
@@ -373,11 +377,22 @@ function isPort(value: string): boolean {
  * Find the health path the project declared for itself.
  *
  * The API test collection is the best source: the agent generates it as an executable
- * probe, so it is a commitment rather than a description. The debug plan comes second — it
- * is prose, and prose about ports has already been caught lying in the reference fixture,
- * but a *path* in it is still a declaration. Conventional guesses are deliberately not
- * here: the caller decides whether to guess, because "the project never declared a health
- * endpoint" is a different verdict from "it declared one and it 404s".
+ * probe, so it is a commitment rather than a description.
+ *
+ * `.azure/integration-plan.md` comes next, and it is the source this chain should have had
+ * from the start. The scaffold agent is *contracted* to record "health endpoint path" in
+ * that artifact's Backend section, and `validateIntegrationPlanArtifact` already fails the
+ * agent with `missingHealthEndpoint` when it doesn't — so it is the one place a health path
+ * is guaranteed to be declared for any project that went through the scaffold flow. Omitting
+ * it meant this gate could report "the project declares no health path" about a project
+ * whose plan declared one on the line above, and then quietly return not-applicable.
+ *
+ * The debug plan comes last — it is prose, and prose about ports has already been caught
+ * lying in the reference fixture, but a *path* in it is still a declaration.
+ *
+ * Conventional guesses are deliberately not here: the caller decides whether to guess,
+ * because "the project never declared a health endpoint" is a different verdict from
+ * "it declared one and it 404s".
  */
 async function discoverHealthPath(workspaceRoot: string): Promise<{ path: string; source: HealthPathSource } | undefined> {
     const collections = path.join(workspaceRoot, 'api-test-collections');
@@ -389,12 +404,28 @@ async function discoverHealthPath(workspaceRoot: string): Promise<{ path: string
         }
     }
 
-    const plan = await readFileSafe(path.join(workspaceRoot, '.azure', 'vscode-debug-plan.md'));
-    const fromPlan = plan && /(\/[\w\-./]*(?:health|healthz|readiness|livez)[\w\-./]*)/i.exec(plan);
-    if (fromPlan) {
-        return { path: fromPlan[1].replace(/[.,)]+$/, ''), source: 'debugPlan' };
+    for (const [file, source] of [
+        ['integration-plan.md', 'integrationPlan'],
+        ['vscode-debug-plan.md', 'debugPlan'],
+    ] as [string, HealthPathSource][]) {
+        const text = await readFileSafe(path.join(workspaceRoot, '.azure', file));
+        const match = text && /(\/[\w\-./]*(?:health|healthz|readiness|livez)[\w\-./]*)/i.exec(text);
+        if (match) {
+            return { path: match[1].replace(/[.,)`]+$/, ''), source };
+        }
     }
     return undefined;
+}
+
+/**
+ * Whether the project went through the scaffold flow, and therefore owed a health endpoint.
+ *
+ * `.azure/integration-plan.md` is the hand-off artifact the scaffold agent must write, and
+ * its Backend section must name a health endpoint path. Its presence is what turns "no
+ * health endpoint answered" from an open question into a contract the product did not meet.
+ */
+export function declaresBackendContract(workspaceRoot: string): Promise<boolean> {
+    return exists(path.join(workspaceRoot, '.azure', 'integration-plan.md'));
 }
 
 /**


### PR DESCRIPTION
## The defect

`runtime-health` **could not go red for a missing health endpoint** — the one thing it exists to check.

Reaching its not-applicable branch requires: the app **started and is answering HTTP**, nothing declared a health path, and **all seven** conventional paths missed. It classed that `outOfScope`, which is defined as *"this project genuinely has nothing for the gate to look at. There is no remedy and nothing to build."*

The evidence says the opposite. Seven misses on a live HTTP server is positive evidence that **no health endpoint was built**. There is a remedy — the agent should have built one. So the gate was wired, ran, and could only ever be green or absent: the vacuous-gate shape, inverted.

Found by the stacks-schema session while writing a data file — before any run was spent — and disclosed with the fact that its own schema has a workaround, which is exactly why it argued for fixing the source rather than leaving a trap for the next gate that copies the pattern.

## The escape hatch made it worse

`--require-health` appears in exactly three places: its own definition, its doc comment, and the hint text in the N/A message telling someone to pass it. **Nothing passes it.**

A capability that exists only in its own documentation is a decoy. Someone auditing the gate sees a flag, assumes strictness is available and presumably in use, and stops looking. Same family as `frontendServerNotStarted` — a self-suppressing *option* rather than a self-suppressing name.

## A second defect underneath it

Health-path discovery read the API test collections and the debug plan, but never **`.azure/integration-plan.md`** — the hand-off artifact the scaffold agent is *contracted* to write:

> **Backend**: project folder, run command (e.g. `func start`), port, build command, **health endpoint path**.
> — `resources/agents/azure-project-scaffold.agent.md:64`

and which an existing gate already enforces:

```ts
// integrationPlan.ts:192
const health = readField(section, /health/i);
if (!health || !health.includes('/')) {
    issues.push(issue('missingHealthEndpoint', '$.backend', 'Backend section must give the health endpoint path.'));
}
```

So a health endpoint is a **hard contract**, and the gate was ignoring the most authoritative declaration of it. It could report "the project declares no health path" about a project that declared one, then return not-applicable about that.

## The fix

**Discovery** — the integration plan becomes the second rung, after the executable API test collection and ahead of the debug plan's prose (the debug plan has already been caught lying about ports in this very fixture).

**Verdict** — follows the `noApplication` pattern already established when `noProjectManifestFound` was retired for being a product failure in an N/A costume:

| situation | verdict |
|---|---|
| declared path doesn't answer | **exit 1** — unchanged |
| nothing declared, no conventional path answers, **integration plan present** | **exit 1** `healthEndpointMissing` — the project owed a health endpoint |
| nothing declared, no conventional path answers, **no integration plan** | **exit 3** `class=coverageGap reason=noHealthPathDeclared` — a real gap we cannot attribute |

Reclassified from `outOfScope` to `coverageGap`, because it is never "nothing to look at".

**Alex's caution — a project with no HTTP surface should stay N/A — is satisfied structurally**: such a project never reaches this gate's verdict at all, because it fails `runtime-app-starts` first.

## Certification: 82/82, and an honest note on what it covers

The new case, `runtime-health-collection-removed`, is a **control against over-strictness** rather than a failure proof — deleting the API test collections must leave the gate *passing* via the integration plan. That's the technique the fidelity gates introduced with their two `expected: passed` mutations, and it's the exposure I'd flagged as having no cover.

Verified it traverses the intended rung rather than passing by luck:

```
collection removed             → /api/health → 200 (declared in .azure/integration-plan.md)
collection + plan removed      → /api/health → 200 (declared in the debug plan)
```

**Stated plainly: the new exit-1 path is verified by hand, not by certification.** A running app with its health route renamed and all three declarations stripped returns exit 1; remove the integration plan and the same app returns exit 3 with `class=coverageGap`. Reaching it needs three files changed at once, and manifest mutations are single-file — so certifying it needs the multi-file machinery in #1722. That is a real coverage gap in this PR and I'd rather name it than let the 82/82 imply otherwise.

## Fallout for consumers

`noHealthPathDeclared` moves `outOfScope` → `coverageGap`, and now fires strictly less often. gateHealth has been told.