### PR TITLE
Stop a typo in the gate table from silently unwiring a gate

### DIFF
--- a/evals/check-stacks.ts
+++ b/evals/check-stacks.ts
@@ -59,9 +59,9 @@ import { fileURLToPath } from 'node:url';
 import { ConfigValidationError } from './src/configValidation.ts';
 import { countAsserted, loadContainerInventory } from './src/containerInventory.ts';
 import { loadGateTable } from './src/gateTable.ts';
-import type { GateTable } from './src/gateTable.ts';
+import type { GatePredicate, GateTable } from './src/gateTable.ts';
 import { selfTestDeclaredGaps } from './src/declaredGaps.ts';
-import { checkKnownGapsAgainstTable, deriveWiring, explainWiring, teachesNothing } from './src/gateWiring.ts';
+import { checkKnownGapsAgainstTable, deriveWiring, evaluatePredicate, explainWiring, teachesNothing } from './src/gateWiring.ts';
 import { loadStack } from './src/stack.ts';
 import type { Stack, StackLoadOptions } from './src/stack.ts';
 
@@ -89,7 +89,7 @@ const VALIDATOR_SOURCES = ['src/stack.ts', 'src/containerInventory.ts', 'src/gat
  * mean that deleting a fixture — or adding a judgment-carrying rule and
  * forgetting to prove it — fails here instead of passing quietly.
  */
-const MIN_PROVEN_CODES = 34;
+const MIN_PROVEN_CODES = 36;
 
 /** `# expect: <code>` in a fixture header — the rule that fixture exists to prove. */
 const EXPECT_DIRECTIVE = /^#\s*expect:\s*([A-Za-z][A-Za-z0-9]*)\s*$/m;
@@ -278,6 +278,25 @@ function checkDerivationBranches(stacks: Stack[], table: GateTable): void {
         fail('a phase whose every wired gate is a declared known gap must warn, and did not');
     } else {
         console.error('  ✔ a run whose every wired gate is a known gap warns');
+    }
+
+    // The deny-list form. Added because an allow-list silently unwires its gate the
+    // day someone adds a value to the enum, and a gate wired nowhere reads as a
+    // clean run. Both directions are driven, because a `not:` that never excludes
+    // anything would look identical to one that works until the excluded value
+    // actually turns up.
+    const notNone: GatePredicate = { 'project.datastore': { not: ['none'] } };
+    if (!evaluatePredicate(stack, notNone).matched) {
+        fail(`{ not: [none] } must match ${stack.id}, whose datastore is ${stack.project.datastore}`);
+    } else {
+        console.error(`  ✔ { not: [none] } matches a stack with a datastore`);
+    }
+    const noDatastore: Stack = { ...stack, project: { ...stack.project, datastore: 'none' } };
+    const excluded = evaluatePredicate(noDatastore, notNone);
+    if (excluded.matched) {
+        fail('{ not: [none] } must NOT match a stack whose datastore is none');
+    } else {
+        console.error(`  ✔ { not: [none] } excludes a stack without one (${excluded.because})`);
     }
 
     // A phase with nothing wired must not warn: there is no run to describe.

--- a/evals/msbench/config/__fixtures__/gates-invalid/path-fact-needs-present.yaml
+++ b/evals/msbench/config/__fixtures__/gates-invalid/path-fact-needs-present.yaml
@@ -1,0 +1,12 @@
+# expect: gatePredicatePathFactNeedsPresent
+# Matching an exact route in the gate table encodes one project's URL layout into
+# a rule meant to apply to every project.
+schemaVersion: 1
+phases: [plan, scaffold, local]
+gates:
+  - id: requirements
+    grader: evals/graders/validate-requirements.ts
+    summary: exact route
+    phases: [plan]
+    requires:
+      project.healthPath: ['/api/health']

--- a/evals/msbench/config/__fixtures__/gates-invalid/predicate-unknown-value-in-not.yaml
+++ b/evals/msbench/config/__fixtures__/gates-invalid/predicate-unknown-value-in-not.yaml
@@ -1,0 +1,13 @@
+# expect: gatePredicateUnknownValue
+# The same typo inside a deny-list. `{ not: [nne] }` excludes nothing, so the gate
+# is wired everywhere including where it has nothing to look at — the deny-list
+# failing in the opposite direction to the allow-list.
+schemaVersion: 1
+phases: [plan, scaffold, local]
+gates:
+  - id: requirements
+    grader: evals/graders/validate-requirements.ts
+    summary: typo in deny-list
+    phases: [plan]
+    requires:
+      project.datastore: { not: [nne] }

--- a/evals/msbench/config/__fixtures__/gates-invalid/predicate-unknown-value.yaml
+++ b/evals/msbench/config/__fixtures__/gates-invalid/predicate-unknown-value.yaml
@@ -1,0 +1,13 @@
+# expect: gatePredicateUnknownValue
+# `postgress` is a typo. It can never be a datastore value, so the condition
+# matches nothing and silently unwires the gate on every stack — and a gate wired
+# nowhere reads as a clean run.
+schemaVersion: 1
+phases: [plan, scaffold, local]
+gates:
+  - id: requirements
+    grader: evals/graders/validate-requirements.ts
+    summary: typo value
+    phases: [plan]
+    requires:
+      project.datastore: [postgress]

--- a/evals/src/gateTable.ts
+++ b/evals/src/gateTable.ts
@@ -15,20 +15,28 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { ConfigValidationError, reject, requireObject, requireString, rejectUnknownKeys } from './configValidation.ts';
+import { API_KINDS, DATASTORE_KINDS, FRONTEND_KINDS, HOSTING_KINDS, STACK_ECOSYSTEMS } from './stack.ts';
 
 /**
  * A condition on a stack's declared facts.
  *
  * Deliberately tiny — two forms, no operators, no nesting:
  *
- *   `project.frontend: [spa]`      the field's value must be one of these
- *   `project.healthPath: present`  the optional field must be set
+ *   `project.frontend: [spa]`        the field's value must be one of these
+ *   `project.healthPath: present`    the optional field must be set
+ *   `project.datastore: { not: [none] }`  anything except these
+ *
+ * The deny-list exists because an allow-list is a maintenance trap in the
+ * invisible direction: `[postgres, cosmos, blob, queue]` silently unwires its
+ * gate the day someone adds a datastore kind, and a gate wired nowhere reads as
+ * a clean run. "Not none" keeps saying what it meant.
  *
  * An expression language would let a gate encode policy that belongs in the
  * gate, and would be unreviewable by the person the schema is written for: the
  * one checking a stack file against a prompt.
  */
-export type GatePredicate = Record<string, string[] | 'present'>;
+export type GateCondition = string[] | 'present' | { not: string[] };
+export type GatePredicate = Record<string, GateCondition>;
 
 export interface GateArgument {
     value: string;
@@ -73,8 +81,30 @@ const KNOWN_FACTS = [
     'project.collectionRoute',
 ] as const;
 
-/** Facts that are optional on a stack, and so are the only ones `present` is meaningful for. */
+/**
+ * Facts that are optional on a stack, and hold a free-form path rather than a
+ * value from a closed set. `present` is the only condition that makes sense on
+ * them: a gate table matching an exact route would be encoding one project's
+ * URL layout into a rule meant to apply to every project.
+ */
 const OPTIONAL_FACTS = ['project.healthPath', 'project.collectionRoute'];
+
+/**
+ * The values each closed-set fact may take, imported from the stack schema
+ * rather than re-typed so the two cannot drift.
+ *
+ * Values were previously unchecked, which left the same silent-unwiring failure
+ * the closed fact list was written to prevent: `project.datastore: [postgress]`
+ * parsed happily and matched nothing, unwiring its gate on every stack. A gate
+ * wired nowhere reads as a clean run.
+ */
+const FACT_VALUES: Record<string, readonly string[]> = {
+    ecosystem: STACK_ECOSYSTEMS,
+    'project.frontend': FRONTEND_KINDS,
+    'project.api': API_KINDS,
+    'project.datastore': DATASTORE_KINDS,
+    'project.hosting': HOSTING_KINDS,
+};
 
 export function loadGateTable(filePath: string, repoRoot: string): GateTable {
     let text: string;
@@ -188,6 +218,23 @@ function parseArguments(value: unknown, filePath: string, gateIndex: number): Ga
     });
 }
 
