### PR TITLE
Stop two runtime gates requiring the declaration they consume

### DIFF
--- a/evals/msbench/config/__snapshots__/react-functions-postgres.wiring.md
+++ b/evals/msbench/config/__snapshots__/react-functions-postgres.wiring.md
@@ -36,9 +36,7 @@ wired:
   debug-artifacts
   debug-breakpoint
   runtime-app-starts  [known gap: functionsHostUnavailable]
+  runtime-health
   runtime-frontend --require-frontend  [known gap: functionsHostUnavailable]
   runtime-frontend-api  [known gap: functionsHostUnavailable]
-
-not wired:
-  runtime-health — project.healthPath is not declared
-  runtime-crud — project.collectionRoute is not declared
+  runtime-crud

--- a/evals/msbench/config/gates.yaml
+++ b/evals/msbench/config/gates.yaml
@@ -30,6 +30,16 @@
 # So `ecosystem` appears almost nowhere below. A Python project has a perfectly
 # real "does it start?" question; what is missing is support we have not written.
 #
+# The corollary, learned the hard way — `runtime-health` and `runtime-crud` both
+# required the stack declaration they consume, so on the stack matching every
+# stimulus we run, neither was wired at all:
+#
+#   **A declaration may make a gate stricter. It must never decide whether the
+#   gate runs at all.**
+#
+# A fact you `requires:` is a fact whose absence silences the gate. A fact you
+# derive an `args:` flag from only sharpens it. When in doubt, the second.
+#
 # ## `args:`
 #
 # Flags derived from the same facts, using the same predicate language. This is
@@ -191,8 +201,14 @@ gates:
     # it was written and **nothing has ever passed it**, so a capability that
     # existed only in its own documentation now gets passed by stacks that
     # contracted for a health endpoint.
+    #
+    # `requires:` is `api: http`, **not** `healthPath: present`. Requiring the
+    # declaration made this gate wireable only where a health path existed to be
+    # probed — the case it passes — and silent on a stack that declared none,
+    # which is where a missing health endpoint would actually be caught. The
+    # declaration still makes the gate *stricter* via `--require-health` below.
     requires:
-      project.healthPath: present
+      project.api: [http]
     args:
       - value: --require-health
         when: { project.healthPath: present }
@@ -220,5 +236,15 @@ gates:
     grader: evals/graders/validate-runtime-crud.ts
     summary: a record can be written and read back
     phases: [local]
+    # Same correction as `runtime-health`. A stack that declares no
+    # `collectionRoute` still has CRUD to check — the gate extracts the endpoint
+    # from the served frontend, and #1730 made a failure to read it a visible
+    # exit 3 rather than a silent stand-down. Requiring the declaration threw
+    # that away on every stack that did not opt in.
+    #
+    # Deliberately not requiring a datastore, though `datastore: none` arguably
+    # has nothing to persist to: spelling it as a list of the kinds that are not
+    # `none` silently unwires this gate the day someone adds a datastore kind,
+    # and it fails in the invisible direction.
     requires:
-      project.collectionRoute: present
+      project.api: [http]

--- a/evals/results/grader-certification/offline/report.json
+++ b/evals/results/grader-certification/offline/report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-26T08:25:42.197Z",
+  "generatedAt": "2026-08-26T08:32:42.367Z",
   "mode": "offline",
   "fixtures": [
     "sample-agent-output",


### PR DESCRIPTION
On `react-functions-postgres` — **the stack matching every stimulus we run** — two of my five runtime gates were not wired at all:

```
runtime-health   NOT WIRED — project.healthPath is not declared
runtime-crud     NOT WIRED — project.collectionRoute is not declared
```

Measured by evaluating the predicates against both shipped stacks, not by reading the rows again. Re-reading would have produced the same confident wrong answer, because I wrote them.

## The circularity is the finding

`gates.yaml` already states the rule: *only require a fact when its absence means the gate has nothing to look at.*

The absence of a declared health path does not mean that. The app still serves HTTP, and #1728 made the gate reach a verdict **without any stack declaration** by using `.azure/integration-plan.md` as contract evidence — a running app with no health endpoint is exit 1 either way. `requires: project.healthPath: present` discarded that.

And it closed a loop:

- the gate is wired only when `healthPath` is declared
- `--require-health` is passed only when `healthPath` is declared

**So the gate ran exactly where a health path existed to be probed — the case it passes — and was silent on the stack where a missing health endpoint would actually be caught.**

That is `noHealthPathDeclared` reborn in YAML, **re-created in config at the same hour it was fixed in code, by the change that closed it.** The declaration built to make `--require-health` mean something is the same declaration whose absence unwired the gate.

`runtime-crud` is the same shape: a stack declaring no `collectionRoute` still has CRUD to check, because the gate extracts the endpoint from the served frontend — and #1730 made a failure to read it a visible exit 3 rather than a silent stand-down.

## The change

Both rows now require `project.api: [http]`, the honest condition: no API means no health endpoint and no routes, which the schema enforces independently. `--require-health` stays derived from `healthPath: present`.

The principle is recorded in `gates.yaml` beside its existing rule:

> **A declaration may make a gate stricter. It must never decide whether the gate runs at all.**
>
> A fact you `requires:` is a fact whose absence silences the gate. A fact you derive an `args:` flag from only sharpens it. When in doubt, the second.

**Deliberately not requiring a datastore for `runtime-crud`**, though `datastore: none` arguably has nothing to persist to. Spelling "not none" as a list of the kinds that are not `none` silently unwires the gate the day someone adds a datastore kind, and it fails in the invisible direction. Asked the stacks session whether the predicate language can express "not none"; if it can, that is a better row and a follow-up.

## Verification

The wiring snapshot moves from **7 wired / 2 not applicable to 9 / 0** on the corpus stack — the whole change, made visible. `node-express-postgres` is unchanged, since it declares both facts and was already wired.

The snapshot check is what forced this to be looked at rather than slipping through as a config tweak, which is a good argument for those snapshots existing.

```
=== react-functions-postgres ===
  runtime-app-starts     WIRED
  runtime-health         WIRED
  runtime-frontend       WIRED
  runtime-frontend-api   WIRED
  runtime-crud           WIRED
```

`check-stacks`, `typecheck`, `certify` (84/84) and `drift` all green.

## What this PR does not claim

**Three of my five rows were already correct** — `runtime-app-starts` requires nothing (every project should start something, and the worker assertion in #1734 means it can now discriminate on `api: none` stacks too), and the two frontend rows require `frontend: [spa]`, which is exhaustive against `FrontendKind = none | spa`.

**The remaining fourteen rows in the table are unaudited, not presumed correct.** The first audit of five returned two wrong, both in the direction that makes a gate unable to fail. A green derivation is not a verified one, and the other rows want the same treatment by their owners.

Tagging the stacks session as reviewer — it is their table and their predicate language.
