### PR TITLE
Stop demanding a Database section from a project that has no datastore

### DIFF
--- a/evals/grader-certification/api-only-no-datastore/.azure/integration-plan.md
+++ b/evals/grader-certification/api-only-no-datastore/.azure/integration-plan.md
@@ -1,0 +1,36 @@
+# Integration Plan
+
+## Overview
+
+Integrate the browser client and Node.js API through same-origin HTTP routes. The browser calls the live backend and never imports preview or mock data modules.
+
+## Backend
+
+| Field | Value |
+|-------|-------|
+| Project folder | `.` (repository root) |
+| Build command | `npm run build` |
+| Run command | `npm start` |
+| Port | 7071 (override with `PORT`) |
+| Health endpoint | `GET /api/health` |
+
+The Node.js service in `src/server.js` exposes health, list, and create routes. It validates project names and returns explicit HTTP statuses.
+
+## API Routes
+
+| # | Method | Path | Description |
+|---|--------|------|-------------|
+| 1 | GET | `/api/health` | Report readiness |
+| 2 | GET | `/api/items` | List projects |
+| 3 | POST | `/api/items` | Create a project |
+
+## Services
+
+| Service | Classification | Role |
+|---------|---------------|------|
+| File repository (IItemRepository) | Essential | Persist project records |
+| Static file server | Essential | Serve HTML, JS, and CSS from `public/` |
+
+## Validation
+
+Run build, generated tests, lint, browser actions, accessibility checks, persistence restart, and debugger readiness.

--- a/evals/grader-certification/api-only-no-datastore/scenario.json
+++ b/evals/grader-certification/api-only-no-datastore/scenario.json
@@ -1,0 +1,28 @@
+{
+    "schemaVersion": "1",
+    "id": "grader-api-only-no-datastore",
+    "prompt": "Build a stateless currency conversion API with no database and no UI \u2014 just REST endpoints that convert between currencies using in-memory rates.",
+    "baselinePrompt": "Create a stateless currency conversion API. It exposes REST endpoints to list supported currencies and convert an amount between two of them, using rates held in memory. There is no database and no browser UI. Include build, test and lint scripts, a local run configuration, and the deployment files needed to host it.",
+    "tags": {
+        "archetype": "api",
+        "frontend": "none",
+        "backend": "node",
+        "database": "none",
+        "auth": "none",
+        "complexity": "small"
+    },
+    "requirementsAnswers": {
+        "dataStores": [
+            "No datastore required"
+        ],
+        "auth": "No auth"
+    },
+    "validation": {
+        "profile": "advanced",
+        "build": true,
+        "test": true,
+        "lint": "required",
+        "timeoutMinutes": 5,
+        "maxAgentRetries": 0
+    }
+}

--- a/evals/grader-certification/manifest.json
+++ b/evals/grader-certification/manifest.json
@@ -68,6 +68,14 @@
                 "service-fidelity": "ecosystemNotSupported",
                 "datastore-fidelity": "ecosystemNotSupported"
             }
+        },
+        {
+            "id": "api-only-no-datastore",
+            "path": "evals/grader-certification/api-only-no-datastore",
+            "description": "An API-only project with no datastore and no frontend, whose hand-off plan correctly omits the Database and Frontend sections. Certifies that the gate does not demand what this project has no reason to have.",
+            "offlineValidators": [
+                "integration-plan"
+            ]
         }
     ],
     "mutations": [
@@ -740,6 +748,17 @@
             "search": "    <script src=\"/app.js\"></script>\n",
             "replacement": "",
             "expectedCode": "frontendMakesNoApiCalls"
+        },
+        {
+            "id": "integration-plan-database-section-dropped",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "integration-plan",
+            "file": ".azure/integration-plan.md",
+            "operation": "replace",
+            "search": "## Database\n\n| Field | Value |\n|-------|-------|\n| Type | File-backed JSON store |\n| Data file | `data/items.json` |\n| Migration tool | none (no schema to migrate) |\n\nProduction migration would replace the file store with managed storage. **NO seed data is to be created.**\n\n### Collection \u2192 table mapping (whitelisted in `src/services/database.ts`)\n\n| Collection (code) | Store key |\n|-------------------|-----------|\n| `tickets` | `items` |",
+            "replacement": "",
+            "expectedCode": "missingDatabase"
         }
     ]
 }

