### PR TITLE
Tell gate-health which reds we already agreed to pay for

### DIFF
--- a/evals/check-stacks.ts
+++ b/evals/check-stacks.ts
@@ -60,6 +60,7 @@ import { ConfigValidationError } from './src/configValidation.ts';
 import { countAsserted, loadContainerInventory } from './src/containerInventory.ts';
 import { loadGateTable } from './src/gateTable.ts';
 import type { GateTable } from './src/gateTable.ts';
+import { selfTestDeclaredGaps } from './src/declaredGaps.ts';
 import { checkKnownGapsAgainstTable, deriveWiring, explainWiring, teachesNothing } from './src/gateWiring.ts';
 import { loadStack } from './src/stack.ts';
 import type { Stack, StackLoadOptions } from './src/stack.ts';
@@ -347,6 +348,15 @@ function main(): void {
 
     checkWiringSnapshots(stacks, table);
     checkDerivationBranches(stacks, table);
+
+    // The join that lets gate-health separate "declared, tracked" from
+    // "undeclared — go look". Checked here rather than in its own command so
+    // there is one place to look for "is the stack machinery sound?".
+    console.error('\nDeclared-gap join');
+    const joinFailures = selfTestDeclaredGaps(line => console.error(line));
+    if (joinFailures > 0) {
+        fail(`${joinFailures} declared-gap join case(s) failed`);
+    }
 
     // ---- Half two: the broken fixtures must be rejected, by name -----------
     const provenStack = checkFixtureDirectory(

--- a/evals/msbench/gate-health.ts
+++ b/evals/msbench/gate-health.ts
@@ -66,6 +66,7 @@ import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { fileURLToPath } from 'node:url';
+import type { DeclaredGap } from '../src/declaredGaps.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -821,6 +822,47 @@ function analyzeInstance(
     }
 }
 
