### PR TITLE
Stop gate-health rebuilding the declared-gap key by hand

### DIFF
--- a/evals/msbench/gate-health.ts
+++ b/evals/msbench/gate-health.ts
@@ -850,9 +850,10 @@ async function loadDeclaredGaps(): Promise<{ declared: Map<string, DeclaredGap>;
             .filter(name => name.endsWith('.yaml'))
             .sort()
             .map(name => loadStack(join(stacksDir, name), { inventory, phasesDirectory: join(config, 'phases') }));
-        const { findStaleDeclarations, annotationFor } = await import('../src/declaredGaps.ts');
+        const { findStaleDeclarations, annotationFor, lookupDeclaredGap } = await import('../src/declaredGaps.ts');
         staleDeclarationsSync = findStaleDeclarations;
         annotationForSync = annotationFor;
+        lookupGapSync = lookupDeclaredGap;
         return { declared: collectDeclaredGaps(stacks), reasonCodes: knownReasonCodes() };
     } catch (error) {
         return {
@@ -984,7 +985,13 @@ function printDeclaration(
     if (gaps.problem || gaps.declared.size === 0) {
         return;
     }
-    const gap = gaps.declared.get(`${gate}\t${reason}`);
+    // Looked up through the exported accessor, never by rebuilding the key here.
+    // This line used to restate `${gate}\t${reason}` as a literal, which is two
+    // representations of one format: change the key in `declaredGaps.ts` and this
+    // silently returns undefined for every gap, so every accounted-for red reads
+    // UNDECLARED — failure in the noisy direction, and invisible, because all
+    // twelve self-test cases go through the accessor and would stay green.
+    const gap = lookupGapSync(gaps.declared, gate, reason);
     // `notAttempted` merges NOT_APPLICABLE reason codes with instance faults like
     // `X_MODEL_NOT_FOUND_ERROR`. Only the former can appear in a `knownGaps`
     // entry, so the decision of whether to say anything at all lives in
@@ -1284,6 +1291,7 @@ function printStaleDeclarations(rows: GateRow[], gaps: { declared: Map<string, D
 
 let staleDeclarationsSync: (declared: Map<string, DeclaredGap>, observed: Map<string, Set<string>>) => DeclaredGap[] = () => [];
 let annotationForSync: (gap: DeclaredGap | undefined, reason: string, reasonCodes: Set<string>) => 'skip' | 'undeclared' | 'declared' = () => 'skip';
+let lookupGapSync: (declared: Map<string, DeclaredGap>, gate: string, reason: string) => DeclaredGap | undefined = () => undefined;
 
 async function main(): Promise<void> {
     const options = parseArgs(process.argv.slice(2));

--- a/evals/src/declaredGaps.ts
+++ b/evals/src/declaredGaps.ts
@@ -35,6 +35,9 @@
  * accounted for on the stack that actually produced it.
  */
 
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Stack } from './stack.ts';
 
 export interface DeclaredGap {
@@ -157,7 +160,53 @@ function stackWith(id: string, gaps: Array<{ gates: string[]; reason: string; tr
 
 const REASON_CODES = new Set(['functionsHostUnavailable', 'ecosystemNotSupported', 'datastoreRequiresContainer']);
 
+/**
+ * Consumers that must reach the map through `lookupDeclaredGap`, never by
+ * rebuilding the key.
+ *
+ * This is a mechanism rather than a comment, because the comment was already
+ * there and did not work: `lookupDeclaredGap` was exported precisely so nobody
+ * would restate the key format, every one of the cases below used it, and the
+ * single real consumer bypassed it with a literal anyway. The tests all ran
+ * through the accessor and would have stayed green while production diverged —
+ * a suite structurally unable to fail for the defect it was written to prevent.
+ */
+const KEY_CONSUMERS = ['../msbench/gate-health.ts'];
+
+/** A map access that builds its own key: `something.get(`${a}\t${b}`)`. */
+const REBUILT_KEY = /\.get\(\s*`[^`]*\$\{[^`]*\\t/u;
+
 const CASES: Case[] = [
+    {
+        name: 'no consumer rebuilds the declared-gap key instead of using the accessor',
+        run: () => {
+            const here = dirname(fileURLToPath(import.meta.url));
+            const rebuilt: string[] = [];
+            const unreadable: string[] = [];
+            for (const consumer of KEY_CONSUMERS) {
+                try {
+                    if (REBUILT_KEY.test(readFileSync(join(here, consumer), 'utf8'))) {
+                        rebuilt.push(consumer);
+                    }
+                } catch {
+                    // A moved or renamed consumer fails too — a guard silently
+                    // covering nothing is the failure it exists to prevent. But it is
+                    // reported as its own problem: telling someone to go and find a
+                    // key literal in a file that does not exist sends them to the
+                    // wrong place and suppresses its own investigation.
+                    unreadable.push(consumer);
+                }
+            }
+            if (unreadable.length > 0) {
+                return `${unreadable.join(', ')} could not be read, so this guard is covering nothing. `
+                    + `Update KEY_CONSUMERS if the file moved.`;
+            }
+            return rebuilt.length === 0
+                ? undefined
+                : `${rebuilt.join(', ')} builds the gate\\treason key directly. Change the key format and it `
+                + `silently matches nothing, so every declared red reads UNDECLARED. Use lookupDeclaredGap.`;
+        },
+    },
     {
         name: 'an instance fault is not annotated at all — no stack could declare it',
         run: () => annotationFor(undefined, 'X_MODEL_NOT_FOUND_ERROR', REASON_CODES) === 'skip'


### PR DESCRIPTION
Prompted by the sentinel-literal bug in `build-config.ts` and the general form drawn from it — **a generated artifact must import its constants, never restate them.** I went looking for the same shape in my own code and found it one file over, in code merged two hours ago.

## The defect

`src/declaredGaps.ts` owns the key format and exports an accessor so no caller has to know it:

```ts
function keyOf(gate: string, reason: string): string {
    return `${gate}\t${reason}`;          // private
}
export function lookupDeclaredGap(declared, gate, reason) {
    return declared.get(keyOf(gate, reason));
}
```

`msbench/gate-health.ts` — **the only real consumer** — bypassed it:

```ts
const gap = gaps.declared.get(`${gate}\t${reason}`);   // restated
```

Change the key format and that silently matches nothing, so every accounted-for red prints `UNDECLARED — nobody has accounted for this one; go and look`. Failure in the **noisy** direction, which is the one that teaches a reader to skip the section — the same alarm-fatigue failure this join has now produced twice.

## Why the tests would not have caught it

This is the part worth recording. **All twelve join cases go through `lookupDeclaredGap`. The one consumer did not.** So the suite would have stayed green while production diverged — structurally unable to fail for the defect it was written to prevent.

And `lookupDeclaredGap` was exported *precisely* so nobody would restate the key. The comment was already there. It did not work.

## So the rule becomes a mechanism

A case scans the consumers for a rebuilt key. Proven both ways rather than asserted:

```
R1  reintroduce the literal
    ✖ ../msbench/gate-health.ts builds the gate\treason key directly. Change the key
      format and it silently matches nothing, so every declared red reads UNDECLARED.
      Use lookupDeclaredGap.                                                    EXIT=1

R2  point the guard at a file that does not exist
    ✖ ../msbench/does-not-exist.ts could not be read, so this guard is covering
      nothing. Update KEY_CONSUMERS if the file moved.                          EXIT=1
```

R2 matters because a guard silently covering nothing is the failure it exists to prevent — the `COUNT(*) = 0` shape again. The two report **separately** on purpose: my first version printed "builds the key directly" for a missing file, which sends the reader hunting for a literal that isn't there. Same lesson as `coverageGap` versus `environmentGap` — a message that points at the wrong place suppresses its own investigation.

## No behaviour change

The key format is unchanged, so the join produces exactly what it did before. This removes a second representation and guards against its return.

## Verification

All seven credential-free gates green: `typecheck`, `stacks:check`, `imports:self-test`, `drift`, `certify` (81/81), `lint`, `clean-machine:check`.

Not in this PR: the `build-config.ts` sentinel literal (config session) and the `integration-plan` `--has-datastore` fix (runtime session).

**No MSBench run was submitted.**