+function checkValues(values: string[], fact: string, filePath: string, what: string): void {
+    const allowed = FACT_VALUES[fact];
+    if (!allowed) {
+        return;
+    }
+    const unknown = values.filter(value => !allowed.includes(value));
+    if (unknown.length > 0) {
+        reject(
+            'gatePredicateUnknownValue',
+            filePath,
+            `${what} names ${unknown.join(', ')}, which '${fact}' can never be. Valid values: ${allowed.join(', ')}. `
+            + `A value that cannot occur matches nothing, silently unwiring this gate on every stack — and a gate `
+            + `wired nowhere looks exactly like a clean run.`,
+        );
+    }
+}
+
 export function parsePredicate(value: unknown, filePath: string, what: string): GatePredicate {
     const node = requireObject(value, 'gatePredicateNotObject', filePath, what);
     const predicate: GatePredicate = {};
@@ -214,9 +261,34 @@ export function parsePredicate(value: unknown, filePath: string, what: string): 
             predicate[fact] = 'present';
             continue;
         }
-        if (!Array.isArray(condition) || condition.length === 0 || condition.some(entry => typeof entry !== 'string')) {
-            reject('gatePredicateValue', filePath, `${what}.${fact} must be a non-empty list of values, or the literal 'present'.`);
+        if (OPTIONAL_FACTS.includes(fact)) {
+            reject(
+                'gatePredicatePathFactNeedsPresent',
+                filePath,
+                `${what}.${fact} holds a free-form path, so 'present' is the only condition it accepts. Matching an `
+                + `exact route here would encode one project's URL layout into a rule meant to apply to every project.`,
+            );
         }
+
+        // Deny-list: `{ not: [none] }`. An allow-list silently unwires its gate the
+        // day someone adds a value to the enum, which is a maintenance trap that
+        // fails invisibly; "not none" keeps saying what it meant.
+        if (!Array.isArray(condition) && typeof condition === 'object' && condition !== null) {
+            const node = requireObject(condition, 'gatePredicateValue', filePath, `${what}.${fact}`);
+            rejectUnknownKeys(node, ['not'], 'gatePredicateValue', filePath, `${what}.${fact}`);
+            const excluded = node.not;
+            if (!Array.isArray(excluded) || excluded.length === 0 || excluded.some(entry => typeof entry !== 'string')) {
+                reject('gatePredicateValue', filePath, `${what}.${fact}.not must be a non-empty list of values.`);
+            }
+            checkValues(excluded as string[], fact, filePath, `${what}.${fact}.not`);
+            predicate[fact] = { not: excluded as string[] };
+            continue;
+        }
+
+        if (!Array.isArray(condition) || condition.length === 0 || condition.some(entry => typeof entry !== 'string')) {
+            reject('gatePredicateValue', filePath, `${what}.${fact} must be a non-empty list of values, 'present', or { not: [...] }.`);
+        }
+        checkValues(condition as string[], fact, filePath, `${what}.${fact}`);
         predicate[fact] = condition as string[];
     }
     return predicate;

