### PR TITLE
Stop the README implying the gate table is verified

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -533,13 +533,26 @@ the kind of thing that gets read as a verdict:
 - **It clears no row.** It flagged one, confirmed three frontend exclusions, and was silent
   on the rest.
 - **It detects one failure direction only** — a gate going *dark* — and is structurally
-  blind to the opposite failure, a gate wired where it has nothing to look at.
-  `project-builds` on a Python stack is that failure, it is real, and only a human reasoning
-  about it caught it.
+  blind to two others. The first is a gate wired where it has nothing to look at:
+  `project-builds` on a Python stack, real, caught only by a human reasoning about it. The
+  second is worse, because the gate genuinely belongs where it is wired: a gate that is
+  applicable but then **demands something inapplicable**. `validate-integration-plan`
+  checked for a Database section unconditionally, so the first stack with
+  `datastore: none` would have been failed for correctly omitting one — a fabricated
+  product failure, latent only because both current stacks use PostgreSQL.
 - **Twelve of nineteen rows are `requires: {}`**, which can never go dark. All twelve come
   back clean and that result means nothing. **A trivially-satisfied computation is not
   evidence** — and those twelve rows are simultaneously where the risk concentrates and
   where a clean line is most misleading. It is the `COUNT(*) = 0` trap wearing another hat.
+
+That second blind spot moved the question this table should be audited against. It is not
+*"why does this row require nothing?"* — the `integration-plan` row's `requires: {}` was
+correct, and the defect was one field below it in `args:`, where no scrutiny of the
+predicate could have found it. The question is:
+
+> **Why does this row demand what it demands?**
+
+which covers `args:` as well as `requires:`, and is the one that would have caught it.
 
 So: a row with a stated reason has been thought about; a row without one is indistinguishable
 from a row nobody considered. `project-builds` is the model — its comment is the only one

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -507,6 +507,44 @@ decoration: `--require-health` had existed on `validate-runtime-health` since it
 written and **nothing had ever passed it**, so the gate could not fail for a missing health
 endpoint. A stack that declares `healthPath` now passes it.
 