--- a/evals/graders/validate-integration-plan.ts
+++ b/evals/graders/validate-integration-plan.ts
@@ -9,16 +9,22 @@
  * The contract lives in `evals/src/artifacts/integrationPlan.ts`, shared with grader
  * certification, so the certified path and the executed path cannot drift.
  *
- * Flags: --has-frontend
+ * Flags:
+ *   --has-frontend   also grade the Frontend and Shared types sections
+ *   --no-datastore   the project declares no datastore, so do not demand a Database
+ *                    section. Deliberately a negative flag: absence must keep the
+ *                    gate strict, or a flag nobody passes silently weakens it.
  */
 
 import { validateIntegrationPlanArtifact } from '../src/artifacts/integrationPlan.ts';
 import { failWithIssues, readArtifact, runGrader } from './graderHarness.ts';
 
 runGrader('integration-plan.md satisfies the hand-off contract', () => {
-    const hasFrontend = process.argv.slice(2).includes('--has-frontend');
+    const flags = process.argv.slice(2);
+    const hasFrontend = flags.includes('--has-frontend');
+    const hasDatastore = !flags.includes('--no-datastore');
 
-    const result = validateIntegrationPlanArtifact(readArtifact('.azure/integration-plan.md'), { hasFrontend });
+    const result = validateIntegrationPlanArtifact(readArtifact('.azure/integration-plan.md'), { hasFrontend, hasDatastore });
     if (!result.valid) {
         failWithIssues('integration plan contract errors:', result.issues);
     }

--- a/evals/msbench/config/gates.yaml
+++ b/evals/msbench/config/gates.yaml
@@ -166,13 +166,22 @@ gates:
     grader: evals/graders/validate-integration-plan.ts
     summary: .azure/integration-plan.md hands off correctly
     phases: [scaffold]
-    # unreviewed: no stated reason for requiring nothing. Not a claim that the row
-    # is wrong — a claim that nobody has written down why it is right, which is
-    # indistinguishable from nobody having considered it.
+    # Every project the flow scaffolds is contracted to produce this artifact — it
+    # is the hand-off between the scaffold and local-dev phases, written whatever
+    # the ecosystem, hosting or datastore. There is no project shape that
+    # legitimately omits it, so no fact's absence leaves this gate nothing to read.
+    # Verified against the grader: every issue code it emits is structural, and the
+    # `func start` / `npm start` mentions are format examples, not ecosystem checks.
     requires: {}
     args:
       - value: --has-frontend
         when: { project.frontend: [spa] }
+      # `[none]` rather than `{ not: [...] }`, and that is deliberate: this flag
+      # names the one value that relaxes the gate, so a new datastore kind must not
+      # be added to it. The deny-list is right for "must be something"; an
+      # allow-list is right for "is exactly this".
+      - value: --no-datastore
+        when: { project.datastore: [none] }
 
   # --- local-dev phase ----------------------------------------------------
   - id: debug-plan

--- a/evals/results/grader-certification/offline/report.json
+++ b/evals/results/grader-certification/offline/report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-26T08:32:42.367Z",
+  "generatedAt": "2026-08-26T08:52:34.771Z",
   "mode": "offline",
   "fixtures": [
     "sample-agent-output",
@@ -8,7 +8,8 @@
     "reference-node-multiservice",
     "reference-python-api",
     "reference-dotnet-api",
-    "reference-go-unsupported"
+    "reference-go-unsupported",
+    "api-only-no-datastore"
   ],
   "outcome": "passed",
   "cases": [
@@ -313,6 +314,18 @@
       "expected": "missingBackendPort",
       "actual": [
         "missingBackendPort"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "integration-plan-database-section-dropped",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "integration-plan",
+      "expected": "missingDatabase",
+      "actual": [
+        "missingDatabase"
       ],
       "passed": true,
       "durationMs": 0
@@ -974,6 +987,16 @@
       "actual": [
         "ecosystemNotSupported"
       ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "golden-integration-plan",
+      "tier": "offline",
+      "fixture": "api-only-no-datastore",
+      "validator": "integration-plan",
+      "expected": "passed",
+      "actual": [],
       "passed": true,
       "durationMs": 0
     }

--- a/evals/results/grader-certification/offline/report.md
+++ b/evals/results/grader-certification/offline/report.md
@@ -1,9 +1,9 @@
 # Copilot on Rails Grader Certification
 
 - Mode: `offline`
-- Fixtures: `sample-agent-output`, `reference-node-fullstack`, `reference-node-multiservice`, `reference-python-api`, `reference-dotnet-api`, `reference-go-unsupported`
+- Fixtures: `sample-agent-output`, `reference-node-fullstack`, `reference-node-multiservice`, `reference-python-api`, `reference-dotnet-api`, `reference-go-unsupported`, `api-only-no-datastore`
 - Outcome: **PASSED**
-- Cases: 84/84 passed
+- Cases: 86/86 passed
 
 | Case | Fixture | Validator | Expected | Actual | Result |
 |---|---|---|---|---|---|
@@ -34,6 +34,7 @@
 | `integration-plan-no-seed-rule-as-table-row` | `sample-agent-output` | `integration-plan` | `passed` | `passed` | PASS |
 | `integration-plan-port-inside-run-command` | `sample-agent-output` | `integration-plan` | `passed` | `passed` | PASS |
 | `integration-plan-missing-backend-port` | `sample-agent-output` | `integration-plan` | `missingBackendPort` | `missingBackendPort` | PASS |
+| `integration-plan-database-section-dropped` | `sample-agent-output` | `integration-plan` | `missingDatabase` | `missingDatabase` | PASS |
 | `golden-debug-plan` | `reference-node-fullstack` | `debug-plan` | `passed` | `passed` | PASS |
 | `golden-debug-config` | `reference-node-fullstack` | `debug-config` | `passed` | `passed` | PASS |
 | `golden-debug-artifacts` | `reference-node-fullstack` | `debug-artifacts` | `passed` | `passed` | PASS |
@@ -91,4 +92,5 @@
 | `fidelity-orm-owns-the-driver-dotnet` | `reference-dotnet-api` | `datastore-fidelity` | `passed` | `passed` | PASS |
 | `golden-service-fidelity` | `reference-go-unsupported` | `service-fidelity` | `ecosystemNotSupported` | `ecosystemNotSupported` | PASS |
 | `golden-datastore-fidelity` | `reference-go-unsupported` | `datastore-fidelity` | `ecosystemNotSupported` | `ecosystemNotSupported` | PASS |
+| `golden-integration-plan` | `api-only-no-datastore` | `integration-plan` | `passed` | `passed` | PASS |
 

--- a/evals/src/artifacts/integrationPlan.ts
+++ b/evals/src/artifacts/integrationPlan.ts
@@ -45,7 +45,7 @@ interface Section {
 
 export function validateIntegrationPlanArtifact(
     content: string,
-    options: { hasFrontend?: boolean } = {},
+    options: { hasFrontend?: boolean; hasDatastore?: boolean } = {},
 ): ArtifactValidationResult {
     const issues: ArtifactValidationIssue[] = [];
 
@@ -59,7 +59,19 @@ export function validateIntegrationPlanArtifact(
 
     validateBackend(findSection(sections, backendHeading)?.body, issues);
     validateRoutes(findSections(sections, /\b(routes?|endpoints?)\b/i, frontendHeading), issues);
-    validateDatabase(findSection(sections, /\b(database|data ?store|persistence|storage)\b/i), issues);
+    // Demanding a Database section is only right when the project has a datastore.
+    // A project declared `datastore: none` correctly omits it, and grading that as
+    // `missingDatabase` blames the agent for a document that is right — the same
+    // fabricated-red shape as running the Node build grader against a Python project.
+    //
+    // Note the polarity: this defaults to **demanding**, and only an explicit
+    // "there is no datastore" relaxes it. The opposite default would mean a caller
+    // that passes no options silently stops checking — a flag nothing passes,
+    // quietly weakening the gate, which is exactly how `--require-health` came to
+    // exist only in its own documentation.
+    if (options.hasDatastore !== false) {
+        validateDatabase(findSection(sections, /\b(database|data ?store|persistence|storage)\b/i), issues);
+    }
     validateServices(findSection(sections, /^(azure )?services\b/i)?.body, issues);
 
     if (options.hasFrontend) {

--- a/evals/src/graderCertification.ts
+++ b/evals/src/graderCertification.ts
@@ -226,6 +226,7 @@ const OFFLINE_VALIDATORS: Record<
     'integration-plan': async (workspace, scenario) =>
         validateIntegrationPlanArtifact(await readArtifact(workspace, '.azure/integration-plan.md'), {
             hasFrontend: (scenario.tags.frontend ?? 'none') !== 'none',
+            hasDatastore: (scenario.tags.database ?? 'none') !== 'none',
         }),
     'plan-gate': async (workspace, scenario) => {
         const azure = path.join(workspace, '.azure');


### PR DESCRIPTION
`validateDatabase` ran unconditionally while its frontend counterpart was gated behind `--has-frontend`. Measured against the certified fixture:

```
baseline (has DB section)              PASS
datastore: none — DB section removed   missingDatabase
```

A project declared `datastore: none`, whose agent **correctly** omits the section, is failed for it. That is the `project-builds` shape — a gate wired where part of what it demands doesn't apply, **blaming the agent for a document that is right.** Latent only because both shipped stacks are postgres, and `DatastoreKind` includes `none`.

## How it was found

By discharging someone else's honest caveat. The stacks session supplied a reason for this row and marked it *"reasoned, not verified against the grader"* — they hadn't read it closely enough to know whether it graded anything ecosystem-specific. Reading it confirmed their reason (every issue code is structural; the `func start` / `npm start` mentions are format examples) and turned up this instead.

**The row's `requires: {}` is correct** — every project does produce this artifact. The bug is one field down, in `args:`. We had both been auditing `requires:` and no amount of scrutiny there would have reached it.

## The flag is negative on purpose

`--no-datastore` relaxes the gate; its absence keeps it strict.

A positive `--has-datastore` would mean a caller passing no flags **silently stops checking** — a flag nothing passes, quietly weakening the gate. That is precisely how `--require-health` came to exist only in its own documentation, and it would have been the most embarrassing possible way to lose that lesson. All four polarities verified by hand:

```
datastore project, DB section present        PASS
datastore project, DB section removed        missingDatabase
datastore: none, DB section removed          PASS
no options passed at all (must stay strict)  missingDatabase
```

The `when:` predicate is an allow-list, `[none]`, deliberately in the opposite direction from `datastore-fidelity`'s: this flag names the one value that *relaxes* the gate, so a new datastore kind must never be added to it. **Deny-lists are right for "must be something"; allow-lists for "is exactly this".**

## Two controls, and the interesting one asserts a gate does *not* fire

**`integration-plan-database-section-dropped`** — a project that *has* a datastore and drops the section still reports `missingDatabase`. Proves the check was gated, not deleted.

**`api-only-no-datastore`** — a new two-file fixture: an API-only project with no datastore whose plan correctly omits Database and Frontend must **PASS**. This is the over-strictness control, the class we keep finding unguarded; every other mutation we have asserts a gate *catches* something.

And it was watched failing rather than assumed to work — reverting the gate turns its golden case red:

```
golden-integration-plan  expected=passed  actual=[missingDatabase]  FAIL — control bites
```

Certification **86/86**. `check-stacks`, `typecheck` and `drift` green.

## Also in this PR

Discharges the `# unreviewed:` marker on `debug-breakpoint`. Its owner answered the "why does this row hold?" question, and the answer is that **the row is too broad**: the honest requirement is a stimulus that writes a probe spec *and* a stack whose debug adapter ships with VS Code. They found by testing — not re-reading — that it previously exited **1** on a correct project with a `debugpy` config, blaming the product for an adapter the container lacks. Their probe now checks `contributes.debuggers[].type` before launching and returns exit 3.

Recorded in place as a documented defect with their change pending, rather than left looking like a question nobody had asked. The markers on `integration-plan`, `debug-plan`, `debug-config` and `debug-artifacts` — the last three not mine — stay.
