### PR TITLE
Stop reporting "my parser found nothing" as "there is nothing to check"

### DIFF
--- a/evals/grader-certification/manifest.json
+++ b/evals/grader-certification/manifest.json
@@ -718,6 +718,28 @@
             "search": "await writeItems(dataFile, [...items, item]);",
             "replacement": "void items;",
             "expectedCode": "crudRoundTripLost"
+        },
+        {
+            "id": "runtime-frontend-api-unresolvable-url",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "runtime-frontend-api",
+            "file": "public/app.js",
+            "operation": "replace",
+            "search": "    const response = await fetch('/api/items');\n    render(await response.json());\n}\n\nform.addEventListener('submit', async event => {\n    event.preventDefault();\n    const response = await fetch('/api/items', {",
+            "replacement": "    const apiBase = '/api';\n    const response = await fetch(`${apiBase}/items`);\n    render(await response.json());\n}\n\nform.addEventListener('submit', async event => {\n    event.preventDefault();\n    const response = await fetch(`${apiBase}/items`, {",
+            "expectedCode": "frontendApiCallsUnresolvable"
+        },
+        {
+            "id": "runtime-frontend-api-nothing-called",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "runtime-frontend-api",
+            "file": "public/index.html",
+            "operation": "replace",
+            "search": "    <script src=\"/app.js\"></script>\n",
+            "replacement": "",
+            "expectedCode": "frontendMakesNoApiCalls"
         }
     ]
 }

