### PR TITLE
Read the stack declaration, and stop asserting that a worker listens

### DIFF
--- a/evals/results/grader-certification/offline/report.json
+++ b/evals/results/grader-certification/offline/report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-26T08:05:29.111Z",
+  "generatedAt": "2026-08-26T08:25:42.197Z",
   "mode": "offline",
   "fixtures": [
     "sample-agent-output",

--- a/evals/src/runtime/appProcess.ts
+++ b/evals/src/runtime/appProcess.ts
@@ -61,6 +61,7 @@ const MAX_CAPTURED_OUTPUT = 64 * 1024;
 
 /** Where the port that answered came from. */
 export type PortProvenance =
+    | 'notApplicable'
     | 'remapped'
     | 'declaredDespiteRemap'
     | 'declared'
@@ -72,9 +73,9 @@ export interface RuntimeFinding {
 }
 
 export interface RunningApp {
-    /** The port the app was found listening on. */
-    readonly port: number;
-    readonly baseUrl: string;
+    /** The port the app was found listening on; absent for a worker with no HTTP surface. */
+    readonly port?: number;
+    readonly baseUrl?: string;
     readonly portProvenance: PortProvenance;
     /**
      * Something true and worth saying that is not this gate's verdict — currently only
@@ -159,7 +160,23 @@ class OutputBuffer {
 
 export interface StartOptions {
     startupTimeoutMs?: number;
+    /**
+     * What counts as "up".
+     *
+     * `listening` is the web case: the app must accept a connection. `alive` is the
+     * background-worker case, where there is no HTTP surface and the only honest positive
+     * assertion is that the process is *still running* after a settling window.
+     *
+     * Deliberately an assertion rather than an exemption. "This stack declares no API, so
+     * skip the check" would be a gate that is wired, runs, and cannot fail — and one that
+     * fails *open on a declaration*, so a mis-declared stack would buy itself immunity. A
+     * worker that exits immediately, or dies two seconds in, still fails.
+     */
+    expect?: 'listening' | 'alive';
 }
+
+/** How long a worker must stay up before we accept that it started. */
+const WORKER_LIVENESS_WINDOW_MS = 5_000;
 
 /**
  * Start `target`, wait for it to listen, and hand back a handle.
@@ -212,6 +229,36 @@ export async function startApp(target: RuntimeTarget, options: StartOptions = {}
     child.once('error', error => {
         spawnError = error;
     });
+
+    if (options.expect === 'alive') {
+        await sleep(WORKER_LIVENESS_WINDOW_MS);
+        const captured = output.read();
+        if (exit) {
+            await stopChild(entry);
+            return {
+                kind: 'productFailure',
+                code: 'appExitedBeforeReadiness',
+                message: `the worker exited ${describeExit(exit)} within ${WORKER_LIVENESS_WINDOW_MS / 1000}s of starting `
+                    + `(started with "${commandLine}" in ${target.cwd}). A background worker is expected to stay running.`,
+                output: captured,
+            };
+        }
+        if (spawnError) {
+            await stopChild(entry);
+            return { kind: 'harnessFault', message: `"${commandLine}" could not be launched: ${spawnError.message}`, output: captured };
+        }
+        return {
+            kind: 'started',
+            app: {
+                port: undefined,
+                baseUrl: undefined,
+                portProvenance: 'notApplicable',
+                findings: [],
+                output: () => output.read(),
+                stop: () => stopChild(entry),
+            },
+        };
+    }
 
     const readiness = await waitForReadiness({
         plan,

--- a/evals/src/runtime/runtimeGates.ts
+++ b/evals/src/runtime/runtimeGates.ts
@@ -103,7 +103,12 @@ export async function validateAppStarts(workspaceRoot: string): Promise<RuntimeV
     const { app, target } = session as Extract<RuntimeSession, { kind: 'started' }>;
     return pass([
         `started with "${[target.command, ...target.args].join(' ')}" in ${target.cwd} (${target.startSource})`,
-        `listening on ${app.baseUrl} (port ${app.portProvenance})`,
+        app.baseUrl === undefined
+            // The stack declares no API, so "it listened" was never the right assertion.
+            // What was checked is that the process was still running after a settling
+            // window — falsifiable, and failed by a worker that exits on startup.
+            ? 'no HTTP surface declared (project.api: none); still running after the liveness window'
+            : `listening on ${app.baseUrl} (port ${app.portProvenance})`,
         ...app.findings.map(finding => `finding [${finding.code}]: ${finding.message}`),
     ]);
 }
@@ -146,14 +151,20 @@ export async function validateHealthEndpoint(workspaceRoot: string, options: Hea
         return blocked;
     }
     const { app, target } = session as Extract<RuntimeSession, { kind: 'started' }>;
+    const httpSurface = requireHttpSurface(session);
+    if (typeof httpSurface !== 'string') {
+        return httpSurface;
+    }
+    const baseUrl = httpSurface;
+
 
     if (target.healthPath) {
-        const result = await probe(`${app.baseUrl}${target.healthPath}`);
+        const result = await probe(`${baseUrl}${target.healthPath}`);
         if (!result.ok) {
             return failure(
                 'healthEndpointUnreachable',
                 target.healthPath,
-                `the app is listening on ${app.baseUrl} but the health endpoint ${target.healthPath} `
+                `the app is listening on ${baseUrl} but the health endpoint ${target.healthPath} `
                 + `(declared in ${describeHealthSource(target.healthPathSource)}) could not be reached: ${result.error}.`,
                 app.output(),
             );
@@ -172,7 +183,7 @@ export async function validateHealthEndpoint(workspaceRoot: string, options: Hea
 
     const attempts: string[] = [];
     for (const candidate of CONVENTIONAL_HEALTH_PATHS) {
-        const result = await probe(`${app.baseUrl}${candidate}`);
+        const result = await probe(`${baseUrl}${candidate}`);
         if (result.ok && isSuccess(result.response.status)) {
             return pass([`${candidate} → ${result.response.status} (guessed; the project declared no health path)`]);
         }
@@ -183,7 +194,7 @@ export async function validateHealthEndpoint(workspaceRoot: string, options: Hea
         return failure(
             'healthEndpointMissing',
             '$.health',
-            `the app is listening on ${app.baseUrl} but no health endpoint answered. Tried: ${attempts.join(', ')}.`,
+            `the app is listening on ${baseUrl} but no health endpoint answered. Tried: ${attempts.join(', ')}.`,
             app.output(),
         );
     }
@@ -195,7 +206,7 @@ export async function validateHealthEndpoint(workspaceRoot: string, options: Hea
         return failure(
             'healthEndpointMissing',
             '$.health',
-            `the app is listening on ${app.baseUrl} but has no health endpoint: nothing is declared in its API test collections, `
+            `the app is listening on ${baseUrl} but has no health endpoint: nothing is declared in its API test collections, `
             + '.azure/integration-plan.md or .azure/vscode-debug-plan.md, and no conventional path answered. '
             + `The project has an integration plan, whose Backend section is required to name a health endpoint path. Tried: ${attempts.join(', ')}.`,
             app.output(),
@@ -203,7 +214,7 @@ export async function validateHealthEndpoint(workspaceRoot: string, options: Hea
     }
     return notApplicable(
         'noHealthPathDeclared',
-        `the app is listening on ${app.baseUrl} but no health endpoint answered (tried ${attempts.join(', ')}), and the workspace `
+        `the app is listening on ${baseUrl} but no health endpoint answered (tried ${attempts.join(', ')}), and the workspace `
         + 'has no .azure/integration-plan.md, so there is no record of it having promised one. The gate has a real question here '
         + 'and no contract to check it against; pass --require-health to fail instead.',
     );
@@ -233,6 +244,12 @@ export async function validateFrontendServes(workspaceRoot: string, options: Fro
         return blocked;
     }
     const { app, target } = session as Extract<RuntimeSession, { kind: 'started' }>;
+    const httpSurface = requireHttpSurface(session);
+    if (typeof httpSurface !== 'string') {
+        return httpSurface;
+    }
+    const baseUrl = httpSurface;
+
 
     const separate = await discoverFrontendDirectory(workspaceRoot);
     if (separate && path.resolve(separate) !== path.resolve(target.packageDirectory)) {
@@ -247,9 +264,9 @@ export async function validateFrontendServes(workspaceRoot: string, options: Fro
         return notApplicable('noFrontendDeclared', 'the project serves no index.html, so it has no browser frontend to probe.');
     }
 
-    const result = await probe(`${app.baseUrl}/`);
+    const result = await probe(`${baseUrl}/`);
     if (!result.ok) {
-        return failure('frontendUnreachable', '/', `the frontend at ${app.baseUrl}/ could not be reached: ${result.error}.`, app.output());
+        return failure('frontendUnreachable', '/', `the frontend at ${baseUrl}/ could not be reached: ${result.error}.`, app.output());
     }
     if (!isSuccess(result.response.status)) {
         return failure('frontendNotServed', '/', `the app returned ${result.response.status} for / instead of the frontend: ${excerpt(result.response.body)}`, app.output());
@@ -286,6 +303,12 @@ export async function validateFrontendApiWiring(workspaceRoot: string): Promise<
         return blocked;
     }
     const { app, target } = session as Extract<RuntimeSession, { kind: 'started' }>;
+    const httpSurface = requireHttpSurface(session);
+    if (typeof httpSurface !== 'string') {
+        return httpSurface;
+    }
+    const baseUrl = httpSurface;
+
 
     const separate = await discoverFrontendDirectory(workspaceRoot);
     if (separate && path.resolve(separate) !== path.resolve(target.packageDirectory)) {
@@ -295,12 +318,12 @@ export async function validateFrontendApiWiring(workspaceRoot: string): Promise<
         );
     }
 
-    const document = await probe(`${app.baseUrl}/`);
+    const document = await probe(`${baseUrl}/`);
     if (!document.ok || !isSuccess(document.response.status) || !looksLikeHtml(document.response)) {
         return notApplicable('noFrontendDeclared', 'the app serves no browser document at /, so there is no frontend wiring to check.');
     }
 
-    const { calls, usesHttpClient } = await collectApiCalls(app.baseUrl, document.response.body);
+    const { calls, usesHttpClient } = await collectApiCalls(baseUrl, document.response.body);
     if (calls.length === 0) {
         switch (attributeAbsence({
             couldNotRead: usesHttpClient,
@@ -321,7 +344,7 @@ export async function validateFrontendApiWiring(workspaceRoot: string): Promise<
                 return failure(
                     'frontendMakesNoApiCalls',
                     '/',
-                    `the served frontend at ${app.baseUrl}/ issues no HTTP requests whatsoever, while `
+                    `the served frontend at ${baseUrl}/ issues no HTTP requests whatsoever, while `
                     + '.azure/integration-plan.md declares the API routes it was supposed to call. '
                     + 'The two halves were built and never connected.',
                     app.output(),
@@ -338,7 +361,7 @@ export async function validateFrontendApiWiring(workspaceRoot: string): Promise<
     const issues: ArtifactValidationIssue[] = [];
     const checked: string[] = [];
     for (const call of calls) {
-        const result = await probe(`${app.baseUrl}${call}`);
+        const result = await probe(`${baseUrl}${call}`);
         if (!result.ok) {
             issues.push(issue('frontendApiRouteUnreachable', call, `the frontend calls ${call}, which could not be reached on the running backend: ${result.error}.`));
             continue;
@@ -377,6 +400,12 @@ export async function validateCrudRoundTrip(workspaceRoot: string): Promise<Runt
         return blocked;
     }
     const { app, target } = session as Extract<RuntimeSession, { kind: 'started' }>;
+    const httpSurface = requireHttpSurface(session);
+    if (typeof httpSurface !== 'string') {
+        return httpSurface;
+    }
+    const baseUrl = httpSurface;
+
 
     const datastore = await findContainerDatastore(target.packageDirectory);
     if (datastore) {
@@ -387,17 +416,34 @@ export async function validateCrudRoundTrip(workspaceRoot: string): Promise<Runt
         );
     }
 
-    const document = await probe(`${app.baseUrl}/`);
+    const document = await probe(`${baseUrl}/`);
     const servesFrontend = document.ok && looksLikeHtml(document.response);
-    const collection = servesFrontend
-        ? await findCollectionEndpoint(app.baseUrl, document.response.body)
+    const extracted = servesFrontend
+        ? await findCollectionEndpoint(baseUrl, document.response.body)
         : undefined;
+
+    // Rung 0 for the route. The *fields* still come from the frontend, because the stack
+    // schema declares a route but not a payload shape — and posting `{}` to a correctly
+    // validating API earns a 400, which would be a fabricated product failure. So a
+    // declared route with no readable payload is reported as our gap, not the product's.
+    if (target.collectionRoute && !extracted) {
+        return harnessFault(
+            `the stack declares project.collectionRoute: ${target.collectionRoute}, but no request body shape could be `
+            + 'extracted from the served frontend, so this gate cannot build a payload the API would accept. '
+            + 'Declaring a payload shape alongside the route would close this.',
+            app.output(),
+            'collectionPayloadUnknown',
+        );
+    }
+    const collection = target.collectionRoute && extracted
+        ? { path: target.collectionRoute, fields: extracted.fields }
+        : extracted;
     if (!collection) {
         // Same attribution rule as the wiring gate. A frontend that plainly posts, whose
         // URL or body shape we could not extract, is our limitation — and reporting it as
         // "this project has no CRUD" is how the gate quietly stopped testing anything.
         const { usesHttpClient } = servesFrontend
-            ? await collectApiCalls(app.baseUrl, document.response.body)
+            ? await collectApiCalls(baseUrl, document.response.body)
             : { usesHttpClient: false };
         if (usesHttpClient) {
             return harnessFault(
@@ -421,7 +467,7 @@ export async function validateCrudRoundTrip(workspaceRoot: string): Promise<Runt
         payload[field] = marker;
     }
 
-    const created = await probe(`${app.baseUrl}${collection.path}`, {
+    const created = await probe(`${baseUrl}${collection.path}`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(payload),
@@ -438,7 +484,7 @@ export async function validateCrudRoundTrip(workspaceRoot: string): Promise<Runt
         );
     }
 
-    const readBack = await probe(`${app.baseUrl}${collection.path}`);
+    const readBack = await probe(`${baseUrl}${collection.path}`);
     if (!readBack.ok) {
         return failure('crudReadUnreachable', collection.path, `GET ${collection.path} could not be reached after a successful create: ${readBack.error}.`, app.output());
     }
@@ -468,6 +514,22 @@ export async function validateCrudRoundTrip(workspaceRoot: string): Promise<Runt
  * the startup failure with the same code, so a broken app produces one obvious root cause
  * across the suite rather than five different-looking symptoms.
  */
+/**
+ * Gates 2-5 all probe over HTTP, so they all need the same guard: a background worker has
+ * no surface to probe. This is the one genuinely out-of-scope case in the vocabulary —
+ * nothing to look at, and no remedy would change that, because the stack declared the
+ * project has no API. Gate 1 deliberately does not use this: for a worker it asserts
+ * liveness instead, so the suite still has one gate that can fail.
+ */
+function requireHttpSurface(session: RuntimeSession): string | RuntimeValidationResult {
+    const baseUrl = session.kind === 'started' ? session.app.baseUrl : undefined;
+    return baseUrl ?? notApplicable(
+        'noHttpSurface',
+        'the stack declares project.api: none, so this project is a background worker with no HTTP surface to probe. '
+        + 'runtime-app-starts still asserts it stays running.',
+    );
+}
+
 function describeUnusableSession(session: RuntimeSession): RuntimeValidationResult | undefined {
     switch (session.kind) {
         case 'started':

--- a/evals/src/runtime/runtimeSession.ts
+++ b/evals/src/runtime/runtimeSession.ts
@@ -84,7 +84,9 @@ async function openSession(workspaceRoot: string): Promise<RuntimeSession> {
         };
     }
 
-    const outcome = await startApp(target);
+    // A stack declaring `project.api: none` is a background worker: asserting it listens
+    // would be a false red on an app behaving exactly as designed, so assert it stays alive.
+    const outcome = await startApp(target, { expect: target.apiKind === 'none' ? 'alive' : 'listening' });
     if (outcome.kind === 'started') {
         return { kind: 'started', app: outcome.app, target };
     }
@@ -112,7 +114,8 @@ export async function releaseRuntimeSessions(): Promise<void> {
             continue;
         }
         await session.app.stop();
-        if (!await waitForPortRelease(session.app.port)) {
+        // A worker holds no port, so there is nothing to wait for its release.
+        if (session.app.port !== undefined && !await waitForPortRelease(session.app.port)) {
             process.stderr.write(
                 `[runtime] WARNING: port ${session.app.port} is still accepting connections after teardown. `
                 + 'A process escaped the group kill and will break later runs on this machine.\n');

--- a/evals/src/runtime/runtimeTarget.ts
+++ b/evals/src/runtime/runtimeTarget.ts
@@ -67,6 +67,7 @@ export type NotApplicableReason =
     | 'frontendDevServerUnsupported'
     | 'noFrontendApiCalls'
     | 'noCollectionRouteDeclared'
+    | 'noHttpSurface'
     | 'datastoreRequiresContainer';
 
 /**
@@ -101,6 +102,9 @@ export const RUNTIME_NOT_APPLICABLE_CLASS: Record<NotApplicableReason, 'outOfSco
     // failure wearing an out-of-scope costume. The stack schema predicts the same thing
     // structurally — an `outOfScope` verdict in a real run is close to a bug report.
     noFrontendDeclared: 'outOfScope',
+    // A declared background worker has no HTTP surface, and no work on our side would
+    // give it one. Genuinely nothing to look at — the case the class was invented for.
+    noHttpSurface: 'outOfScope',
     // Reachable only when the served frontend makes no HTTP calls *and* nothing declared
     // the routes it owed. When either is untrue the gate now has a verdict.
     noFrontendApiCalls: 'coverageGap',
@@ -141,6 +145,16 @@ export interface RuntimeTarget {
     };
     healthPath?: string;
     healthPathSource?: HealthPathSource;
+    /**
+     * What the stack says this project *is*, when a stack declared it.
+     *
+     * `none` means a background worker with no HTTP surface. Without it there is no way to
+     * tell an app that was never going to listen from one that failed to, and the gates
+     * were resolving that ambiguity by reporting a harness fault forever.
+     */
+    apiKind?: 'none' | 'http';
+    /** The stack's declared collection endpoint, replacing a regex over frontend source. */
+    collectionRoute?: string;
     workspaceRoot: string;
     /** Directory of the `package.json` the app belongs to. */
     packageDirectory: string;
@@ -190,8 +204,90 @@ interface PackageManifest {
     dependencies: Record<string, string>;
 }
 
+/**
+ * The stack declaration, as projected to JSON by `build-config`.
+ *
+ * Rung 0 of every discovery chain in this module, and the only rung that is a *statement*
+ * rather than an inference. It is read as JSON rather than YAML deliberately: the graders
+ * run from source in a container with no `node_modules`, and `stage-graders` refuses any
+ * grader reachable from a bare specifier — so importing the `yaml` package here would break
+ * staging rather than fail at runtime.
+ *
+ * Absent fields are omitted rather than nulled, so "declared" and "declared as nothing"
+ * stay distinguishable — a distinction two gate verdicts now turn on.
+ */
+export interface StackProjection {
+    id: string;
+    api: 'none' | 'http';
+    healthPath?: string;
+    collectionRoute?: string;
+    start?: {
+        command: string;
+        args?: string[];
+        cwd?: string;
+        port?: { value: number; remap?: PortRemap };
+    };
+}
+
+/**
+ * Where the projection is staged. `/agent/assets/stack.json` is the container path;
+ * the env var exists so a grader run by hand can be pointed at one.
+ */
+function stackProjectionCandidates(): string[] {
+    const configured = process.env.COR_STACK_PROJECTION;
+    return [
+        ...(configured ? [configured] : []),
+        '/agent/assets/stack.json',
+        path.resolve(import.meta.dirname, '..', '..', 'msbench', 'assets', 'stack.json'),
+    ];
+}
+
+/**
+ * Read the stack declaration, or nothing.
+ *
+ * A missing projection is the normal case outside an MSBench run and must never be an
+ * error: every rung below this one still works, which is the point of a cascade.
+ */
+export async function readStackProjection(): Promise<StackProjection | undefined> {
+    for (const candidate of stackProjectionCandidates()) {
+        const text = await readFileSafe(candidate);
+        if (text === undefined) {
+            continue;
+        }
+        try {
+            const parsed = JSON.parse(text) as StackProjection;
+            if (typeof parsed?.id === 'string' && (parsed.api === 'none' || parsed.api === 'http')) {
+                return parsed;
+            }
+        } catch {
+            // A malformed projection is not worth failing a gate over; the cascade covers it.
+        }
+    }
+    return undefined;
+}
+
 export async function resolveRuntimeTarget(workspaceRoot: string): Promise<RuntimeTargetResolution> {
+    const stack = await readStackProjection();
     const packages = await discoverPackages(workspaceRoot);
+
+    // Rung 0. A stack that declares its own start command is answering for an ecosystem the
+    // rungs below may not be able to walk at all — which is the only place a declaration
+    // earns its keep. Where the cascade works, stacks deliberately declare nothing, so that
+    // rung 0 does not become the place people put things to avoid making discovery work.
+    if (stack?.start) {
+        const cwd = stack.start.cwd ? path.resolve(workspaceRoot, stack.start.cwd) : workspaceRoot;
+        return await completeTarget(workspaceRoot, packageFor(cwd, packages) ?? emptyPackage(cwd), {
+            command: stack.start.command,
+            args: stack.start.args ?? [],
+            cwd,
+            env: {},
+            startSource: 'stackDeclaration',
+            port: stack.start.port
+                ? { declared: stack.start.port.value, source: 'stackDeclaration', remap: stack.start.port.remap }
+                : { source: 'undeclared' },
+        }, stack);
+    }
+
     if (packages.length === 0) {
         return await describeMissingNodeProject(workspaceRoot);
     }
@@ -201,12 +297,12 @@ export async function resolveRuntimeTarget(workspaceRoot: string): Promise<Runti
         return functions;
     }
 
-    const fromLaunch = await resolveFromLaunchConfiguration(workspaceRoot, packages);
+    const fromLaunch = await resolveFromLaunchConfiguration(workspaceRoot, packages, stack);
     if (fromLaunch) {
         return fromLaunch;
     }
 
-    const fromScript = resolveFromStartScript(workspaceRoot, packages);
+    const fromScript = resolveFromStartScript(workspaceRoot, packages, stack);
     if (fromScript) {
         return fromScript;
     }
@@ -229,15 +325,22 @@ export async function resolveRuntimeTarget(workspaceRoot: string): Promise<Runti
 async function completeTarget(
     workspaceRoot: string,
     manifest: PackageManifest,
-    partial: Omit<RuntimeTarget, 'healthPath' | 'healthPathSource' | 'workspaceRoot' | 'packageDirectory' | 'declaresDependencies' | 'dependenciesInstalled'>,
+    partial: Omit<RuntimeTarget, 'healthPath' | 'healthPathSource' | 'apiKind' | 'collectionRoute' | 'workspaceRoot' | 'packageDirectory' | 'declaresDependencies' | 'dependenciesInstalled'>,
+    stack?: StackProjection,
 ): Promise<RuntimeTargetResolution> {
-    const health = await discoverHealthPath(workspaceRoot);
+    // Rung 0 first: a declared health path is a statement, and every rung below it is an
+    // inference from artifacts the agent happened to write.
+    const health = stack?.healthPath
+        ? { path: stack.healthPath, source: 'stackDeclaration' as HealthPathSource }
+        : await discoverHealthPath(workspaceRoot);
     return {
         kind: 'resolved',
         target: {
             ...partial,
             healthPath: health?.path,
             healthPathSource: health?.source,
+            apiKind: stack?.api,
+            collectionRoute: stack?.collectionRoute,
             workspaceRoot,
             packageDirectory: manifest.directory,
             declaresDependencies: Object.keys(manifest.dependencies).length > 0,
@@ -249,6 +352,7 @@ async function completeTarget(
 async function resolveFromLaunchConfiguration(
     workspaceRoot: string,
     packages: PackageManifest[],
+    stack?: StackProjection,
 ): Promise<RuntimeTargetResolution | undefined> {
     const launchPath = path.join(workspaceRoot, '.vscode', 'launch.json');
     let parsed: unknown;
@@ -307,7 +411,7 @@ async function resolveFromLaunchConfiguration(
             startSource: 'launchConfiguration',
             launchConfigName: asString(config.name),
             port: readPort(env, args),
-        });
+        }, stack);
     }
     return undefined;
 }
@@ -315,6 +419,7 @@ async function resolveFromLaunchConfiguration(
 function resolveFromStartScript(
     workspaceRoot: string,
     packages: PackageManifest[],
+    stack?: StackProjection,
 ): Promise<RuntimeTargetResolution> | undefined {
     const manifest = packages.find(value => typeof value.scripts.start === 'string' && value.scripts.start.trim());
     if (!manifest) {
@@ -342,7 +447,7 @@ function resolveFromStartScript(
         port: port.declared === undefined
             ? port
             : { declared: port.declared, source: 'packageJsonStartScript' },
-    });
+    }, stack);
 }
 
 /**
@@ -541,6 +646,10 @@ async function discoverPackages(workspaceRoot: string): Promise<PackageManifest[
 }
 
 /** The package that owns `directory`, preferring the deepest one that contains it. */
+function emptyPackage(directory: string): PackageManifest {
+    return { directory, scripts: {}, dependencies: {} };
+}
+
 function packageFor(directory: string, packages: PackageManifest[]): PackageManifest {
     const containing = packages
         .filter(value => directory === value.directory || directory.startsWith(`${value.directory}${path.sep}`))


### PR DESCRIPTION
Wires **rung 0** of the discovery chains to `assets/stack.json`, and gives `runtime-app-starts` a verdict it can actually reach for a background worker.

## First: the defect I set out to fix mostly does not exist

Instructed to verify the behaviour before fixing it, I did, and the prediction was wrong in a way worth recording:

| worker shape | today's verdict |
|---|---|
| no declared port | **exit 3** — "no port could be determined" |
| **with** a declared port (`launch.json` `env.PORT`) | **exit 1** `appNeverListened` — the false red |

Only the second is the false red I claimed. The first was already covered by the injected-port rule added during the original review — I had forgotten my own fix and proposed a second one for the same case.

So the bug is real but narrower than advertised. **The common shape was wrong in a different way**: a permanently unscoreable exit 3, a gate that never discriminates for that stack. Honest, and useless.

That is the second claim of mine in two days that did not survive checking (the first being `GRADER ERROR` verdicts supposedly counted as failures, which never reproduced). The pattern is mine: reasoning one step past what I have actually checked.

## The worker assertion is positive, not an exemption

With `project.api: none`, `runtime-app-starts` asserts **the process is still running after a settling window**.

Deliberately an assertion rather than a skip. *"This stack declares no API, so do not check"* would be a gate that is wired, runs, and cannot fail — and one that **fails open on a declaration**, so a mis-declared stack buys itself immunity. That is strictly worse than the original bug, because the declaration makes it look deliberate.

A worker that exits immediately still fails, with `appExitedBeforeReadiness`.

Gates 2-5 report `noHttpSurface` — **the first genuinely out-of-scope reason in the vocabulary.** Nothing to look at, and no work on our side would give a worker an HTTP surface. Gate 1 deliberately does *not* take that exit, so the suite keeps one gate that can fail for a worker stack.

## Rung 0

**JSON, not YAML** — the graders run from source in a container with no `node_modules`, and `stage-graders` refuses any grader reachable from a bare specifier, so importing `yaml` here would break staging rather than fail at runtime. A missing projection is the normal case outside an MSBench run and is never an error: every rung below still works, which is the point of a cascade.

**Rung 0 only answers where it was asked to.** A declared `start` supplies a command for stacks whose ecosystem the chain cannot walk. Both shipped stacks are Node and deliberately declare none — the cascade already works there, and declaring one would replace working discovery with a guess about a layout the agent picks at runtime.

**`project.collectionRoute` replaces the shakiest inference in the suite** — a regex over served frontend JavaScript hunting a `fetch` with a POST body. But the *fields* still come from the frontend, because the schema declares a route and not a payload shape, and posting an empty object to a correctly validating API earns a 400 that would be a fabricated product failure. A declared route with no readable payload is reported as **our** gap (`collectionPayloadUnknown`), not the product's. A payload shape in the schema would close it.

Verified:

```
rung 0 health  -> /api/health -> 200 (declared in the stack declaration)
rung 0 start   -> started with "node src/server.js" (stackDeclaration)
                  listening on http://127.0.0.1:54921 (port remapped)
```

## Certification: 84/84, and what it does not cover

The worker paths are verified **by hand, both directions, asserting the code rather than the colour** — a healthy worker passes; one that returns immediately fails with `appExitedBeforeReadiness` specifically, not merely red.

They are **not certified**, and the reason is structural: exercising them needs a fixture that carries its own stack declaration, i.e. per-fixture environment setup. That is the machinery #1722 is building for the port squatter. Rather than invent a second mechanism, I would add the worker fixture there.

If a smaller path is preferred, the smallest is letting `readStackProjection` accept a workspace-scoped override so a fixture can ship one — raising it rather than doing it unilaterally, since it means a test-only lookup path in production code.
