### PR TITLE
Make "run.sh works on a clean machine" a check, not a comment

### DIFF
--- a/.github/workflows/agent-contracts.yml
+++ b/.github/workflows/agent-contracts.yml
@@ -82,3 +82,18 @@ jobs:
       - name: Lint eval specs
         run: npm run lint
         working-directory: evals
+
+      # `run.sh` promises a clean machine can execute it, and the MSBench eval job
+      # depends on that: it installs nothing before running `run.sh --skip-build`.
+      # A script it invokes that statically imports a package therefore fails on
+      # the one path where failure costs money. That rule was written down, in
+      # prose, and then broken by the next change to the same file family — so it
+      # is a mechanism now rather than a hope.
+      #
+      # Deliberately last: this step moves `evals/node_modules` aside and restores
+      # it in a `finally`. Running it after everything else means that even a
+      # catastrophic failure to restore cannot make an unrelated step fail with a
+      # confusing error.
+      - name: Check run.sh works on a clean machine
+        run: npm run clean-machine:check
+        working-directory: evals

--- a/evals/msbench/check-clean-machine.ts
+++ b/evals/msbench/check-clean-machine.ts
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Prove that `run.sh` still works on a machine with nothing installed.
+ *
+ * ## Why this exists, stated against its author
+ *
+ * `run.sh` promises that "a clean machine with `az login` already done should be
+ * able to execute this unmodified", and the MSBench `eval` job depends on it:
+ * checkout, setup-node, download the VSIX artifact, `run.sh --skip-build`.
+ * **Nothing installs anything on that host** — no `node_modules` at the repo
+ * root, none in `evals/`. A script `run.sh` invokes that statically imports a
+ * third-party package therefore fails there, on the one path where failure costs
+ * money.
+ *
+ * That constraint was written down, in prose, as the reason `stage-graders.ts`
+ * could not use `ts.preProcessFile`. The very next change to that file family —
+ * by the same author, the same night — added four static imports of a
+ * YAML-parsing module to `build-config.ts` and turned the build red.
+ *
+ * **Knowing the rule and writing it down did not enforce it. CI did.** So the
+ * rule stops being prose here and becomes a mechanism.
+ *
+ * ## Two halves, because either alone is fooled
+ *
+ * 1. **Static** — walk the eagerly-imported graph of each entrypoint and reject
+ *    any bare specifier. Deterministic and instant, and it names the offending
+ *    file and its import chain rather than a stack trace. Dynamic `import()` is
+ *    deliberately allowed to reach third-party code: it runs only when that path
+ *    is taken, which is exactly how `--stack` is offered without burdening the
+ *    stimulus path.
+ * 2. **Executed** — actually run the entrypoints with `evals/node_modules`
+ *    hidden. The static walk cannot see a dependency acquired some other way (a
+ *    `require`, a transitive package resolved at runtime), and "it should work"
+ *    has been wrong once already today.
+ *
+ * The second half is what the first would miss; the first is what makes the
+ * second's failures legible.
+ *
+ * ## A negative control
+ *
+ * A guard that cannot fail is worse than no guard, so the static walker is also
+ * pointed at a synthetic file containing a real bare import and must reject it.
+ * Without that, a walker broken to return nothing would report success forever.
+ *
+ * Runs straight off source via Node's built-in type stripping — no build step.
+ *
+ * Usage: npm run clean-machine:check
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { findImportReferences } from './importScanner.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const EVALS_ROOT = resolve(HERE, '..');
+const REPO_ROOT = resolve(EVALS_ROOT, '..');
+const NODE_MODULES = join(EVALS_ROOT, 'node_modules');
+
+/**
+ * Where `node_modules` is parked while the executed half runs.
+ *
+ * A fixed, self-describing name rather than a random one, so that a run killed
+ * halfway leaves something a human can identify — and so this script can restore
+ * it automatically on the next invocation instead of leaving a broken checkout.
+ */
+const PARKED = join(EVALS_ROOT, 'node_modules.parked-by-clean-machine-check');
+
+/**
+ * Everything `run.sh` invokes with `node`. Keep this in step with `run.sh`; a
+ * script added there and not here is unguarded.
+ */
+const ENTRYPOINTS = [
+    { script: 'evals/msbench/stage-graders.ts', args: [] as string[] },
+    { script: 'evals/msbench/build-config.ts', args: ['photo-app-requirements'] },
+    { script: 'evals/msbench/verify-run.ts', args: ['--self-test'] },
+];
+
+const failures: string[] = [];
+
+function fail(message: string): void {
+    failures.push(message);
+    console.error(`  ✖ ${message}`);
+}
+
+/**
+ * Collect every file reachable from `entry` through **eager** imports only,
+ * rejecting any bare specifier found on the way.
+ *
+ * `trail` carries the import chain so a failure says how the dependency was
+ * reached, which is the difference between a fix and an investigation.
+ */
+function walkEagerGraph(entry: string, seen: Set<string>, trail: string[], report: (message: string) => void): void {
+    if (seen.has(entry)) {
+        return;
+    }
+    seen.add(entry);
+
+    const absolute = join(REPO_ROOT, entry);
+    if (!existsSync(absolute)) {
+        report(`${entry} does not exist (imported by ${trail.at(-1) ?? '<entrypoint>'})`);
+        return;
+    }
+
+    for (const reference of findImportReferences(readFileSync(absolute, 'utf8'))) {
+        // Dynamic imports run only on the path that opts in; type-only imports are
+        // erased before anything runs. Neither can make a clean machine fail, and
+        // counting them produced a false failure against `build-config.ts` for
+        // importing a *type* from a module that happens to parse YAML.
+        if (reference.dynamic || reference.typeOnly || reference.specifier.startsWith('node:')) {
+            continue;
+        }
+        if (!reference.specifier.startsWith('.')) {
+            report(
+                `${entry} statically imports '${reference.specifier}' from node_modules.\n`
+                + `      chain: ${[...trail, entry].join(' -> ')}\n`
+                + `      run.sh invokes this on hosts with no node_modules. Defer it behind a dynamic\n`
+                + `      import() on the path that needs it, as build-config.ts does for --stack.`,
+            );
+            continue;
+        }
+        walkEagerGraph(
+            toPosix(relative(REPO_ROOT, resolve(dirname(absolute), reference.specifier))),
+            seen,
+            [...trail, entry],
+            report,
+        );
+    }
+}
+
+function toPosix(value: string): string {
+    return value.split(/[\\/]/).join('/');
+}
+
+function checkStaticGraphs(): void {
+    console.error('Static import graphs');
+    for (const { script } of ENTRYPOINTS) {
+        const before = failures.length;
+        walkEagerGraph(script, new Set(), [], message => fail(message));
+        if (failures.length === before) {
+            console.error(`  ✔ ${script} — no eagerly imported package dependency`);
+        }
+    }
+}
+
+/**
+ * Point the walker at a file that really does import a package, and require it
+ * to complain. A walker that silently returns nothing would otherwise report
+ * every entrypoint clean forever.
+ */
+function checkWalkerCanFail(): void {
+    console.error('\nNegative control');
+    const directory = mkdtempSync(join(tmpdir(), 'clean-machine-'));
+    try {
+        const file = join(directory, 'offender.ts');
+        writeFileSync(file, "import { parse } from 'yaml';\nexport const x = parse;\n");
+
+        const complaints: string[] = [];
+        walkEagerGraph(toPosix(relative(REPO_ROOT, file)), new Set(), [], message => complaints.push(message));
+
+        if (complaints.length === 0) {
+            fail('the static walker accepted a file that statically imports `yaml`; it cannot fail, so it proves nothing');
+        } else {
+            console.error('  ✔ a real bare import is rejected, so the walker can fail');
+        }
+    } finally {
+        rmSync(directory, { recursive: true, force: true });
+    }
+}
+
+/**
+ * Run each entrypoint for real with `evals/node_modules` moved aside.
+ *
+ * The parked directory is restored in a `finally`, and a leftover from a killed
+ * run is restored on the next invocation, because a check that can leave a
+ * developer's checkout broken will be deleted rather than fixed.
+ */
+function checkExecutesWithoutDependencies(): void {
+    console.error('\nExecuted with evals/node_modules hidden');
+
+    if (!existsSync(NODE_MODULES)) {
+        // Nothing installed at all: the executed half is exactly what CI does
+        // anyway, so run it directly rather than skipping and reporting green.
+        runEntrypoints();
+        return;
+    }
+
+    renameSync(NODE_MODULES, PARKED);
+    try {
+        runEntrypoints();
+    } finally {
+        renameSync(PARKED, NODE_MODULES);
+        console.error('  ✔ evals/node_modules restored');
+    }
+}
+
+function runEntrypoints(): void {
+    for (const { script, args } of ENTRYPOINTS) {
+        const result = spawnSync(
+            process.execPath,
+            ['--disable-warning=MODULE_TYPELESS_PACKAGE_JSON', join(REPO_ROOT, script), ...args],
+            { encoding: 'utf8', cwd: REPO_ROOT },
+        );
+        if (result.status === 0) {
+            console.error(`  ✔ ${script} ${args.join(' ')} — exit 0`);
+            continue;
+        }
+        const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim().split('\n').slice(0, 6).join('\n        ');
+        fail(`${script} ${args.join(' ')} exited ${result.status} with no node_modules:\n        ${output}`);
+    }
+}
+
+function main(): void {
+    // Restore a checkout left broken by a previous run that was killed.
+    if (existsSync(PARKED) && !existsSync(NODE_MODULES)) {
+        renameSync(PARKED, NODE_MODULES);
+        console.error('Recovered evals/node_modules parked by an interrupted earlier run.\n');
+    }
+
+    checkStaticGraphs();
+    checkWalkerCanFail();
+    checkExecutesWithoutDependencies();
+
+    console.error('');
+    if (failures.length > 0) {
+        console.error(`FAIL: ${failures.length} problem(s) above.`);
+        process.exit(1);
+    }
+    console.error(`PASS: ${ENTRYPOINTS.length} entrypoints run on a clean machine.`);
+}
+
+main();