--- a/evals/results/grader-certification/offline/report.json
+++ b/evals/results/grader-certification/offline/report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-26T07:55:45.905Z",
+  "generatedAt": "2026-08-26T08:05:29.111Z",
   "mode": "offline",
   "fixtures": [
     "sample-agent-output",
@@ -646,6 +646,30 @@
       "expected": "crudRoundTripLost",
       "actual": [
         "crudRoundTripLost"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "runtime-frontend-api-unresolvable-url",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "runtime-frontend-api",
+      "expected": "frontendApiCallsUnresolvable",
+      "actual": [
+        "frontendApiCallsUnresolvable"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "runtime-frontend-api-nothing-called",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "runtime-frontend-api",
+      "expected": "frontendMakesNoApiCalls",
+      "actual": [
+        "frontendMakesNoApiCalls"
       ],
       "passed": true,
       "durationMs": 0

--- a/evals/results/grader-certification/offline/report.md
+++ b/evals/results/grader-certification/offline/report.md
@@ -3,7 +3,7 @@
 - Mode: `offline`
 - Fixtures: `sample-agent-output`, `reference-node-fullstack`, `reference-node-multiservice`, `reference-python-api`, `reference-dotnet-api`, `reference-go-unsupported`
 - Outcome: **PASSED**
-- Cases: 82/82 passed
+- Cases: 84/84 passed
 
 | Case | Fixture | Validator | Expected | Actual | Result |
 |---|---|---|---|---|---|
@@ -63,6 +63,8 @@
 | `runtime-frontend-calls-missing-route` | `reference-node-fullstack` | `runtime-frontend-api` | `frontendApiRouteMissing` | `frontendApiRouteMissing` | PASS |
 | `runtime-health-collection-removed` | `reference-node-fullstack` | `runtime-health` | `passed` | `passed` | PASS |
 | `runtime-crud-write-not-persisted` | `reference-node-fullstack` | `runtime-crud` | `crudRoundTripLost` | `crudRoundTripLost` | PASS |
+| `runtime-frontend-api-unresolvable-url` | `reference-node-fullstack` | `runtime-frontend-api` | `frontendApiCallsUnresolvable` | `frontendApiCallsUnresolvable` | PASS |
+| `runtime-frontend-api-nothing-called` | `reference-node-fullstack` | `runtime-frontend-api` | `frontendMakesNoApiCalls` | `frontendMakesNoApiCalls` | PASS |
 | `golden-service-fidelity` | `reference-node-multiservice` | `service-fidelity` | `passed` | `passed` | PASS |
 | `golden-datastore-fidelity` | `reference-node-multiservice` | `datastore-fidelity` | `passed` | `passed` | PASS |
 | `fidelity-planned-service-dropped` | `reference-node-multiservice` | `service-fidelity` | `plannedServiceMissing` | `plannedServiceMissing` | PASS |

--- a/evals/src/runtime/runtimeGates.ts
+++ b/evals/src/runtime/runtimeGates.ts
@@ -51,6 +51,36 @@ const CONVENTIONAL_HEALTH_PATHS = ['/api/health', '/health', '/healthz', '/api/h
 /** Datastore clients that need a server we cannot start — the container has no Docker. */
 const CONTAINER_DATASTORE_PACKAGES = ['pg', 'postgres', 'mysql', 'mysql2', 'mongodb', 'mongoose', 'redis', 'ioredis', 'mssql', 'cassandra-driver'];
 
+/**
+ * **The attribution rule.** Stated once here because every gate in this file needs it and
+ * three sessions have now independently re-derived it, once per gate, at the cost of a
+ * silent pass each time.
+ *
+ * When a gate looks for a capability and does not find it, there are three different
+ * situations behind that one observation, and they take three different exit codes:
+ *
+ *   1. **We could not read well enough to tell** → *harness fault*, exit 3. Our parser's
+ *      limitation is never the agent's defect. This case is the one that gets forgotten,
+ *      because from the outside it looks exactly like the capability being absent.
+ *   2. **Contract evidence says the product owed this, and it is absent** → *product
+ *      failure*, exit 1. A real, reportable defect.
+ *   3. **No contract evidence either way** → *not applicable*. We have a real question and
+ *      nothing to check it against; that is a coverage gap, not a clean bill of health.
+ *
+ * Order matters: (1) is checked first, because a parser that cannot read the frontend
+ * produces the same emptiness as a frontend that does nothing, and reporting the second
+ * when the first is true manufactures a failure — or, as it did here three times, a silent
+ * pass. "Nothing found" is only evidence once you know you could have found something.
+ */
+type AbsenceAttribution = 'cannotTell' | 'productOwedIt' | 'noContract';
+
+function attributeAbsence(evidence: { couldNotRead: boolean; contractDeclared: boolean }): AbsenceAttribution {
+    if (evidence.couldNotRead) {
+        return 'cannotTell';
+    }
+    return evidence.contractDeclared ? 'productOwedIt' : 'noContract';
+}
+
 /** Static roots an app-served frontend is normally read from. */
 const STATIC_ROOTS = ['public', 'wwwroot', 'static', 'client', 'dist', '.'];
 
@@ -270,12 +300,39 @@ export async function validateFrontendApiWiring(workspaceRoot: string): Promise<
         return notApplicable('noFrontendDeclared', 'the app serves no browser document at /, so there is no frontend wiring to check.');
     }
 
-    const calls = await collectApiCalls(app.baseUrl, document.response.body);
+    const { calls, usesHttpClient } = await collectApiCalls(app.baseUrl, document.response.body);
     if (calls.length === 0) {
-        return notApplicable(
-            'noFrontendApiCalls',
-            'the served frontend issues no same-origin API calls, so there is no frontend-to-backend wiring to verify.',
-        );
+        switch (attributeAbsence({
+            couldNotRead: usesHttpClient,
+            contractDeclared: await declaresBackendContract(workspaceRoot),
+        })) {
+            case 'cannotTell':
+                return harnessFault(
+                    'the served frontend issues HTTP requests, but none of their URLs could be resolved statically — '
+                    + 'a computed base (`fetch(`${base}/items`)`) or a client wrapper defeats the extraction. '
+                    + 'This says nothing about whether the frontend is wired; it says this gate cannot read it.',
+                    app.output(),
+                    'frontendApiCallsUnresolvable',
+                );
+            case 'productOwedIt':
+                // The failure this gate exists for, and the one it could not previously
+                // report: an integration plan promising API routes, and a served frontend
+                // that calls nothing at all.
+                return failure(
+                    'frontendMakesNoApiCalls',
+                    '/',
+                    `the served frontend at ${app.baseUrl}/ issues no HTTP requests whatsoever, while `
+                    + '.azure/integration-plan.md declares the API routes it was supposed to call. '
+                    + 'The two halves were built and never connected.',
+                    app.output(),
+                );
+            case 'noContract':
+                return notApplicable(
+                    'noFrontendApiCalls',
+                    'the served frontend issues no HTTP requests, and the workspace has no .azure/integration-plan.md '
+                    + 'declaring routes it should have called, so there is no contract to hold it to.',
+                );
+        }
     }
 
     const issues: ArtifactValidationIssue[] = [];
@@ -331,13 +388,30 @@ export async function validateCrudRoundTrip(workspaceRoot: string): Promise<Runt
     }
 
     const document = await probe(`${app.baseUrl}/`);
-    const collection = document.ok && looksLikeHtml(document.response)
+    const servesFrontend = document.ok && looksLikeHtml(document.response);
+    const collection = servesFrontend
         ? await findCollectionEndpoint(app.baseUrl, document.response.body)
         : undefined;
     if (!collection) {
+        // Same attribution rule as the wiring gate. A frontend that plainly posts, whose
+        // URL or body shape we could not extract, is our limitation — and reporting it as
+        // "this project has no CRUD" is how the gate quietly stopped testing anything.
+        const { usesHttpClient } = servesFrontend
+            ? await collectApiCalls(app.baseUrl, document.response.body)
+            : { usesHttpClient: false };
+        if (usesHttpClient) {
+            return harnessFault(
+                'the served frontend issues HTTP requests, but no collection endpoint could be extracted from them — '
+                + 'a computed URL or a client wrapper defeats the extraction. Declare `project.collectionRoute` in the '
+                + 'stack file to check this stack properly; this gate cannot read it unaided.',
+                app.output(),
+                'collectionRouteUnresolvable',
+            );
+        }
         return notApplicable(
             'noCollectionRouteDeclared',
-            'no collection endpoint could be identified from the served frontend, so there is no round-trip to attempt.',
+            'the served frontend issues no HTTP requests at all, so no collection endpoint could be identified and '
+            + 'there is no round-trip to attempt.',
         );
     }
 
@@ -431,16 +505,34 @@ async function findContainerDatastore(packageDirectory: string): Promise<string 
 }
 
 /** Same-origin paths the served frontend calls, gathered from the document and its scripts. */
-async function collectApiCalls(baseUrl: string, document: string): Promise<string[]> {
+/**
+ * Same-origin paths the served frontend calls, plus whether it makes HTTP calls *at all*.
+ *
+ * The second half is what stops this gate lying. A frontend that writes
+ * `` fetch(`${base}/items`) `` — an env-configured API base, which is the ordinary way a
+ * generated app is written, not an exotic one — defeats the path extraction below while
+ * plainly making calls. Without `usesHttpClient` the gate could not tell that from a
+ * frontend that calls nothing, and reported the second, which is the failure it exists to
+ * catch. Distinguishing them is the difference between "the product is broken" and "our
+ * parser cannot read this".
+ */
+async function collectApiCalls(baseUrl: string, document: string): Promise<{ calls: string[]; usesHttpClient: boolean }> {
     const sources = [document, ...await fetchScripts(baseUrl, document)];
     const calls = new Set<string>();
+    let usesHttpClient = false;
     for (const source of sources) {
         for (const call of findApiCalls(source)) {
             calls.add(call);
         }
+        if (HTTP_CLIENT_TOKENS.test(source)) {
+            usesHttpClient = true;
+        }
     }
-    return [...calls].sort();
+    return { calls: [...calls].sort(), usesHttpClient };
 }
+
+/** Evidence that the frontend issues HTTP requests, independent of whether we can read the URL. */
+const HTTP_CLIENT_TOKENS = /\bfetch\s*\(|\baxios\b|\bXMLHttpRequest\b|\$\.ajax\s*\(|\buseSWR\s*\(|\buseQuery\s*\(/;
 
 async function fetchScripts(baseUrl: string, document: string): Promise<string[]> {
     const bodies: string[] = [];
@@ -700,10 +792,10 @@ function withOutput(result: RuntimeValidationResult, output: string): RuntimeVal
  * agent is never blamed, and the issue makes the golden certification case go red — because
  * a probe that cannot connect for its own reasons must not look like a pass.
  */
-function harnessFault(message: string, output: string): RuntimeValidationResult {
+function harnessFault(message: string, output: string, code = 'runtimeHarnessFault'): RuntimeValidationResult {
     return withOutput({
         valid: false,
-        issues: [issue('runtimeHarnessFault', '$.runtime', message)],
+        issues: [issue(code, '$.runtime', message)],
         harnessFault: message,
         diagnostics: [],
     }, output);

--- a/evals/src/runtime/runtimeTarget.ts
+++ b/evals/src/runtime/runtimeTarget.ts
@@ -96,9 +96,15 @@ export type NotApplicableReason =
  */
 export const RUNTIME_NOT_APPLICABLE_CLASS: Record<NotApplicableReason, 'outOfScope' | 'coverageGap'> = {
     // This project has nothing for the gate to look at, and no remedy would change that.
+    // Down to one code, and that is the expected end state rather than an accident: every
+    // other reason examined closely has turned out to be a coverage gap or a product
+    // failure wearing an out-of-scope costume. The stack schema predicts the same thing
+    // structurally — an `outOfScope` verdict in a real run is close to a bug report.
     noFrontendDeclared: 'outOfScope',
-    noFrontendApiCalls: 'outOfScope',
-    noCollectionRouteDeclared: 'outOfScope',
+    // Reachable only when the served frontend makes no HTTP calls *and* nothing declared
+    // the routes it owed. When either is untrue the gate now has a verdict.
+    noFrontendApiCalls: 'coverageGap',
+    noCollectionRouteDeclared: 'coverageGap',
     // The gate has a real question here and something is missing that could be supplied.
     functionsHostUnavailable: 'coverageGap',
     datastoreRequiresContainer: 'coverageGap',


### PR DESCRIPTION
## The reproduction, which is the whole argument

Change the reference fixture's frontend from `fetch('/api/items')` to `` fetch(`${base}/items`) ``. **Identical calls, identical routes, one template literal.** Two gates stand down silently:

```
runtime-frontend-api  → NOT_APPLICABLE class=outOfScope reason=noFrontendApiCalls
runtime-crud          → NOT_APPLICABLE class=outOfScope reason=noCollectionRouteDeclared
```

Nothing about the product changed. The regex just couldn't resolve the path.

`runtime-frontend-api` exists to catch **a frontend and a backend that were built and never connected** — and it declined in exactly the state an unconnected frontend also produces. It could not fail for the thing it exists to check.

An env-configured API base is not a corner case. It is arguably the *modal* way a real scaffolded frontend writes an API call.

## Why 84/84 kept saying otherwise

A systemic bias worth recording: **certification fixtures written by the person who wrote the parser will use the syntax the parser handles.** Not carelessness — you cannot write a fixture in a syntax you didn't think of. Every mutation is drawn from the same imagination as the code.

Same root as the hostile-fixture argument in #1722: a clean fixture on a clean machine exercises the happy path, and here it exercised *the parser's own dialect*.

The defence is the method used to find this: **mutate the fixture's incidental form, not its meaning.** Same routes, same behaviour, different syntax — the verdict must not move. Added to #1722 as a fixture class.

## The rule, stated once instead of re-derived per gate

Third instance of one defect — after `noProjectManifestFound` and `noHealthPathDeclared`, both mine, both fixed after someone else pointed at them. So it now lives in `attributeAbsence`:

```
we could not read well enough to tell   → harness fault, exit 3
contract says it was owed, and absent   → product failure, exit 1
no contract evidence either way         → not applicable
```

**Order matters, and it is the part that gets forgotten.** "Could not read" is checked first, because a parser that cannot read the frontend produces the same emptiness as a frontend that does nothing. *Nothing found is only evidence once you know you could have found something.*

## The discriminator was cheap and available all along

**Do the served assets contain HTTP client tokens at all?**

| served JavaScript | contract | verdict |
|---|---|---|
| `fetch(` / `axios` / `XMLHttpRequest` present, no resolvable URL | any | **exit 3** `frontendApiCallsUnresolvable` — our limitation, never billed to the agent |
| no client tokens at all | integration plan declares routes | **exit 1** `frontendMakesNoApiCalls` — built and never connected |
| no client tokens at all | no integration plan | **exit 3** `class=coverageGap` — a real question, nothing to check it against |

Per Alex's ruling, the third row is explicitly *not* exit 1: absent contract evidence means we cannot fairly attribute, consistent with #1728.

`runtime-crud` gets the same treatment, minus the product-failure row — "this app has no CRUD" is legitimately out of scope for many projects, so an unreadable collection route is exit 3 and a frontend that calls nothing stays N/A.

## Certification: 84/84, both new paths pinned

```
runtime-frontend-api-unresolvable-url  expected=frontendApiCallsUnresolvable  PASS
runtime-frontend-api-nothing-called    expected=frontendMakesNoApiCalls       PASS
```

The second is the verdict this gate **has never once been able to give**. Without it this PR would have moved the vacuum rather than removed it.

Worth noting the first mutation initially failed to bite: it defeated only the `GET` call site while the literal `POST` still resolved, so the gate passed. Rewritten to span both call sites. A mutation that doesn't actually reach the branch is the same decoration problem one level up.

Verified end to end: template literal → 3, frontend calling nothing with a contract → 1, same without a contract → 3 `coverageGap`.

## `outOfScope` is now one code

Only `noFrontendDeclared` remains. That's the expected end state, not an accident — every other reason examined closely has been a coverage gap or a product failure in a costume. **Two independent derivations agree**: the stack schema predicts `outOfScope` should be near-unreachable structurally, and this converges on it empirically from the other end.

## Not in this PR

Improving the parser to resolve simple computed bases. Deliberately separate: the exit-3 branch is what makes the parser's blind spots *visible*, and it's the mechanism that stops `project.collectionRoute` from becoming the reason the regex never gets fixed. Declaration and parser are complements.