+/**
+ * What the stacks declare will be red, or an empty map if they cannot be read.
+ *
+ * Loaded lazily and **never fatally**. This tool's job is auditing past runs;
+ * refusing to print that audit because a config file is malformed would trade a
+ * useful report for a validation error that `npm run stacks:check` already
+ * reports better. A failure here degrades the annotations, not the tool — and it
+ * says so, rather than silently showing every red as undeclared, which would
+ * look identical to nobody having declared anything.
+ */
+async function loadDeclaredGaps(): Promise<{ declared: Map<string, DeclaredGap>; reasonCodes: Set<string>; problem?: string }> {
+    try {
+        const [{ collectDeclaredGaps }, { loadContainerInventory }, { loadStack }] = await Promise.all([
+            import('../src/declaredGaps.ts'),
+            import('../src/containerInventory.ts'),
+            import('../src/stack.ts'),
+        ]);
+        const config = join(HERE, 'config');
+        const stacksDir = join(config, 'stacks');
+        const { knownReasonCodes } = await import('../src/stack.ts');
+        if (!existsSync(stacksDir)) {
+            return { declared: new Map(), reasonCodes: knownReasonCodes() };
+        }
+        const inventory = loadContainerInventory(join(config, 'container.yaml'));
+        const stacks = readdirSync(stacksDir)
+            .filter(name => name.endsWith('.yaml'))
+            .sort()
+            .map(name => loadStack(join(stacksDir, name), { inventory, phasesDirectory: join(config, 'phases') }));
+        const { findStaleDeclarations, annotationFor } = await import('../src/declaredGaps.ts');
+        staleDeclarationsSync = findStaleDeclarations;
+        annotationForSync = annotationFor;
+        return { declared: collectDeclaredGaps(stacks), reasonCodes: knownReasonCodes() };
+    } catch (error) {
+        return {
+            declared: new Map(),
+            reasonCodes: new Set(),
+            problem: `stack declarations could not be read, so nothing below is annotated as declared: ${error instanceof Error ? error.message : String(error)}`,
+        };
+    }
+}
+
 function classify(tally: GateTally): Verdict {
     const rendered = tally.passed + tally.failed;
     if (rendered === 0 && tally.notApplicable > 0 && tally.notAttempted === 0) {
@@ -924,7 +966,48 @@ function printTable(rows: GateRow[]): void {
     console.log('it never means 100%.');
 }
 
-function printFindings(rows: GateRow[], minRuns: number, unexercised: Map<string, string[]>): number {
+/**
+ * Say whether anybody had already accounted for this red.
+ *
+ * Wording matters more than usual here. MSBench artifacts carry no record of
+ * which stack produced a run, so this cannot say "the stack this run used
+ * declared it" — only that **some** stack declares this gate red for this
+ * reason. Every line below is written to mean exactly that, because the stronger
+ * claim would quietly excuse a red on a stack that never accounted for it.
+ */
+function printDeclaration(
+    gaps: { declared: Map<string, DeclaredGap>; reasonCodes: Set<string>; problem?: string },
+    gate: string,
+    reason: string,
+    indent: string,
+): void {
+    if (gaps.problem || gaps.declared.size === 0) {
+        return;
+    }
+    const gap = gaps.declared.get(`${gate}\t${reason}`);
+    // `notAttempted` merges NOT_APPLICABLE reason codes with instance faults like
+    // `X_MODEL_NOT_FOUND_ERROR`. Only the former can appear in a `knownGaps`
+    // entry, so the decision of whether to say anything at all lives in
+    // `annotationFor`, where a case holds it. See the note there.
+    const annotation = annotationForSync(gap, reason, gaps.reasonCodes);
+    if (annotation === 'skip') {
+        return;
+    }
+    if (annotation === 'undeclared' || !gap) {
+        console.log(`${indent}UNDECLARED — no stack declares ${gate} red for reason=${reason}. Nobody has`);
+        console.log(`${indent}accounted for this one; go and look.`);
+        return;
+    }
+    console.log(`${indent}declared by stack(s) ${gap.stacks.join(', ')} — expected red, tracked:`);
+    console.log(`${indent}  ${gap.tracking[0].replace(/\s+/gu, ' ').slice(0, 150)}`);
+}
+
+function printFindings(
+    rows: GateRow[],
+    minRuns: number,
+    unexercised: Map<string, string[]>,
+    gaps: { declared: Map<string, DeclaredGap>; reasonCodes: Set<string>; problem?: string },
+): number {
     const of = (verdict: Verdict): GateRow[] => rows.filter(row => row.verdict === verdict);
     const suspect = of('never-passed');
     const starved = of('never-attempted');
@@ -977,6 +1060,7 @@ function printFindings(rows: GateRow[], minRuns: number, unexercised: Map<string
             console.log(`  * ${cause} — ${gates.length} gate(s) ${ran ? 'errored' : 'blocked'}, 0 real verdicts between them`);
             for (const { gate, tally } of gates) {
                 console.log(`      ${gate} (${tally.notAttempted} ${ran ? 'untrustworthy' : 'blocked'} over ${tally.runs.size} run(s))`);
+                printDeclaration(gaps, gate, cause, '        ');
             }
             if (ran) {
                 console.log('      These ran and reported their own results untrustworthy. Fix the grader,');
@@ -1009,6 +1093,18 @@ function printFindings(rows: GateRow[], minRuns: number, unexercised: Map<string
             console.log(`      ${gates.join(', ')}`);
             console.log(`      Wired to ${gates.length > 1 ? 'stacks these gates' : 'a stack this gate'} cannot answer for, or never wired to one`);
             console.log('      that exercises it.');
+            // Under stack-derived wiring a gate is attached only when the stack
+            // declared the thing it inspects, so this verdict should be
+            // unreachable for any run built with `run.sh --stack`. Seeing one is
+            // therefore a claim about the schema, not about the product — and the
+            // schema said so in writing, which is what makes it falsifiable.
+            console.log('      If this run was built with `run.sh --stack`, an outOfScope verdict is a BUG IN');
+            console.log('      THE STACK SCHEMA: the derivation wired a gate whose fact the stack did not');
+            console.log('      declare, or the stack declared a fact its project does not have. Check');
+            console.log('      config/gates.yaml and the stack before blaming the gate.');
+            for (const gate of gates) {
+                printDeclaration(gaps, gate, reason, '      ');
+            }
         }
     }
 
@@ -1139,6 +1235,56 @@ function printPreamble(runs: string[], instances: number, voidInstances: number,
 // Main
 // ---------------------------------------------------------------------------
 
+/**
+ * Declarations the corpus contradicts.
+ *
+ * The pressure that keeps `knownGaps` honest. `stacks:check` can only verify a
+ * declaration structurally — that the gate exists and the stack could wire it —
+ * because it has no runs to look at. This does: a gate that was observed, and
+ * never once for the reason a stack swears it is red for, has a declaration that
+ * has stopped describing reality.
+ *
+ * Guarded on the gate having been observed at all, because a declaration for a
+ * phase nobody has run yet is a fact about the corpus rather than about the
+ * declaration — and a report that is mostly noise gets ignored, which is how the
+ * thing it was meant to catch survives.
+ */
+function printStaleDeclarations(rows: GateRow[], gaps: { declared: Map<string, DeclaredGap>; reasonCodes: Set<string>; problem?: string }): void {
+    if (gaps.problem || gaps.declared.size === 0) {
+        return;
+    }
+    const observed = new Map<string, Set<string>>();
+    for (const { gate, tally } of rows) {
+        const reasons = new Set<string>([...tally.notApplicableReasons.keys(), ...tally.notAttemptedReasons.keys()]);
+        observed.set(gate, reasons);
+    }
+
+    // Imported lazily for the same reason as the declarations themselves: a
+    // config problem must degrade this section, never the whole audit.
+    let stale: DeclaredGap[] = [];
+    try {
+        stale = staleDeclarationsSync(gaps.declared, observed);
+    } catch {
+        return;
+    }
+    if (stale.length === 0) {
+        return;
+    }
+
+    console.log('');
+    console.log('DECLARED BUT NEVER OBSERVED — a stack swears these gates are red for a reason the');
+    console.log('runs never once reported, on gates the runs *did* exercise. Either the gap closed');
+    console.log('and the declaration outlived it, or it is red for a different reason nobody has');
+    console.log('accounted for. Both are worth a minute; a stale declaration silently excuses a');
+    console.log('genuine failure for as long as nobody rereads it.');
+    for (const gap of stale) {
+        console.log(`  * ${gap.gate} — declared reason=${gap.reason} by ${gap.stacks.join(', ')}, never observed`);
+    }
+}
+
+let staleDeclarationsSync: (declared: Map<string, DeclaredGap>, observed: Map<string, Set<string>>) => DeclaredGap[] = () => [];
+let annotationForSync: (gap: DeclaredGap | undefined, reason: string, reasonCodes: Set<string>) => 'skip' | 'undeclared' | 'declared' = () => 'skip';
+
 async function main(): Promise<void> {
     const options = parseArgs(process.argv.slice(2));
     jsonMode = options.json;
@@ -1259,7 +1405,12 @@ async function main(): Promise<void> {
 
     printPreamble(auditedRuns, instanceCount, voidInstances, options.minRuns, readerFaults, skipped);
     printTable(rows);
-    const confidentSuspects = printFindings(rows, options.minRuns, unexercised);
+    const gaps = await loadDeclaredGaps();
+    if (gaps.problem) {
+        log(`WARNING: ${gaps.problem}`);
+    }
+    const confidentSuspects = printFindings(rows, options.minRuns, unexercised, gaps);
+    printStaleDeclarations(rows, gaps);
 
     console.log('');
     console.log('None of these verdicts proves a defect. Each is a reason to look before quoting a score.');

--- a/evals/src/declaredGaps.ts
+++ b/evals/src/declaredGaps.ts
@@ -1,0 +1,293 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Join what the stacks *declare* will be red against what the runs actually did.
+ *
+ * `gate-health.ts` reconstructs expectations from stderr: it groups always-N/A
+ * gates by `reason=` so that five missing-binary reds read as one actionable
+ * line instead of five mysterious gates. That grouping is the right shape, but
+ * it can only say *what happened* — it cannot say whether anyone had already
+ * decided that was acceptable.
+ *
+ * The stacks now carry that decision in machine-readable form. `knownGaps` says
+ * "this gate, for this reason, is expected red, and here is where the work to
+ * close it is tracked". Joining the two splits one undifferentiated pile into
+ * two piles with different owners:
+ *
+ *   **declared**   — somebody looked at this, wrote down why, and named the
+ *                    follow-up. It is a bill we agreed to pay, not a surprise.
+ *   **undeclared** — nobody has accounted for this. Go and look.
+ *
+ * That distinction is the difference between a report you skim and one you act
+ * on, and it is also the only mechanical pressure on `knownGaps` to stay honest:
+ * a declaration whose reason never actually appears is reported as stale.
+ *
+ * ## What this deliberately does NOT claim
+ *
+ * There is no run-to-stack linkage. MSBench artifacts do not record which stack
+ * produced them, so this cannot say "the stack this run used declared it". It
+ * says "**some** stack declares this gate red for this reason", and every string
+ * it emits is worded to mean exactly that and no more. Overstating it would be
+ * worse than not joining at all: a red that some other stack declared is not
+ * accounted for on the stack that actually produced it.
+ */
+
+import type { Stack } from './stack.ts';
+
+export interface DeclaredGap {
+    gate: string;
+    reason: string;
+    /** Stack ids declaring this pair, sorted. */
+    stacks: string[];
+    /** The `tracking` note from each declaration, in stack order. */
+    tracking: string[];
+}
+
+/**
+ * Key on **gate and reason together**, never gate alone.
+ *
+ * A stack declaring `runtime-crud` red for `datastoreRequiresContainer` has said
+ * nothing about `runtime-crud` failing for some other reason — and treating it
+ * as blanket cover for that gate would let a genuine, unrelated failure hide
+ * behind an accepted one. That is the accounted-for-by-accident failure, and it
+ * is exactly what a declaration must not buy.
+ */
+function keyOf(gate: string, reason: string): string {
+    return `${gate}\t${reason}`;
+}
+
+export function collectDeclaredGaps(stacks: Stack[]): Map<string, DeclaredGap> {
+    const declared = new Map<string, DeclaredGap>();
+    for (const stack of [...stacks].sort((a, b) => a.id.localeCompare(b.id))) {
+        for (const gap of stack.knownGaps) {
+            for (const gate of gap.gates) {
+                const key = keyOf(gate, gap.reason);
+                const existing = declared.get(key);
+                if (existing) {
+                    existing.stacks.push(stack.id);
+                    existing.tracking.push(gap.tracking);
+                    continue;
+                }
+                declared.set(key, { gate, reason: gap.reason, stacks: [stack.id], tracking: [gap.tracking] });
+            }
+        }
+    }
+    return declared;
+}
+
+export function lookupDeclaredGap(
+    declared: Map<string, DeclaredGap>,
+    gate: string,
+    reason: string,
+): DeclaredGap | undefined {
+    return declared.get(keyOf(gate, reason));
+}
+
+/**
+ * Declarations whose reason never actually appeared for a gate the corpus did
+ * observe.
+ *
+ * The `observed` guard is the load-bearing half. A declaration for a gate that
+ * never ran at all is not stale — the runs simply never exercised it, which is a
+ * statement about the corpus rather than about the declaration. Reporting those
+ * would bury the real signal under every gap for every phase nobody has run yet,
+ * and a report that is mostly noise gets ignored, which is how the thing it was
+ * meant to catch survives.
+ */
+export function findStaleDeclarations(
+    declared: Map<string, DeclaredGap>,
+    observedReasonsByGate: Map<string, Set<string>>,
+): DeclaredGap[] {
+    const stale: DeclaredGap[] = [];
+    for (const gap of declared.values()) {
+        const observed = observedReasonsByGate.get(gap.gate);
+        if (!observed || observed.size === 0) {
+            continue;
+        }
+        if (!observed.has(gap.reason)) {
+            stale.push(gap);
+        }
+    }
+    return stale.sort((a, b) => keyOf(a.gate, a.reason).localeCompare(keyOf(b.gate, b.reason)));
+}
+
+/**
+ * What a report should say about one red, if anything.
+ *
+ * A pure decision so the guard that matters most has a regression test. The
+ * first real run of this feature printed *"no stack declares ... red for
+ * reason=X_MODEL_NOT_FOUND_ERROR"* four times — against rate limits and model
+ * resolution faults, which no `knownGaps` entry could ever declare, because the
+ * schema only accepts codes from the closed NOT_APPLICABLE vocabulary.
+ *
+ * That is the alarm-fatigue failure: four confident, useless lines are enough to
+ * teach a reader to skip the section, and then the one line that matters is
+ * skipped with them. It was caught by running the tool against the real corpus
+ * and reading the output, which is not a repeatable safeguard — so the decision
+ * moved here, where a case can hold it.
+ */
+export type GapAnnotation = 'skip' | 'undeclared' | 'declared';
+
+export function annotationFor(
+    gap: DeclaredGap | undefined,
+    reason: string,
+    reasonCodes: Set<string>,
+): GapAnnotation {
+    if (!reasonCodes.has(reason)) {
+        return 'skip';
+    }
+    return gap ? 'declared' : 'undeclared';
+}
+
+// ---------------------------------------------------------------------------
+// Self-test
+// ---------------------------------------------------------------------------
+
+type Case = { name: string; run: () => string | undefined };
+
+function stackWith(id: string, gaps: Array<{ gates: string[]; reason: string; tracking: string }>): Stack {
+    // Only the fields the join reads. Typed through `Stack` so a schema change
+    // that renames `knownGaps` breaks this at compile time rather than silently
+    // making every case pass against a field that no longer exists.
+    return { id, knownGaps: gaps } as unknown as Stack;
+}
+
+const REASON_CODES = new Set(['functionsHostUnavailable', 'ecosystemNotSupported', 'datastoreRequiresContainer']);
+
+const CASES: Case[] = [
+    {
+        name: 'an instance fault is not annotated at all — no stack could declare it',
+        run: () => annotationFor(undefined, 'X_MODEL_NOT_FOUND_ERROR', REASON_CODES) === 'skip'
+            ? undefined
+            : 'a cause outside the NOT_APPLICABLE vocabulary must produce no line; four such lines shipped once',
+    },
+    {
+        name: 'a grader error is not annotated either',
+        run: () => annotationFor(undefined, 'graderError', REASON_CODES) === 'skip'
+            ? undefined
+            : 'graderError is not a reason a stack can declare',
+    },
+    {
+        name: 'a real reason code with no declaration is reported undeclared',
+        run: () => annotationFor(undefined, 'functionsHostUnavailable', REASON_CODES) === 'undeclared'
+            ? undefined
+            : 'an unaccounted-for red must say so',
+    },
+    {
+        name: 'a real reason code with a declaration is reported declared',
+        run: () => {
+            const gap: DeclaredGap = { gate: 'g', reason: 'functionsHostUnavailable', stacks: ['a'], tracking: ['t'] };
+            return annotationFor(gap, 'functionsHostUnavailable', REASON_CODES) === 'declared'
+                ? undefined
+                : 'a declared red must be labelled as such';
+        },
+    },
+    {
+        name: 'a declared gate+reason pair is found, with its tracking note',
+        run: () => {
+            const declared = collectDeclaredGaps([
+                stackWith('a', [{ gates: ['runtime-crud'], reason: 'datastoreRequiresContainer', tracking: 'needs a database server' }]),
+            ]);
+            const hit = lookupDeclaredGap(declared, 'runtime-crud', 'datastoreRequiresContainer');
+            return hit?.tracking[0] === 'needs a database server' ? undefined : `expected the tracking note, got ${JSON.stringify(hit)}`;
+        },
+    },
+    {
+        name: 'the same reason on a DIFFERENT gate does not match',
+        run: () => {
+            const declared = collectDeclaredGaps([
+                stackWith('a', [{ gates: ['runtime-crud'], reason: 'ecosystemNotSupported', tracking: 't' }]),
+            ]);
+            return lookupDeclaredGap(declared, 'runtime-health', 'ecosystemNotSupported')
+                ? 'a declaration for one gate must not cover another'
+                : undefined;
+        },
+    },
+    {
+        name: 'the same gate with a DIFFERENT reason does not match',
+        run: () => {
+            // The failure this prevents: a real, unrelated red hiding behind an
+            // accepted one because the gate name happened to be declared.
+            const declared = collectDeclaredGaps([
+                stackWith('a', [{ gates: ['runtime-crud'], reason: 'datastoreRequiresContainer', tracking: 't' }]),
+            ]);
+            return lookupDeclaredGap(declared, 'runtime-crud', 'functionsHostUnavailable')
+                ? 'a declaration for one reason must not cover a different failure of the same gate'
+                : undefined;
+        },
+    },
+    {
+        name: 'two stacks declaring the same pair are merged, both named',
+        run: () => {
+            const declared = collectDeclaredGaps([
+                stackWith('b', [{ gates: ['runtime-app-starts'], reason: 'functionsHostUnavailable', tracking: 'tb' }]),
+                stackWith('a', [{ gates: ['runtime-app-starts'], reason: 'functionsHostUnavailable', tracking: 'ta' }]),
+            ]);
+            const hit = lookupDeclaredGap(declared, 'runtime-app-starts', 'functionsHostUnavailable');
+            return JSON.stringify(hit?.stacks) === JSON.stringify(['a', 'b']) ? undefined : `expected both stacks sorted, got ${JSON.stringify(hit?.stacks)}`;
+        },
+    },
+    {
+        name: 'an empty declaration set matches nothing',
+        run: () => {
+            // The negative control. A join broken so that it matches everything
+            // would relabel every red in the corpus as "declared, tracked" — the
+            // most expensive possible failure of this feature, and invisible.
+            const declared = collectDeclaredGaps([]);
+            return lookupDeclaredGap(declared, 'runtime-crud', 'datastoreRequiresContainer')
+                ? 'an empty declaration set must not match anything'
+                : undefined;
+        },
+    },
+    {
+        name: 'a declaration whose reason never appeared for an observed gate is stale',
+        run: () => {
+            const declared = collectDeclaredGaps([
+                stackWith('a', [{ gates: ['runtime-health'], reason: 'functionsHostUnavailable', tracking: 't' }]),
+            ]);
+            const observed = new Map([['runtime-health', new Set(['noHealthPathDeclared'])]]);
+            const stale = findStaleDeclarations(declared, observed);
+            return stale.length === 1 && stale[0].gate === 'runtime-health' ? undefined : `expected one stale declaration, got ${stale.length}`;
+        },
+    },
+    {
+        name: 'a declaration for a gate the corpus never observed is NOT stale',
+        run: () => {
+            // Otherwise every gap for a phase nobody has run yet is reported, and
+            // a report that is mostly noise gets ignored.
+            const declared = collectDeclaredGaps([
+                stackWith('a', [{ gates: ['runtime-health'], reason: 'functionsHostUnavailable', tracking: 't' }]),
+            ]);
+            const stale = findStaleDeclarations(declared, new Map());
+            return stale.length === 0 ? undefined : 'a gate the corpus never observed says nothing about its declaration';
+        },
+    },
+    {
+        name: 'a declaration whose reason did appear is not stale',
+        run: () => {
+            const declared = collectDeclaredGaps([
+                stackWith('a', [{ gates: ['runtime-health'], reason: 'functionsHostUnavailable', tracking: 't' }]),
+            ]);
+            const observed = new Map([['runtime-health', new Set(['functionsHostUnavailable'])]]);
+            return findStaleDeclarations(declared, observed).length === 0 ? undefined : 'a declaration that matched an observation is not stale';
+        },
+    },
+];
+
+/** Returns the number of failing cases; 0 is a pass. */
+export function selfTestDeclaredGaps(report: (line: string) => void): number {
+    let failed = 0;
+    for (const testCase of CASES) {
+        const problem = testCase.run();
+        if (problem) {
+            failed++;
+            report(`  ✖ ${testCase.name} — ${problem}`);
+        } else {
+            report(`  ✔ ${testCase.name}`);
+        }
+    }
+    return failed;
+}


### PR DESCRIPTION
`gate-health` groups always-N/A gates by `reason=` so that five missing-binary reds read as one actionable line rather than five mysterious gates. That is the right shape, but it can only say *what happened* — never whether anyone had already decided it was acceptable.

The stacks now carry that decision. `knownGaps` says *"this gate, for this reason, is expected red, and here is where the follow-up is tracked."* Joining them splits one undifferentiated pile into two with different owners:

```
  * ecosystemNotSupported — 2 gate(s) blocked, 0 real verdicts between them
      service-fidelity (4 blocked over 3 run(s))
        declared by stack(s) go-tickets-api — expected red, tracked:
          analyser understands node/python/dotnet; #NNNN to add Go
      runtime-crud (4 blocked over 3 run(s))
        UNDECLARED — no stack declares runtime-crud red for reason=ecosystemNotSupported.
        Nobody has accounted for this one; go and look.
```

That is the difference between a report you skim and one you act on. It also attacks the 41-of-48 never-failed number by making it interpretable: **a gate that is red by declaration is a different object from one that has never discriminated**, and today they are indistinguishable in the tally.

## The join keys on gate AND reason, never gate alone

A stack declaring `runtime-crud` red for `datastoreRequiresContainer` has said **nothing** about `runtime-crud` failing for some other reason. Treating a declaration as blanket cover for a gate would let a genuine, unrelated failure hide behind an accepted one — the accounted-for-by-accident failure, and precisely what a declaration must not buy. Two cases hold that.

## The reverse direction: declarations the corpus contradicts

`stacks:check` can only verify a declaration *structurally* — that the gate exists and the stack could wire it — because it has no runs to look at. This can. A gate that was observed, and never once for the reason a stack swears it is red for, has a declaration that has stopped describing reality.

Guarded on the gate having been observed at all: a declaration for a phase nobody has run yet is a fact about the corpus, not about the declaration, and reporting those would bury the real signal under every gap for every unrun phase.

## The falsifiable claim, now stated where it will be seen

The `ALWAYS OUT-OF-SCOPE` section now says what the schema promised in #1726:

> If this run was built with `run.sh --stack`, an `outOfScope` verdict is a **bug in the stack schema**: the derivation wired a gate whose fact the stack did not declare, or the stack declared a fact its project does not have.

Under fact-derived wiring a gate is attached only when the stack declared the thing it inspects, so that verdict should be unreachable. Putting the claim where the contradicting evidence would appear is what makes it falsifiable rather than decorative.

## Found by running it, not by reading it

The first version printed this **four times**:

```
UNDECLARED — no stack declares agent produced GPT.txt red for reason=X_MODEL_NOT_FOUND_ERROR
```

`notAttempted` merges two different things: NOT_APPLICABLE reason codes, and instance faults like rate limits and model-resolution failures. No `knownGaps` entry can ever declare the latter — the schema only accepts codes from the closed vocabulary. So those lines were guaranteed noise, and **four confident useless lines are enough to teach a reader to skip the section** — after which the one line that matters is skipped with them. Same alarm-fatigue failure as the type-only false positive in #1733, one PR later.

Catching it by eye is not a repeatable safeguard, so the decision of whether to annotate at all is now `annotationFor()`, a pure function with cases holding it:

```
✔ an instance fault is not annotated at all — no stack could declare it
✔ a grader error is not annotated either
✔ a real reason code with no declaration is reported undeclared
✔ a real reason code with a declaration is reported declared
```

## Nothing here is fatal

A malformed stack config degrades the annotations and **says so**, rather than refusing to print an audit of past runs. Silently showing every red as undeclared would look identical to nobody having declared anything, which is why the failure is announced rather than swallowed. `npm run stacks:check` remains the place a config problem is reported properly.

## What this does not claim

MSBench artifacts carry no record of which stack produced a run, so this cannot say *"the stack this run used declared it"* — only that **some** stack declares this gate red for this reason. Every emitted string is worded to mean exactly that. The stronger claim would quietly excuse a red on a stack that never accounted for it.

## Verification

12 join cases run inside `stacks:check`, including the negative control: **an empty declaration set must match nothing**, since a join broken to match everything would relabel every red in the corpus as "declared, tracked" — the most expensive possible failure of this feature, and completely invisible.

All seven credential-free gates green: `typecheck`, `imports:self-test`, `stacks:check`, `drift`, `certify` (81/81), `lint`, `clean-machine:check`. `gate-health` was run against the real 30-run local cache before and after; it now emits **zero** annotation lines there, correctly, because that corpus contains no NOT_APPLICABLE reason codes at all — the gates that emit them postdate it. **So the rendering path is currently unexercised by real data and will light up on the first run that produces a marker.** Stating that rather than implying the join has been proven end-to-end.

3 files, +456/−2. **No MSBench run was submitted.**