--- a/evals/src/gateWiring.ts
+++ b/evals/src/gateWiring.ts
@@ -86,6 +86,12 @@ export function evaluatePredicate(stack: Stack, predicate: GatePredicate): { mat
             }
             continue;
         }
+        if (!Array.isArray(condition)) {
+            if (value !== undefined && condition.not.includes(value)) {
+                return { matched: false, because: `${fact} is ${value}` };
+            }
+            continue;
+        }
         if (value === undefined || !condition.includes(value)) {
             return { matched: false, because: describeMiss(fact, value, condition) };
         }

--- a/evals/src/stack.ts
+++ b/evals/src/stack.ts
@@ -80,7 +80,7 @@ import type { BinaryFact, ContainerInventory } from './containerInventory.ts';
  * of a Go stack (see `knownGaps` below), and the type says it out loud.
  */
 export type StackEcosystem = Ecosystem | 'go';
-const STACK_ECOSYSTEMS: readonly StackEcosystem[] = ['node', 'python', 'dotnet', 'go'];
+export const STACK_ECOSYSTEMS: readonly StackEcosystem[] = ['node', 'python', 'dotnet', 'go'];
 
 /** The binary each ecosystem cannot run without. Used for a coherence check. */
 const ECOSYSTEM_BINARY: Record<StackEcosystem, string> = {
@@ -95,10 +95,10 @@ export type ApiKind = 'none' | 'http';
 export type DatastoreKind = 'none' | 'postgres' | 'cosmos' | 'blob' | 'queue';
 export type HostingKind = 'appService' | 'functions' | 'containerApps';
 
-const FRONTEND_KINDS: readonly FrontendKind[] = ['none', 'spa'];
-const API_KINDS: readonly ApiKind[] = ['none', 'http'];
-const DATASTORE_KINDS: readonly DatastoreKind[] = ['none', 'postgres', 'cosmos', 'blob', 'queue'];
-const HOSTING_KINDS: readonly HostingKind[] = ['appService', 'functions', 'containerApps'];
+export const FRONTEND_KINDS: readonly FrontendKind[] = ['none', 'spa'];
+export const API_KINDS: readonly ApiKind[] = ['none', 'http'];
+export const DATASTORE_KINDS: readonly DatastoreKind[] = ['none', 'postgres', 'cosmos', 'blob', 'queue'];
+export const HOSTING_KINDS: readonly HostingKind[] = ['appService', 'functions', 'containerApps'];
 
 /**
  * The facts gates are wired from.


### PR DESCRIPTION
The predicate language in `gates.yaml` validated fact **names** against a closed list and never validated **values**. So this parsed happily:

```yaml
requires:
  project.datastore: [postgress]
```

`postgress` can never be a datastore value, so the condition matches nothing and the gate is unwired **on every stack** — and a gate wired nowhere reads as a clean run, which is the `never-attempted` signal `gate-health` exists to catch.

That is worse than the two wrong rows the first audit found in #1736. Those needed a defensible-but-wrong judgement; this needs only a slip. Both fail the same way: a gate that quietly does not run.

## What changed

**Values are checked against the fact's enum**, imported from the stack schema rather than re-typed, so the two cannot drift:

```
[gatePredicateUnknownValue] gates.yaml: gates[0].requires.project.datastore names postgress,
which 'project.datastore' can never be. Valid values: none, postgres, cosmos, blob, queue.
A value that cannot occur matches nothing, silently unwiring this gate on every stack —
and a gate wired nowhere looks exactly like a clean run.
```

**A deny-list condition**, asked for by the runtime session while auditing `runtime-crud`:

```yaml
requires:
  project.api: [http]
  project.datastore: { not: [none] }
```

Their reasoning for wanting it was right: spelling that requirement as an allow-list `[postgres, cosmos, blob, queue]` **silently unwires the gate the day someone adds a datastore kind** — the same failure in miniature, in the invisible direction. "Not none" keeps saying what it meant.

**A value list on a path-valued fact is rejected.** Matching an exact route in the gate table would encode one project's URL layout into a rule meant to apply to every project; `present` is the only condition `healthPath` and `collectionRoute` accept.

## Proof

Three rejection fixtures, including the typo **inside a deny-list** — which fails in the *opposite* direction to the allow-list version: it excludes nothing, so the gate is wired even where it has nothing to look at. A guard that only tested the allow-list would have missed it.

Both evaluator directions are driven, because a `not:` that never excludes anything looks identical to one that works right up until the excluded value turns up:

```
✔ { not: [none] } matches a stack with a datastore
✔ { not: [none] } excludes a stack without one (project.datastore is none)
```

Coverage ratchet raised 34 → 36.

## Deliberately additive

**No `gates.yaml` row is touched**, so this has zero file overlap with #1736 and the two can land in either order. Applying `{ not: [none] }` to the `runtime-crud` row is a one-line follow-up once both are in, along with correcting `react-functions-postgres`'s `knownGaps` to list all five runtime gates rather than the three that were wired while two rows were wrong.

I had started the row fix before our messages crossed and threw it away rather than duplicate #1736; what we'd each written independently was identical.

## Verification

All seven credential-free gates green: `typecheck`, `imports:self-test`, `stacks:check` (36 rules by 37 fixtures), `drift`, `certify` (81/81), `lint`, `clean-machine:check`. 7 files, +148/−13.

**Fourteen of the nineteen `requires:` rows remain unaudited.** The first five audited returned two wrong. This PR makes a *class* of error in that table impossible; it does not make the table correct.

**No MSBench run was submitted.**