--- a/evals/msbench/importScanner.ts
+++ b/evals/msbench/importScanner.ts
@@ -68,9 +68,37 @@ type Token =
  */
 const SPECIFIER_KEYWORDS = new Set(['from', 'import']);
 
-export function findImportSpecifiers(source: string): string[] {
+/**
+ * One import, and whether it is loaded eagerly.
+ *
+ * The distinction is load-bearing for the clean-machine check. A **static**
+ * import runs on every invocation of the module, so a script `run.sh` calls on a
+ * host with no `node_modules` cannot have one reaching a third-party package. A
+ * **dynamic** `import()` runs only when that code path is taken, which is how
+ * `build-config.ts` offers `--stack` without making the stimulus path — the one
+ * every current run uses — depend on anything.
+ */
+export interface ImportReference {
+    specifier: string;
+    dynamic: boolean;
+    /**
+     * `import type { T } from './x.ts'` — erased before the code runs.
+     *
+     * The module is never loaded, so a type-only import cannot bring a runtime
+     * dependency with it. That distinction is invisible to a regex and matters:
+     * without it the clean-machine check reports `build-config.ts` as depending
+     * on `yaml` because it imports a *type* from a module that parses YAML,
+     * which is a false failure — and a check that cries wolf gets switched off.
+     *
+     * Only statement-level `import type` / `export type` counts. An inline
+     * `import { type A, b }` still loads the module.
+     */
+    typeOnly: boolean;
+}
+
+export function findImportReferences(source: string): ImportReference[] {
     const tokens = tokenize(source);
-    const specifiers: string[] = [];
+    const references: ImportReference[] = [];
 
     for (let index = 0; index < tokens.length; index++) {
         const token = tokens[index];
@@ -83,18 +111,46 @@ export function findImportSpecifiers(source: string): string[] {
         }
         // `import x from './y.ts'`, `export { a } from './y.ts'`, `import './y.ts'`.
         if (previous.kind === 'word' && SPECIFIER_KEYWORDS.has(previous.value)) {
-            specifiers.push(token.value);
+            references.push({ specifier: token.value, dynamic: false, typeOnly: isTypeOnlyStatement(tokens, index) });
             continue;
         }
         // `await import('./y.ts')` — the specifier sits behind the parenthesis.
         if (previous.kind === 'punct' && previous.value === '(') {
             const beforeParen = tokens[index - 2];
             if (beforeParen?.kind === 'word' && beforeParen.value === 'import') {
-                specifiers.push(token.value);
+                references.push({ specifier: token.value, dynamic: true, typeOnly: false });
             }
         }
     }
-    return specifiers;
+    return references;
+}
+
+/**
+ * Walk back to the statement's `import`/`export` keyword and ask whether `type`
+ * follows it.
+ *
+ * Bounded rather than unbounded: a malformed file should cost one wrong answer,
+ * not a scan of everything before it. An import clause long enough to exceed
+ * this is not something this repository contains.
+ */
+function isTypeOnlyStatement(tokens: Token[], specifierIndex: number): boolean {
+    const limit = Math.max(0, specifierIndex - 128);
+    for (let index = specifierIndex - 1; index >= limit; index--) {
+        const token = tokens[index];
+        if (token.kind !== 'word') {
+            continue;
+        }
+        if (token.value === 'import' || token.value === 'export') {
+            const next = tokens[index + 1];
+            return next?.kind === 'word' && next.value === 'type';
+        }
+    }
+    return false;
+}
+
+/** Specifiers only. `stage-graders.ts` stages every reachable file, eager or not. */
+export function findImportSpecifiers(source: string): string[] {
+    return findImportReferences(source).map(reference => reference.specifier);
 }
 
 function tokenize(source: string): Token[] {
@@ -301,6 +357,8 @@ interface ScannerCase {
     name: string;
     source: string;
     expected: string[];
+    /** Optional stricter expectation over the full references, not just specifiers. */
+    expectedReferences?: ImportReference[];
 }
 
 /**
@@ -358,9 +416,34 @@ const CASES: ScannerCase[] = [
         expected: ['./reexport.ts'],
     },
     {
-        name: 'type-only import is found, as before',
+        name: 'type-only import is found, and marked type-only',
         source: 'import type { T } from \'./types.ts\';',
         expected: ['./types.ts'],
+        expectedReferences: [{ specifier: './types.ts', dynamic: false, typeOnly: true }],
+    },
+    {
+        name: 'a value import is not marked type-only',
+        source: 'import { a } from \'./values.ts\';',
+        expected: ['./values.ts'],
+        expectedReferences: [{ specifier: './values.ts', dynamic: false, typeOnly: false }],
+    },
+    {
+        name: 'an inline type specifier still loads the module',
+        source: 'import { type A, b } from \'./mixed.ts\';',
+        expected: ['./mixed.ts'],
+        expectedReferences: [{ specifier: './mixed.ts', dynamic: false, typeOnly: false }],
+    },
+    {
+        name: 'export type is type-only too',
+        source: 'export type { T } from \'./reexported-types.ts\';',
+        expected: ['./reexported-types.ts'],
+        expectedReferences: [{ specifier: './reexported-types.ts', dynamic: false, typeOnly: true }],
+    },
+    {
+        name: 'a dynamic import is never type-only',
+        source: 'const m = await import(\'./dyn2.ts\');',
+        expected: ['./dyn2.ts'],
+        expectedReferences: [{ specifier: './dyn2.ts', dynamic: true, typeOnly: false }],
     },
     {
         name: 'multi-line import statement is found',
@@ -383,7 +466,10 @@ export function selfTest(): number {
     let failed = 0;
     for (const testCase of CASES) {
         const actual = findImportSpecifiers(testCase.source);
-        const ok = JSON.stringify(actual) === JSON.stringify(testCase.expected);
+        let ok = JSON.stringify(actual) === JSON.stringify(testCase.expected);
+        if (ok && testCase.expectedReferences) {
+            ok = JSON.stringify(findImportReferences(testCase.source)) === JSON.stringify(testCase.expectedReferences);
+        }
         if (ok) {
             console.error(`  ✔ ${testCase.name}`);
         } else {

--- a/evals/package.json
+++ b/evals/package.json
@@ -11,6 +11,7 @@
         "lint:local-dev": "vally lint --eval-spec local-dev/eval.yaml",
         "typecheck": "tsc --noEmit -p tsconfig.json",
         "imports:self-test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON msbench/importScanner.ts --self-test",
+        "clean-machine:check": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON msbench/check-clean-machine.ts",
         "certify": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON src/graderCertification.ts",
         "stacks:check": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON check-stacks.ts",
         "regrade": "node --disable-warning=ExperimentalWarning msbench/regrade.ts",


### PR DESCRIPTION
`run.sh` promises *"a clean machine with `az login` already done should be able to execute this unmodified"*, and the MSBench `eval` job depends on it: checkout, setup-node, download the VSIX artifact, `run.sh --skip-build`. **Nothing installs anything on that host.** A script `run.sh` invokes that statically imports a third-party package therefore fails there — on the one path where failure costs money.

That rule was written down two PRs ago, in prose, as the reason `stage-graders.ts` could not use `ts.preProcessFile`. **The next change to the same file family, by the same author the same night, broke it**: four static imports of a YAML-parsing module in `build-config.ts`, and `build` went red with `Cannot find package 'yaml'`.

Knowing the rule and writing it down did not enforce it. CI did. So it stops being prose.

## Two halves, because either alone is fooled

**Static** — walk the eagerly-imported graph of every entrypoint `run.sh` invokes and reject a bare specifier, naming the file *and the chain that reached it*:

```
✖ evals/src/containerInventory.ts statically imports 'yaml' from node_modules.
    chain: evals/msbench/build-config.ts -> evals/src/gateWiring.ts -> evals/src/stack.ts
           -> evals/src/containerInventory.ts
    run.sh invokes this on hosts with no node_modules. Defer it behind a dynamic
    import() on the path that needs it, as build-config.ts does for --stack.
```

**Executed** — run those entrypoints for real with `evals/node_modules` moved aside. The static walk cannot see a dependency acquired some other way, and *"it should work"* has already been wrong once today.

## What running it taught me, immediately

The first version **reported a false failure**: `build-config.ts` was flagged as depending on `yaml` because it imports a *type* from a module that parses YAML. Type-only imports are erased before anything runs, so that dependency does not exist — and **a check that cries wolf gets switched off**, which would have been a worse outcome than no check.

So the scanner now reports `typeOnly` per reference, with cases covering statement-level `import type`, `export type`, and an inline `{ type A, b }` specifier that *does* still load the module. Dynamic `import()` is excluded for the same reason: it runs only on the path that opts in, which is exactly how `--stack` is offered without burdening the stimulus path every current run uses. 17/17 scanner cases.

I would not have found that by reading the code. I found it by running it against the real tree.

## Proof it can fail

A **negative control** points the walker at a synthetic file that really does import a package and requires it to complain — without which a walker broken to return nothing would report every entrypoint clean forever.

And the original regression, reintroduced deliberately:

```
✖ evals/src/containerInventory.ts statically imports 'yaml' from node_modules.
✖ evals/msbench/build-config.ts photo-app-requirements exited 1 with no node_modules
FAIL: 2 problem(s) above.                                                    EXIT=1
```

Both halves catch it independently — one names the chain, one fails to execute.

## One deliberate placement

The CI step is **last** in the `contracts` job. It moves `node_modules` aside and restores it in a `finally`; running it after everything else means that even a catastrophic failure to restore cannot make an unrelated step fail with a confusing error. A run killed mid-flight parks the directory under a self-describing name, and the next invocation restores it rather than leaving a developer with a broken checkout.

## Verification

All seven credential-free gates green locally: `typecheck`, `imports:self-test` (17/17), `stacks:check` (34/34), `drift`, `certify` (81/81), `lint`, `clean-machine:check`. 4 files, +348/−7.

**No MSBench run was submitted.**