+### What is verified here, and what is not
+
+**The mechanism is verified. The table it operates on is not.** Those are different claims
+and the difference is easy to lose, so it is written down here rather than left implied.
+
+Verified, and mechanically: the derivation is a pure function, so the same inputs always
+produce the same wiring; the wiring snapshots fail on drift; the check fails if two stacks
+ever derive an identical gate set; a growing corpus of rejection fixtures each assert their
+own error code, under a coverage ratchet that may only go up. A green `npm run stacks:check`
+means all of that held.
+
+**It does not mean the wiring is right.** Each `requires:` row encodes a judgement about
+what one grader actually inspects, and those judgements were made by reading grader headers
+and flags. Nothing mechanical checks them.
+
+The first five rows were audited by the session that owns those graders. **Two were wrong** —
+`runtime-health` and `runtime-crud` each required the very declaration they consume, so both
+were dark on `react-functions-postgres`, the stack matching every stimulus we run (#1736).
+Fourteen rows remain unaudited, and are unaudited rather than presumed correct.
+
+Three properties of that audit are worth carrying, because a clean line from it is exactly
+the kind of thing that gets read as a verdict:
+
+- **It clears no row.** It flagged one, confirmed three frontend exclusions, and was silent
+  on the rest.
+- **It detects one failure direction only** — a gate going *dark* — and is structurally
+  blind to the opposite failure, a gate wired where it has nothing to look at.
+  `project-builds` on a Python stack is that failure, it is real, and only a human reasoning
+  about it caught it.
+- **Twelve of nineteen rows are `requires: {}`**, which can never go dark. All twelve come
+  back clean and that result means nothing. **A trivially-satisfied computation is not
+  evidence** — and those twelve rows are simultaneously where the risk concentrates and
+  where a clean line is most misleading. It is the `COUNT(*) = 0` trap wearing another hat.
+
+So: a row with a stated reason has been thought about; a row without one is indistinguishable
+from a row nobody considered. `project-builds` is the model — its comment is the only one
+that let a reviewer tell a deliberate exception from a mistake *without opening the grader*.
+
 ### Wiring snapshots
 
 `config/__snapshots__/<stack>.wiring.md` is generated and checked in, and
@@ -520,12 +558,17 @@ The snapshots are also the demonstration that any of this does something. Same g
 `local` phase, two stacks:
 
 ```
-  react-functions-postgres          node-express-postgres
-  runtime-frontend      WIRED       runtime-frontend      not wired (frontend is none)
-  runtime-frontend-api  WIRED       runtime-frontend-api  not wired (frontend is none)
-  runtime-health        not wired   runtime-health        WIRED --require-health
-  runtime-crud          not wired   runtime-crud          WIRED
+  react-functions-postgres                node-express-postgres
+  runtime-frontend      WIRED             runtime-frontend      not wired (frontend is none)
+  runtime-frontend-api  WIRED             runtime-frontend-api  not wired (frontend is none)
+  runtime-health        WIRED             runtime-health        WIRED --require-health
+  runtime-crud          WIRED             runtime-crud          WIRED
 ```
+
+The health and CRUD rows read the same on both stacks and differ only in strictness — that
+is the corrected behaviour from #1736, and the earlier version of this table showed them
+unwired on the left, which was the bug. A declaration makes a gate stricter; it must never
+decide whether the gate runs at all.
 
 ### Running a stack
 
@@ -1585,6 +1628,12 @@ allowlisted a scheduled run would only ever be red. Local runs need none of this
 
 Failure modes that cost real time while building this. Most now fail fast in `run.sh`
 with a clear message:
+
+- **`git status` dirty after running the checks.** `npm run certify` rewrites
+  `evals/results/grader-certification/offline/report.json` with a fresh `generatedAt`
+  timestamp on every invocation, so running the credential-free gates locally leaves an
+  unrelated one-line change staged into whatever you commit next. It has reached review on
+  several PRs. `git checkout -- evals/results/` before committing.
 
 - **A red run that is actually rate limiting.** Back-to-back runs get throttled by the
   Copilot API mid-run. The agent then produces nothing, so artifact assertions fail

--- a/evals/msbench/config/__snapshots__/react-functions-postgres.wiring.md
+++ b/evals/msbench/config/__snapshots__/react-functions-postgres.wiring.md
@@ -36,7 +36,7 @@ wired:
   debug-artifacts
   debug-breakpoint
   runtime-app-starts  [known gap: functionsHostUnavailable]
-  runtime-health
+  runtime-health  [known gap: functionsHostUnavailable]
   runtime-frontend --require-frontend  [known gap: functionsHostUnavailable]
   runtime-frontend-api  [known gap: functionsHostUnavailable]
-  runtime-crud
+  runtime-crud  [known gap: functionsHostUnavailable]

--- a/evals/msbench/config/stacks/react-functions-postgres.yaml
+++ b/evals/msbench/config/stacks/react-functions-postgres.yaml
@@ -50,7 +50,13 @@ knownGaps:
   # cannot ask it because the Functions host is not in the container. They stay
   # red on purpose: "we are not testing something we claim to test" is true, and
   # a green here would be a lie that no later report could undo.
-  - gates: [runtime-app-starts, runtime-frontend, runtime-frontend-api]
+  # All five runtime gates, not three. The original list named only the gates
+  # that were wired at the time — and two of them were dark because the
+  # runtime-health and runtime-crud rows in gates.yaml each required the
+  # declaration they consume (#1736). Corrected together, because a knownGaps
+  # list that faithfully tracks a broken derivation is worth less than no list:
+  # it makes the wrong wiring look accounted for.
+  - gates: [runtime-app-starts, runtime-health, runtime-crud, runtime-frontend, runtime-frontend-api]
     reason: functionsHostUnavailable
     binary: func
     tracking: >-


### PR DESCRIPTION
A green `npm run stacks:check` says **the mechanism held**. It does not say the wiring is right — and the README read as though it did.

Given tonight's evidence, that sentence being read as "the wiring is verified" is the single most likely way this all quietly stops working. It is also the sentence someone quotes in three months.

## The two claims, now separated

**Verified, mechanically:** the derivation is a pure function, so identical inputs always produce identical wiring; the snapshots fail on drift; the check fails if two stacks ever derive an identical gate set; the rejection fixtures each assert their own error code under a ratchet that may only go up.

**Not verified:** every `requires:` row encodes a judgement about what one grader actually inspects, and those judgements were made by reading grader headers and flags. Nothing mechanical checks them. Five rows have been audited by the session owning those graders; **two were wrong** (#1736). Fourteen remain **unaudited rather than presumed correct**.

## Three properties of that audit, recorded because a clean line reads as a verdict

- **It clears no row.** It flagged one, confirmed three frontend exclusions, and was silent on the rest.
- **It detects one failure direction only** — a gate going *dark*. It is structurally blind to the opposite failure: a gate wired where it has nothing to look at. `project-builds` on a Python stack is exactly that, it is real, and only a human reasoning about it caught it.
- **Twelve of nineteen rows are `requires: {}`**, which can never go dark. All twelve come back clean and **that result means nothing.**

The last is the `COUNT(*) = 0` trap in another hat — a trivially-satisfied computation is not evidence — and those twelve rows are simultaneously where the risk concentrates and where a clean line is most misleading.

Credit where due: that framing is the runtime session's, from the pass they ran over all nineteen rows, and it is sharper than anything I would have written about my own table.

## The section's own example was illustrating the bug

```diff
-  runtime-health        not wired   runtime-health        WIRED --require-health
-  runtime-crud          not wired   runtime-crud          WIRED
+  runtime-health        WIRED       runtime-health        WIRED --require-health
+  runtime-crud          WIRED       runtime-crud          WIRED
```

The left column is `react-functions-postgres`, the stack matching every stimulus we run. The old table showed both gates unwired there and presented it as the derivation working — it was the defect #1736 fixed. The rows now differ only in *strictness*, which is the corrected behaviour and the rule it comes from: **a declaration makes a gate stricter; it must never decide whether the gate runs at all.**

## Two smaller corrections

**`react-functions-postgres`'s `knownGaps` now names all five runtime gates**, not the three that happened to be wired while two rows were wrong. A `knownGaps` list that faithfully tracks a broken derivation is worse than no list — it makes the wrong wiring look accounted for. The snapshot moves accordingly:

```diff
-  runtime-health
+  runtime-health  [known gap: functionsHostUnavailable]
-  runtime-crud
+  runtime-crud  [known gap: functionsHostUnavailable]
```

**Troubleshooting gains the `certify` timestamp churn.** `npm run certify` rewrites `report.json`'s `generatedAt` on every run, so the credential-free gates leave an unrelated one-line change in whatever you commit next. It has reached review on several PRs, which makes it a workflow trap rather than anyone's mistake.

## Not in this PR, deliberately

The comment pass over the silent `requires: {}` rows is **#1738**, by the session that owns those graders. I had started the same thing and dropped it — they checked first and found it was five rows needing a reason, not twelve; seven already had one, and I would have added noise to those.

## Verification

All seven credential-free gates green: `typecheck`, `stacks:check`, `imports:self-test`, `drift`, `certify` (81/81), `lint`, `clean-machine:check`. 3 files, +63/−8. Documentation and one data correction; no code changes.

**No MSBench run was submitted.**
