### PR TITLE
Record the part of a gate that nothing tests

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -1291,6 +1291,35 @@ covers, and in every case the fix was the same move: **make the output claim onl
 knows**. That is why `rate` prints `n/a` rather than `100%`, why N/A is its own bucket, and
 why the out-of-scope section says *for the stacks observed*.
 
+#### The part nothing tests: the sentence attached to the verdict
+
+Of the defects found while building these gates, **four were cases where the logic was
+correct and the wording was the bug**: a reason code named for a product failure when it
+meant a harness gap; a class named `environmentGap` for a missing analyser, sending
+triagers to inspect a container that was fine; a stranded-content check reporting `clean`
+when it had examined only insertions; and a section telling the reader a grader had been
+*blocked* when it had actually run and disowned its own answer.
+
+Every one of them pointed a reader somewhere, and the somewhere was wrong.
+
+What connects them structurally is worth stating, because it bounds what any of this
+tooling can promise. **A gate's prose is the one part of it that nothing tests.**
+Certification asserts verdicts and exit codes; a hostile fixture can prove a gate reaches
+the right *verdict* on input designed to fool it. Neither can assert that the sentence
+attached to that verdict names the right person to go and fix it. So this failure mode is
+not merely hard to catch — it is *structurally uncovered*, inside a suite whose entire
+purpose is coverage.
+
+There is no cheap mechanical answer, and this report does not claim one. Two consequences
+follow anyway:
+
+- **When a report line tells someone where to look, being wrong costs more than being
+  silent.** Wrong advice that reads as authoritative consumes exactly the attention the
+  report exists to direct. That is why the remedies here fork rather than generalise, and
+  why each one names what it actually knows.
+- **A green certification number says nothing about it.** Read the sentence a gate emits,
+  not just the code it exits.
+
 #### And why it is computed rather than judged
 
 The argument for automating any of this is not that people are careless. It is narrower and
@@ -1318,6 +1347,14 @@ ended the argument, the checks re-run against a second case. It needs no clevern
 available to anyone. Its corollary is the half that keeps being missed — *having the
 evidence is not the same as having read it*. All four of those participants ran the thing;
 they read past the answer.
+
+And the part that argues for the mechanical checks more than any of the above: **not one of
+those defects was caught by its own author.** Every fix, in every direction, entered
+because someone else read the code — including a bug report that turned out not to
+reproduce, which was only established by building a fixture instead of accepting a
+confident claim. Deference to a confident report is how a phantom defect earns a permanent
+workaround. The author is the one person who cannot see it, and a stranger happening to
+look is not a mechanism.
 
 That is the same failure this tool exists to catch, one level up. A gate that has failed 16
 times looks routine; nothing about a routine-looking thing invites inspection, which is


### PR DESCRIPTION
Documentation only. One README section, no code.

## Why

Four defects found while building these gates had **correct logic and wrong wording**:

| Defect | Where it sent the reader |
| --- | --- |
| `frontendServerNotStarted` — a harness capability gap named as a product failure | Investigate the app. The app was fine. |
| `environmentGap` for a missing Go analyser | Inspect the container. The container was fine. |
| A stranded-content check reporting `clean — fully merged` | Nowhere — it had examined insertions only, and a lost deletion reported success. |
| A report section calling a grader **blocked** when it had run and disowned its own answer | Check the environment. The environment was fine; the grader's parser was not. |

Every one pointed a reader somewhere, and the somewhere was wrong. None was a bug in the logic.

## The structural point, which bounds what this tooling can promise

**A gate's prose is the one part of it that nothing tests.**

Certification asserts verdicts and exit codes. A hostile fixture can prove a gate reaches the right *verdict* on input designed to fool it. Neither can assert that the sentence attached to that verdict names the right person to go and fix it.

So this failure mode is not merely hard to catch — it is **structurally uncovered**, inside a suite whose entire purpose is coverage. That is why all four needed a stranger to read them.

There is no cheap mechanical answer and this PR does not claim one. It records two consequences that follow anyway:

- **When a report line tells someone where to look, being wrong costs more than being silent.** Wrong advice that reads as authoritative consumes exactly the attention the report exists to direct. That is why `gate-health`'s remedies fork rather than generalise, and why each names only what it knows.
- **A green certification number says nothing about it.** Read the sentence a gate emits, not just the code it exits.

## Also recorded

That **no defect was caught by its own author** — every fix, in every direction, entered because someone else read the code. Including a bug report that turned out **not to reproduce**, established by building a fixture rather than accepting a confident claim. Deference to a confident report is how a phantom defect earns a permanent workaround.

This sits next to the existing note on why verdicts are computed rather than judged, and completes its argument: the author is the one person who cannot see it, and a stranger happening to look is not a mechanism.

## Verification

`npm run typecheck` passes; corpus unchanged at 30 runs / 48 gates, no verdict moved. Documentation-only change to `evals/msbench/README.md`.