### PR TITLE
Fix five places the MSBench docs and config disagreed with themselves

### DIFF
--- a/.github/workflows/msbench-evals.yml
+++ b/.github/workflows/msbench-evals.yml
@@ -33,6 +33,10 @@ on:
         description: 'Benchmark instance to borrow for its container image'
         required: false
         default: 'vscbench.say_hello'
+      stimulus:
+        description: 'Stimulus to submit. The default is the cheapest one whose answer we already know.'
+        required: false
+        default: 'scaffold-unapproved-plan'
 
 env:
   NODE_VERSION: '22'
@@ -117,10 +121,21 @@ jobs:
           tenant-id: ${{ secrets.MSBENCH_AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.MSBENCH_AZURE_SUBSCRIPTION_ID }}
 
-      - name: Run project-plan eval
+      # STIMULUS is read from the environment by run.sh, the same way BENCHMARK
+      # is, so `--stimulus` on the command line still wins for a local run.
+      #
+      # It is set explicitly rather than left to run.sh's default, which is
+      # `photo-app-requirements` — a full planning run whose result would then
+      # have to be interpreted. The first CI runs are testing the *pipeline*, so
+      # they use a stimulus whose answer is already known locally (6/6 green):
+      # a red then means CI is broken, which is the only question being asked.
+      # A first run against an unknown-answer stimulus cannot separate "CI is
+      # misconfigured" from "the product changed".
+      - name: Run the MSBench eval
         run: ./evals/msbench/run.sh --skip-build --output "$RUNNER_TEMP/report.json" --data_dir "$RUNNER_TEMP/msbench-data"
         env:
           BENCHMARK: ${{ inputs.benchmark }}
+          STIMULUS: ${{ inputs.stimulus }}
 
       # Keep the report and per-instance data so a failure can be diagnosed from
       # the transcript and patch rather than by re-running.

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -488,20 +488,29 @@ confirmation from the MSBench team (<CodeExService@microsoft.com>).
 > `completed` *before* `initialized`, so `initialized` there is a re-download rather than
 > a run start):
 >
-> | | setup | agent time |
-> | --- | --- | --- |
-> | min | 147.9s | 45.1s |
-> | median | 181.0s | 107.0s |
-> | **max** | **896.6s** (14.9m) | 2826.1s (47.1m) |
+> | | n | min | median | max |
+> | --- | --- | --- | --- | --- |
+> | one extension | 17 | 147.9s | 171.1s | 233.2s |
+> | **two extensions** (current) | 6 | 182.5s | **195.5s** | **896.6s** |
+> | agent time (all) | 23 | 45.1s | 107.0s | 2826.1s |
+>
+> Two extensions is the current configuration: since [#1720](https://github.com/microsoft/vscode-azureresourcegroups/pull/1720),
+> `base.yaml` installs the debug probe alongside the product VSIX on **every** run.
 >
 > The ~15m assumption was, as it happens, almost exactly right — and that is the trap. It
 > matched the observed maximum at **1.00x headroom**, meaning none.
 >
-> **Setup is not a constant; it grows with what we install.** The 896.6s outlier is
-> `debug-probe-smoke` (`2026082620311350`), the one run that installs a *second*
-> extension. One extra extension took setup from ~181s to ~897s, so a third of similar
-> cost lands near 1600s and would blow a 15m allowance outright. 30m is 2.0x the observed
-> max and absorbs that.
+> **The 896.6s maximum is unexplained, and that is why the allowance is 2x rather than
+> tight.** It is tempting to attribute it to the second extension, since it is
+> `debug-probe-smoke` (`2026082620311350`). That is wrong: the second extension costs
+> about **+24s** on the median, and the five later two-extension runs took 182–216s. A
+> cold image pull is also ruled out — the full runlog shows that run *and* its successor
+> pulling every layer. It was the first probe run, which is suggestive of a one-off, but
+> that is a correlation with n=1, not a cause.
+>
+> An unexplained 4.6x excursion is a *better* argument for headroom than a known cost
+> would be: a known cost can be budgeted, an unpredictable one can only be absorbed.
+> Sizing to the median would have been beaten by a run we have already observed.
 >
 > **Erring low is the safe direction, which is why the headroom is generous rather than
 > tight.** Too low: the agent timeout fires, `runnerGraceSeconds` runs, artifacts flush,

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -407,7 +407,7 @@ run, so they are set explicitly:
 
 | Key | Default | Ours | Why |
 | --- | --- | --- | --- |
-| `agentSeconds` | 6300 (1h45m) | **5400 (90m)** | The E2E chain is describe → requirements → plan → scaffold → build → run → debug in **one** session, so the per-turn default is the wrong shape — but the budget is capped by the measured 7200s runner limit, not by what the chain would like. `7200 − 15m setup − 15m grace`. See below. |
+| `agentSeconds` | 6300 (1h45m) | **4500 (75m)** | The E2E chain is describe → requirements → plan → scaffold → build → run → debug in **one** session, so the per-turn default is the wrong shape — but the budget is capped by the measured 7200s runner limit, not by what the chain would like. `7200 − 30m setup − 15m grace`, both terms measured. See below. |
 | `stallSeconds` | 2700 (45m) | **2700 (45m)** — the default | Must stay strictly below `agentSeconds` or it can never fire. Kept at the schema default rather than derived; the longest measured quiet stretch is 211.8s. See below. |
 | `runnerGraceSeconds` | 300 (5m) | 900 (15m) | A long session has far more to flush at the end (screen recording, trajectory, `session.sqlite`) than a 5-step run, and a truncated artifact is an unreadable result. |
 
@@ -429,8 +429,11 @@ precisely the runs you most need to diagnose. `agentSeconds` must therefore be t
 cap minus setup minus grace:
 
 ```
-7200s runner cap − ~15m setup − 15m grace ⇒ 5400s agent
+7200s runner cap − 30m setup allowance − 15m grace ⇒ 4500s agent
 ```
+
+Both terms are measured; see the box below for how the setup allowance was derived and
+why it is 2x the observed maximum rather than equal to it.
 
 The schema gives all three a `maximum` of `9007199254740991`, so nothing above is
 schema-constrained. The real ceiling is the platform job limit, and that is **measured
@@ -470,17 +473,45 @@ confirmation from the MSBench team (<CodeExService@microsoft.com>).
 > So the arithmetic above is re-derived against 7200 rather than an assumed 21600:
 >
 > ```
-> 7200s runner cap − ~15m setup − 15m grace ⇒ 5400s agent
+> 7200s runner cap − 30m setup allowance − 15m grace ⇒ 4500s agent
 > ```
 >
-> `config/base.yaml` now sets `agentSeconds: 5400`. The previous 18000 was **2.5x the
-> real budget** — the exact failure this section warns about, sitting in the config that
+> `config/base.yaml` now sets `agentSeconds: 4500`. The previous 18000 was **4x the real
+> budget** — the exact failure this section warns about, sitting in the config that
 > documents it.
 >
-> **Two consequences worth stating rather than discovering.**
+> **The setup allowance is measured too, and that is the second half of the fix.** A first
+> attempt at this derivation used the measured cap with an *assumed* ~15m setup and
+> produced 5400 — replacing an assumption-derived number with another assumption-derived
+> number while calling it measured. Setup is now `timestamps.initialized` to the first
+> agent step, over 23 usable cached runs (two excluded: their own metadata reports
+> `completed` *before* `initialized`, so `initialized` there is a re-download rather than
+> a run start):
 >
-> First, `stallSeconds` had to move. At 5400 it would have equalled `agentSeconds`, so a
-> stall could never fire before the agent budget expired — an inert timeout that reads as
+> | | setup | agent time |
+> | --- | --- | --- |
+> | min | 147.9s | 45.1s |
+> | median | 181.0s | 107.0s |
+> | **max** | **896.6s** (14.9m) | 2826.1s (47.1m) |
+>
+> The ~15m assumption was, as it happens, almost exactly right — and that is the trap. It
+> matched the observed maximum at **1.00x headroom**, meaning none.
+>
+> **Setup is not a constant; it grows with what we install.** The 896.6s outlier is
+> `debug-probe-smoke` (`2026082620311350`), the one run that installs a *second*
+> extension. One extra extension took setup from ~181s to ~897s, so a third of similar
+> cost lands near 1600s and would blow a 15m allowance outright. 30m is 2.0x the observed
+> max and absorbs that.
+>
+> **Erring low is the safe direction, which is why the headroom is generous rather than
+> tight.** Too low: the agent timeout fires, `runnerGraceSeconds` runs, artifacts flush,
+> the run is diagnosable. Too high: the job is killed first and *nothing* is flushed.
+> Those are not symmetric, so the budget is sized against the bad direction. 4500s is
+> still 1.6x the longest agent time ever observed here.
+>
+> **`stallSeconds` had to move as a consequence, and this is the part worth reading.** It
+> was also 5400. Left there it would have equalled or exceeded `agentSeconds`, so a stall
+> could never fire before the agent budget expired — an inert timeout that reads as
 > protection, which is the same shape as a gate that cannot fail. It is now the schema
 > default of **2700**, and that is a *default, not a derivation*: no arithmetic here
 > yields a stall threshold. It is not unexamined, though — the longest gap between agent
@@ -492,11 +523,9 @@ confirmation from the MSBench team (<CodeExService@microsoft.com>).
 > `azd provision` is the obvious candidate and has never been measured, so **revisit this
 > when the deploy gate lands** rather than treating a mystery kill as a product failure.
 >
-> Second, the new derivation leaves **no margin**: 5400 + 900 grace + 900 setup is 7200
-> exactly, where the old 6h derivation held 30m back. Nothing has come close — the
-> longest run to date is 49m, and `2026082614813342` used 465s of the 7200s (6.5%) — but
-> the first run that approaches the cap will find that edge. Worth confirming the setup
-> allowance with <CodeExService@microsoft.com> before the deploy phase is wired up.
+> One caveat on the setup figures: `results.json` writes its timestamps as naive local
+> wall-clock while trajectory steps are UTC, so comparing them directly yields a ~7h
+> offset and nonsense numbers. Convert before subtracting.
 
 **`msbench-cli run --timeout` — not the same thing, and don't add it.** It is a *local*
 wait. From `cli/arguments.py`: *"Max seconds to wait locally for completion. When
@@ -2193,6 +2222,22 @@ with a clear message:
   because it explained anything: the artifact scare that prompted the enumeration turned
   out to be a read that predated the run's completion by about five minutes, and member
   order was not the cause. Noted here so nobody re-derives it as one.
+- **A trailing `echo` after `&&` reports success unconditionally.** `cmd && check; echo
+  "done"` prints `done` whether or not `cmd` ran, because `;` is not `&&` — and if
+  anything earlier in the chain fails, everything after the `&&` is skipped while the
+  final `echo` still fires. This has bitten three times here, in two shapes: a
+  `git push` that never ran but reported "pushed" (caught only when PR creation failed
+  with *"No commits between feat/CoR and feat/CoR"*), and `npm run gates | tail`
+  reporting exit 0 because a pipeline's status is the *last* command's, not the first's.
+  Put the echo inside the chain, check `$?` explicitly, or use `${PIPESTATUS[0]}` after a
+  pipe. A false green from your own tooling is worth more suspicion than a red gate,
+  because nothing downstream will contradict it.
+
+- **`results.json` timestamps are naive local time; trajectory steps are UTC.**
+  Subtracting one from the other directly yields a ~7h offset — setup times of ~25,400s
+  on runs that finished in 240s. Convert before comparing. This is how the setup
+  measurement behind `agentSeconds` was nearly derived from garbage.
+
 - **`msbench-cli` silently installs an ancient version.** pip's 15s default read
   timeout treats a slow feed download as an *unusable candidate* rather than a network
   error, so it backtracks through older releases and reports success — once landing

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -512,6 +512,17 @@ confirmation from the MSBench team (<CodeExService@microsoft.com>).
 > would be: a known cost can be budgeted, an unpredictable one can only be absorbed.
 > Sizing to the median would have been beaten by a run we have already observed.
 >
+> **It is left recorded as unexplained rather than attributed.** If it recurs it becomes
+> a pattern with its first data point already logged; attributed to the wrong cause, the
+> recurrence looks like a new problem.
+>
+> **Cheapest way to sanity-check any setup figure: total run duration bounds it from
+> above.** `results.json` carries `timestamps.initialized` and `timestamps.completed`,
+> and a run that finished in 242s cannot contain 897s of setup. That check needs two
+> fields and no trajectory parsing, and it is what refuted the claim that the 896.6s
+> figure had become the norm — the two-extension runs that followed took 4m32s and 4m33s
+> end to end. Reach for it before parsing anything.
+>
 > **Erring low is the safe direction, which is why the headroom is generous rather than
 > tight.** Too low: the agent timeout fires, `runnerGraceSeconds` runs, artifacts flush,
 > the run is diagnosable. Too high: the job is killed first and *nothing* is flushed.
@@ -2122,6 +2133,32 @@ three repository secrets still have to be set before a dispatch can authenticate
 until they are, the `Azure login` step fails before `run.sh` is reached. That is a
 different failure from the one this section used to describe, and it fails in a
 different place, so read the failing *step* rather than assuming the allowlist.
+
+### Known issue: the federated credential subject must be ID-based
+
+**This is unresolved at the time of writing, and recorded before its fix on purpose** —
+the next repository onboarded to MSBench hits it identically, and a known issue written
+while the error text is still to hand is worth more than one reconstructed later.
+
+A dispatch fails at `azure/login` with a subject mismatch. GitHub presents an **ID-based**
+subject; the federated credential was written in the **path-based** form:
+
+```
+presented:   repository_owner_id:6154722:repository_id:238360694:ref:refs/heads/feat/CoR
+credential:  repo:microsoft/vscode-azureresourcegroups:ref:refs/heads/feat/CoR
+```
+
+Two things make this cheap to act on. The failure costs **nothing** — it happens before
+`run.sh` is reached, so no run is submitted and no tokens are spent. And the fix is
+**known-good rather than speculative**: the same identity already carries an ID-based
+credential for `vscode-azure`, so someone has hit and solved this before.
+
+The blocker is not our configuration. The subscription carries a `ReadOnly` lock, so the
+credential cannot be added without an owner lifting it.
+
+**It also means a red `eval` job is not evidence about the eval.** Read which *step*
+failed before concluding anything: `Azure login` red is setup, `Run the MSBench eval` red
+is the pipeline, and only a completed submission says anything about the product.
 
 **It stays manual, and not only because of setup.** Every dispatch submits a real run and
 spends real tokens, so a schedule or a PR trigger would spend on every push. Local runs

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -243,7 +243,17 @@ number for the chain that is measured rather than extrapolated from single-turn 
 > **+154% on uncached**, because a subagent starts a fresh context and so caches badly
 > (47.9% cached, against the main trajectory's 93.2%). Sum
 > `trajectories/*.trajectory.json`, not just the report, or every subagent-heavy phase
-> will look cheaper than it is — and scaffold is expected to use more of them, not fewer.
+> will look cheaper than it is.
+>
+> ~~and scaffold is expected to use more of them, not fewer~~ — **retracted, measured
+> false.** `scaffold-fullstack` (`2026082620153444`) produced **exactly one** trajectory
+> and made **no** `runSubagent` calls: 39 steps, 88 tool calls, all in the main
+> trajectory. It delegated *less* than the planning run above, not more. So the
+> undercount for that run is zero by construction, and phase complexity does not predict
+> subagent use — at least not in the direction assumed here. The rest of this box is
+> unaffected: the undercount is real whenever delegation happens, and you cannot tell
+> from the report whether it did. **That** is why summing the trajectory files is the
+> rule rather than a precaution for phases believed to delegate. n=1 in each direction.
 >
 > **This failure is silent.** You do not get an error or an obviously odd figure; you get
 > a plausible number that is 20% low on total and 154% low on uncached. Nothing about the
@@ -397,8 +407,8 @@ run, so they are set explicitly:
 
 | Key | Default | Ours | Why |
 | --- | --- | --- | --- |
-| `agentSeconds` | 6300 (1h45m) | 18000 (5h) | The E2E chain is describe → requirements → plan → scaffold → build → run → debug in **one** session. The default is a per-turn budget, not a chain budget. Sized to fit inside the job cap — see below. |
-| `stallSeconds` | 2700 (45m) | 5400 (90m) | See below. |
+| `agentSeconds` | 6300 (1h45m) | **5400 (90m)** | The E2E chain is describe → requirements → plan → scaffold → build → run → debug in **one** session, so the per-turn default is the wrong shape — but the budget is capped by the measured 7200s runner limit, not by what the chain would like. `7200 − 15m setup − 15m grace`. See below. |
+| `stallSeconds` | 2700 (45m) | **2700 (45m)** — the default | Must stay strictly below `agentSeconds` or it can never fire. Kept at the schema default rather than derived; the longest measured quiet stretch is 211.8s. See below. |
 | `runnerGraceSeconds` | 300 (5m) | 900 (15m) | A long session has far more to flush at the end (screen recording, trajectory, `session.sqlite`) than a 5-step run, and a truncated artifact is an unreadable result. |
 
 `stallSeconds` is the one that bites. It is **not** an agent-inactivity timeout — the
@@ -416,26 +426,26 @@ is killed *first*, the agent timeout never fires, and because `runnerGraceSecond
 time the runner takes **after** the agent timeout, the grace period never runs either.
 Nothing gets flushed — no screen recording, no trajectory, no `session.sqlite` — on
 precisely the runs you most need to diagnose. `agentSeconds` must therefore be the job
-cap minus setup minus grace, with margin:
+cap minus setup minus grace:
 
 ```
-6h job cap − ~15m setup − 15m grace ⇒ 5h agent
+7200s runner cap − ~15m setup − 15m grace ⇒ 5400s agent
 ```
 
 The schema gives all three a `maximum` of `9007199254740991`, so nothing above is
-schema-constrained. The real ceiling is the platform job limit. GitHub documents a 6-hour
-cap for hosted runners and 5 days for self-hosted; our runs report `dispatched to GitHub
-Actions` with `run_platform='linux_container'`, but **we could not verify which pool
-MSBench dispatches to** — that is decided by a server-side workflow not visible from the
-CLI or from `vscode-copilot-evaluation`. The 6h figure above is therefore an assumption,
-chosen because it is the safer of the two documented limits. If the cap is ever
-confirmed, re-derive `agentSeconds` from the arithmetic above rather than just raising
-it; raising it past 6h needs confirmation from the MSBench team
-(<CodeExService@microsoft.com>).
+schema-constrained. The real ceiling is the platform job limit, and that is **measured
+rather than assumed**: every instance runlog prints `Using timeout of 7200 seconds`
+before the agent starts. GitHub documents a 6-hour cap for hosted runners and 5 days for
+self-hosted, and our runs report `dispatched to GitHub Actions` with
+`run_platform='linux_container'` — but which pool MSBench dispatches to never had to be
+resolved, because the runner announces the limit it is actually applying. An earlier
+version of this section assumed the 6h figure and derived `agentSeconds: 18000` from it,
+which was 2.5x the real budget. Raising anything past the announced cap needs
+confirmation from the MSBench team (<CodeExService@microsoft.com>).
 
-> **The observed runner cap is 2h, not 6h — so `agentSeconds: 18000` is mis-derived.**
-> The instance runlog for `2026082614813342` says, verbatim, immediately after the
-> benchmark banner and before the agent starts:
+> **The runner cap is 7200s (2h), measured — and `agentSeconds` is now derived from it.**
+> The instance runlog says, verbatim, immediately after the benchmark banner and before
+> the agent starts:
 >
 > ```
 > containerName=vscbench.eval.x86_64.say_hello
@@ -446,22 +456,47 @@ it; raising it past 6h needs confirmation from the MSBench team
 > Runner script finished!
 > ```
 >
-> That is the outer runner applying a 2h timeout to `entry.sh` — the process that contains
-> the whole agent session — and the 5h `agentSeconds` above was derived from an *assumed*
-> 6h cap. If 7200s is the real per-instance limit then the agent budget is 2.5x the
-> runner's, which is precisely the failure this section warns about: the job is killed
-> first, the agent timeout never fires, `runnerGraceSeconds` never runs because it only
-> starts *after* the agent timeout, and nothing is flushed on the runs that most need
-> diagnosing. Re-derived from the observed cap, the arithmetic gives `7200 − ~15m setup −
-> 15m grace ⇒ ~1.5h agent (5400s)`.
+> That is the outer runner applying a 2h timeout to `entry.sh` — the process containing
+> the whole agent session. This was originally recorded as a single observation, and left
+> unactioned on two grounds: that it was one run, and that the line did not say whether
+> 7200s is fixed per instance or set per dispatch.
 >
-> This is left unchanged pending confirmation rather than fixed here, for two reasons:
-> it is one observation, and the line does not say whether 7200s is fixed per instance
-> or something the orchestrator sets per dispatch. Nothing has come close to it yet — the
-> longest run to date is 49m and `2026082614813342` used 465s of the 7200s (6.5%) — so
-> this is a latent trap rather than an active one. It becomes active on exactly the long
-> chain runs this timeout section exists for. Worth confirming with
-> <CodeExService@microsoft.com> before the scaffold and deploy phases get wired up.
+> **Both are now answered.** The value is identical in **all 30 cached runs**, spanning
+> three days, four models (`claude-sonnet-4.5`, `gpt-5`, `gpt-4.1`, `gpt-5.6`), several
+> benchmarks and multi-instance dispatches. Identical values across *different payloads*
+> is what rules out a per-dispatch setting — one run could not, thirty with varying
+> inputs can.
+>
+> So the arithmetic above is re-derived against 7200 rather than an assumed 21600:
+>
+> ```
+> 7200s runner cap − ~15m setup − 15m grace ⇒ 5400s agent
+> ```
+>
+> `config/base.yaml` now sets `agentSeconds: 5400`. The previous 18000 was **2.5x the
+> real budget** — the exact failure this section warns about, sitting in the config that
+> documents it.
+>
+> **Two consequences worth stating rather than discovering.**
+>
+> First, `stallSeconds` had to move. At 5400 it would have equalled `agentSeconds`, so a
+> stall could never fire before the agent budget expired — an inert timeout that reads as
+> protection, which is the same shape as a gate that cannot fail. It is now the schema
+> default of **2700**, and that is a *default, not a derivation*: no arithmetic here
+> yields a stall threshold. It is not unexamined, though — the longest gap between agent
+> steps in any successful cached run is **211.8s** (`2026082614813342`), and
+> `scaffold-fullstack`, which runs a real `npm install` and build, peaks at **82.4s**.
+> Those gaps are an *upper* bound on all-four-quiet, since workspace file activity
+> continues within a step gap, so 2700 sits at least 12.7x above anything measured. The
+> measurement that would refine it is a run that legitimately goes quiet for longer —
+> `azd provision` is the obvious candidate and has never been measured, so **revisit this
+> when the deploy gate lands** rather than treating a mystery kill as a product failure.
+>
+> Second, the new derivation leaves **no margin**: 5400 + 900 grace + 900 setup is 7200
+> exactly, where the old 6h derivation held 30m back. Nothing has come close — the
+> longest run to date is 49m, and `2026082614813342` used 465s of the 7200s (6.5%) — but
+> the first run that approaches the cap will find that edge. Worth confirming the setup
+> allowance with <CodeExService@microsoft.com> before the deploy phase is wired up.
 
 **`msbench-cli run --timeout` — not the same thing, and don't add it.** It is a *local*
 wait. From `cli/arguments.py`: *"Max seconds to wait locally for completion. When
@@ -974,6 +1009,25 @@ the wrong path" are indistinguishable from the outside:
 sqlite3 session.sqlite "SELECT output FROM exec WHERE command LIKE '%uname%'"
 sqlite3 session.sqlite "SELECT exitCode, stdErr FROM exec WHERE command LIKE '%validate-%'"
 ```
+
+**It also settles `config/container.yaml`, which is otherwise asserted rather than
+measured.** That file records what the container has in three states (`present`,
+`absent`, `unavailable`), and 14 of its 15 rows are marked `evidence: asserted` — copied
+from documentation, never observed. The fingerprint now sweeps the same binaries:
+
+```
+for b in node npm python3 pip3 func go dotnet docker azd java; do
+  printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"
+done
+```
+
+so **the next run anybody submits, for any reason, is also a measurement of the
+inventory** — at no extra cost, no extra assertion, and no risk of failing the run. The
+sweep was already in the generated stack stimuli; the hand-written ones carried three
+older variants that only listed directories, which meant the measurement depended on
+which kind of stimulus happened to run. The sweep is now identical in all of them and
+only the trailing directory listing varies, because which directories matter genuinely is
+per-stimulus.
 
 
 ## The second extension: the debug probe
@@ -2010,8 +2064,8 @@ on disk for the other.
 ## Running in CI
 
 [`.github/workflows/msbench-evals.yml`](../../.github/workflows/msbench-evals.yml) runs
-this on `ubuntu-latest`. It is **`workflow_dispatch` only**, because it cannot run yet
-without one-time setup.
+this on `ubuntu-latest`. It is **`workflow_dispatch` only**, and stays that way even now
+that the identity work is done — see below for what actually still gates it.
 
 The Vally CI path needed no secrets — `copilot-requests: write` lets the built-in
 `GITHUB_TOKEN` authenticate the Copilot CLI. That trick does not transfer. MSBench runs
@@ -2025,9 +2079,32 @@ on CES, which identifies callers by Entra client id, so CI needs a real Azure id
    [Submitting MSBench runs from GitHub Actions](https://dev.azure.com/devdiv/OnlineServices/_git/msbench?path=/wiki/Submitting-MSBench-runs-from-GitHub-Actions.md).
    This step is not self-service.
 
-Step 3 is the reason the workflow is manual-only and unscheduled: until the identity is
-allowlisted a scheduled run would only ever be red. Local runs need none of this —
-`az login` plus the `MSBench User` role is enough, which is why that path landed first.
+**Step 3 is done — the Entra-side permissions have been granted.** Step 2 is not: the
+three repository secrets still have to be set before a dispatch can authenticate, and
+until they are, the `Azure login` step fails before `run.sh` is reached. That is a
+different failure from the one this section used to describe, and it fails in a
+different place, so read the failing *step* rather than assuming the allowlist.
+
+**It stays manual, and not only because of setup.** Every dispatch submits a real run and
+spends real tokens, so a schedule or a PR trigger would spend on every push. Local runs
+need none of the above — `az login` plus the `MSBench User` role is enough, which is why
+that path landed first.
+
+### The first CI run should be one whose answer we already know
+
+`workflow_dispatch` takes a `stimulus` input, defaulting to **`scaffold-unapproved-plan`**
+rather than to `run.sh`'s own default of `photo-app-requirements`.
+
+That is deliberate, and it is about what a red result would *mean*. The first dispatches
+are testing the pipeline — federated auth, the feed token, VSIX staging, grader staging,
+config generation, submission, artifact upload — not the product. `scaffold-unapproved-plan`
+is the cheapest merged stimulus (a refusal that ends after two tool calls) **and** its
+answer is already established locally at 6/6 green. So a red is unambiguous: CI is
+broken. Against an unknown-answer stimulus a red cannot distinguish "CI is misconfigured"
+from "the product changed", which is the one distinction the exercise exists to make.
+
+Pass any other stimulus once the pipeline is proven. `STIMULUS` is read from the
+environment by `run.sh` exactly as `BENCHMARK` is, so `--stimulus` still wins locally.
 
 ## Troubleshooting
 
@@ -2041,8 +2118,7 @@ with a clear message:
   several PRs. `git checkout -- evals/results/` before committing.
 
 - **A `400 BadRequest` from CES at submission time is probably transient — retry before
-  changing anything.** Seen once in five back-to-back submissions, on a run submitted
-  within a second of the previous one completing:
+  changing anything.** Seen twice, from `/api/ces/benchmark/startRun`:
 
   ```
   requests.exceptions.HTTPError: 400 Client Error: Bad Request for url:
@@ -2050,11 +2126,28 @@ with a clear message:
   Response body: 400.0 BadRequest
   ```
 
-  The next submission, 13 seconds later with a byte-identical config, succeeded. No
-  tokens are spent and no run is created, so the only cost is the confusion. The trap is
-  that `400` reads as *"your config is malformed"*, which invites editing a config that
-  was fine — and the edit then gets credited with the fix when the retry was what worked.
-  Leave a few seconds between submissions and retry once before believing it.
+  No run id is allocated and no tokens are spent, so the only cost is the confusion. The
+  trap is that `400` reads as *"your config is malformed"*, which invites editing a config
+  that was fine — and the edit then gets credited with the fix when the retry was what
+  worked. **Retry once with the same config before changing anything.**
+
+  **The two observations do not fit a cooldown, and that is the useful part.** Both are
+  recorded here rather than averaged into a single waiting time, because together they
+  rule out the explanation each one separately suggests:
+
+  | | Gap after the previous run finished | Result |
+  | --- | --- | --- |
+  | A | ~1s | `400` |
+  | A, retried | ~14s | **succeeded** |
+  | B | ~90s | `400` |
+  | B, retried | a few minutes | **succeeded** |
+
+  A fixed minimum gap between submissions cannot make 14s succeed *and* 90s fail. So
+  "wait N seconds" is not the remedy, and any specific N here would be invented rather
+  than measured — what is actually established is only that **resubmitting an unchanged
+  config works**. Whether the trigger is concurrency, a server-side transient, or
+  something else is unknown; n=2, and neither observation was instrumented beyond the
+  timings above. Do not derive a cooldown from this entry.
 
 - **A red run that is actually rate limiting.** Back-to-back runs get throttled by the
   Copilot API mid-run. The agent then produces nothing, so artifact assertions fail
@@ -2100,11 +2193,6 @@ with a clear message:
   because it explained anything: the artifact scare that prompted the enumeration turned
   out to be a read that predated the run's completion by about five minutes, and member
   order was not the cause. Noted here so nobody re-derives it as one.
-- **`HTTP 400 BadRequest` from `/api/ces/benchmark/startRun` at submit time.** Seen
-  submitting ~90s after a previous run finished; no run id is allocated. The same
-  config submitted cleanly after a cooldown, so treat it as transient submission
-  throttling rather than a config error — wait a few minutes and resubmit before
-  debugging the YAML.
 - **`msbench-cli` silently installs an ancient version.** pip's 15s default read
   timeout treats a slow feed download as an *unusable candidate* rather than a network
   error, so it backtracks through older releases and reports success — once landing

--- a/evals/msbench/assertionIdentity.ts
+++ b/evals/msbench/assertionIdentity.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * The canonical text of the assertion comments that more than one stimulus shares.
+ *
+ * This module exists because the previous arrangement — a literal in
+ * `check-stimulus-comments.ts` and a second copy in `build-config.ts` — was
+ * itself an instance of the failure the checker exists to prevent.
+ *
+ * `comment` is the only stable identifier a SQL assertion carries into stored run
+ * results; there is no grader filename to fall back on the way an `exec:`
+ * assertion has. So rewording one does not annotate a gate, it forks that gate
+ * into a second identity with no history, silently, while the original appears to
+ * stop being evaluated. The checker was written to make that impossible.
+ *
+ * It could not see `build-config.ts`, which *generates* stack stimuli and carried
+ * its own copy of the sentinel string. That copy had already drifted to the
+ * pre-canonicalisation wording, so every generated stack stimulus was forking the
+ * sentinel gate — in the one code path that creates new stimuli, guarded by a
+ * checker that only read the hand-written ones.
+ *
+ * Hence a single exported constant rather than a rule that the two literals be
+ * kept equal. A rule needs enforcing; a shared import cannot drift.
+ */
+
+/**
+ * The liveness sentinel, pinned.
+ *
+ * Turn attribution is deliberately NOT encoded, even though the multi-turn
+ * stimuli carry one per turn and the earlier wordings named the turn. The
+ * `assertions` table stores a `stepIndex` column alongside the comment, so which
+ * turn a sentinel belongs to is already recorded and recoverable. Encoding it
+ * here as well would fork the gate into one history per turn index — precisely
+ * the failure this constant exists to prevent.
+ *
+ * "this turn" rather than "session data must exist" because the implied
+ * `stepIndex` filter means a sentinel only ever sees its own turn. The
+ * session-scoped phrasing was the more common of the two variants and was wrong
+ * in six of the thirteen places it appeared.
+ */
+export const SENTINEL_COMMENT = 'Sentinel; this turn must have produced a response or its checks are vacuous';
+
+/** Recognises a sentinel by what it *does*, so a paraphrased comment cannot hide one. */
+export const SENTINEL_QUERY = /^SELECT\s+COUNT\(\*\)\s*>\s*0\s+FROM\s+llm_responses$/i;
+
+/**
+ * A whole-conversation constraint is duplicated once per turn precisely so the
+ * failing assertion names the turn that misbehaved, so `(turn N)` is meaningful
+ * rather than noise. It is stripped before comparison: an identity scheme can
+ * strip a fixed trailing pattern, where it cannot un-paraphrase free text.
+ */
+export const TURN_SUFFIX = / \(turn \d+\)$/;
+
+/**
+ * The non-asserting environment fingerprint every stimulus carries last.
+ *
+ * Shared between the hand-written stimuli and the generated ones, so it belongs
+ * here for the same reason the sentinel does. The *command* deliberately varies —
+ * each stimulus lists the directories that matter to it — but the comment is the
+ * label a reader greps for when a grader goes red, and one label is worth more
+ * than an accurate-per-stimulus one.
+ */
+export const FINGERPRINT_COMMENT = 'Environment fingerprint for triage';
+
+/**
+ * The paired `test -f` that accompanies every `files`-table assertion.
+ *
+ * `files` holds what the *agent* wrote through the tracked channel during a step,
+ * so a file written by an extension, a `script:` preamble or the container is
+ * invisible to it however plainly it exists on disk. This records the disk answer
+ * next to the table answer: present-on-disk-but-absent-from-`files` is the
+ * wrong-channel signature, and it is the difference between a ten-minute forensic
+ * pass and reading one row.
+ */
+export const DISK_TRIAGE_COMMENT = 'Triage; is the file on disk at all?';

--- a/evals/msbench/build-config.ts
+++ b/evals/msbench/build-config.ts
@@ -47,6 +47,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { DISK_TRIAGE_COMMENT, FINGERPRINT_COMMENT, SENTINEL_COMMENT } from './assertionIdentity.ts';
 import type { PhaseWiring } from '../src/gateWiring.ts';
 import type { Stack } from '../src/stack.ts';
 import { seedFor, seedPaths } from './stage-workspace.ts';
@@ -250,7 +251,7 @@ function renderStimulus(stack: Stack, wiring: PhaseWiring): string {
         '    assertions:',
         '      # Liveness sentinel — must come first. Without it the negative assertions',
         '      # below pass trivially against an empty table.',
-        '      - comment: Sentinel; session data must exist or the negative checks below are vacuous',
+        `      - comment: ${SENTINEL_COMMENT}`,
         "        query: SELECT COUNT(*) > 0 FROM llm_responses",
         '',
     ];
@@ -271,7 +272,7 @@ function renderStimulus(stack: Stack, wiring: PhaseWiring): string {
     // turns the next run anybody submits — for any reason — into a measurement
     // of it, at no extra cost.
     lines.push('      # Recorded, not asserted: the container inventory config/container.yaml claims.');
-    lines.push('      - comment: Environment fingerprint for triage');
+    lines.push(`      - comment: ${FINGERPRINT_COMMENT}`);
     lines.push("        exec: 'uname -sm; echo \"cwd=$(pwd)\"; for b in node npm python3 pip3 func go dotnet docker azd java; do printf \"%s=%s\\n\" \"$b\" \"$(command -v $b || echo MISSING)\"; done; python3 -m ensurepip --version 2>&1 | head -1'");
     lines.push('        assertZeroExitCode: false');
 
@@ -564,7 +565,7 @@ function assertFilesAssertionsArePaired(merged: string, stimulus: string): void 
             `The 'files' table holds what the AGENT wrote through the tracked channel, not what\n` +
             `is on disk, and whether a given path can ever appear there is not decidable from\n` +
             `this config. So each such assertion must carry its own discriminator:\n\n` +
-            `      - comment: Triage; is the file on disk at all?\n` +
+            `      - comment: ${DISK_TRIAGE_COMMENT}\n` +
             `        exec: 'test -f <path>; echo "exit=$?"'\n` +
             `        assertZeroExitCode: false\n\n` +
             `Present on disk but absent from 'files' is the wrong-channel signature. With the\n` +

--- a/evals/msbench/check-stimulus-comments.ts
+++ b/evals/msbench/check-stimulus-comments.ts
@@ -47,35 +47,11 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parse } from 'yaml';
+import { SENTINEL_COMMENT, SENTINEL_QUERY, TURN_SUFFIX } from './assertionIdentity.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const STIMULI = join(HERE, 'config', 'stimuli');
-
-/**
- * The liveness sentinel, pinned.
- *
- * Turn attribution is deliberately NOT encoded, even though the multi-turn
- * stimuli carry one per turn and the earlier wordings named the turn. The
- * `assertions` table stores a `stepIndex` column alongside the comment, so which
- * turn a sentinel belongs to is already recorded and recoverable. Encoding it
- * here as well would fork the gate into one history per turn index — precisely
- * the failure this file exists to prevent.
- *
- * "this turn" rather than "session data must exist" because the implied
- * `stepIndex` filter means a sentinel only ever sees its own turn. The
- * session-scoped phrasing was the more common of the two variants and was wrong
- * in six of the thirteen places it appeared.
- */
-const SENTINEL_QUERY = /^SELECT\s+COUNT\(\*\)\s*>\s*0\s+FROM\s+llm_responses$/i;
-const SENTINEL_COMMENT = 'Sentinel; this turn must have produced a response or its checks are vacuous';
-
-/**
- * A whole-conversation constraint is duplicated once per turn precisely so the
- * failing assertion names the turn that misbehaved, so `(turn N)` is meaningful
- * rather than noise. It is stripped before comparison: an identity scheme can
- * strip a fixed trailing pattern, where it cannot un-paraphrase free text.
- */
-const TURN_SUFFIX = / \(turn \d+\)$/;
+const STACKS = join(HERE, 'config', 'stacks');
 
 interface Assertion {
     comment?: string;
@@ -101,8 +77,41 @@ function normalise(text: string): string {
     return text.trim().replace(/\s+/g, ' ').toLowerCase();
 }
 
+/**
+ * The generated stimuli cannot be parsed the way the hand-written ones are.
+ *
+ * `build-config.ts` writes its output to `assets/user-overrides.yaml`, which is
+ * shared mutable state that `run.sh` holds a lock on for the duration of a run.
+ * A checker that invoked the generator to inspect its output would clobber the
+ * config of an in-flight submission — trading a drift bug for a
+ * grades-the-wrong-prompt bug, which is strictly worse.
+ *
+ * So the generator is checked at the source level instead: no assertion comment
+ * may be a bare string literal there. Every one must come from
+ * `assertionIdentity.ts` or from `config/gates.yaml`, both of which are shared
+ * with the hand-written path. That is weaker than parsing real output — it
+ * cannot tell whether a `gates.yaml` summary collides with a hand-written
+ * comment — but it closes the hole that actually occurred: a second copy of a
+ * canonical string, drifting silently, in the one path that creates stimuli.
+ */
+function checkGeneratorSource(failures: string[]): number {
+    const source = readFileSync(join(HERE, 'build-config.ts'), 'utf8');
+    const literals = [...source.matchAll(/- comment: (?!\$\{)([^`'"\n]+)/g)];
+
+    for (const [, text] of literals) {
+        failures.push(
+            `build-config.ts\n` +
+            `  gate     generated stimulus assertion\n` +
+            `  found    hardcoded comment literal: ${text.trim()}\n` +
+            `  fix      import the canonical string from assertionIdentity.ts instead`
+        );
+    }
+    return literals.length;
+}
+
 function main(): void {
     const files = readdirSync(STIMULI).filter(name => name.endsWith('.yaml')).sort();
+    const stacks = readdirSync(STACKS).filter(name => name.endsWith('.yaml'));
 
     /** normalised query/exec -> every comment seen for it. */
     const gates = new Map<string, Occurrence[]>();
@@ -141,6 +150,8 @@ function main(): void {
         }
     }
 
+    checkGeneratorSource(failures);
+
     if (failures.length) {
         console.error(
             `${failures.length} gate identity problem(s).\n\n` +
@@ -157,7 +168,9 @@ function main(): void {
     const shared = [...gates.values()].filter(occurrences => occurrences.length > 1).length;
     console.log(
         `✔ gate identity consistent: ${gates.size} distinct assertions across ${files.length} stimuli, ` +
-        `${shared} of them shared by more than one stimulus.`
+        `${shared} of them shared by more than one stimulus.\n` +
+        `✔ build-config.ts hardcodes no assertion comment, so the ${stacks.length} generated ` +
+        `stack stimuli cannot fork a gate the hand-written ones share.`
     );
 }
 

--- a/evals/msbench/config/base.yaml
+++ b/evals/msbench/config/base.yaml
@@ -65,15 +65,25 @@ timeouts:
   # completed before initialized, so `initialized` there is a re-download, not a
   # run start).
   #
-  #   min 147.9s   median 181.0s   max 896.6s
+  #   one extension   n=17   min 147.9s   median 171.1s   max 233.2s
+  #   two extensions  n=6    min 182.5s   median 195.5s   max 896.6s
   #
-  # 30m is 2.0x the observed max, and that headroom is bought deliberately rather
-  # than out of caution: the 896.6s outlier is `debug-probe-smoke`, the one run
-  # that installs a SECOND extension. One extra extension took setup from ~181s
-  # to ~897s. So setup is not a constant, it grows with what we install, and a
-  # third extension of similar cost lands near 1600s. A 15m allowance would have
-  # covered the observed max with 1.00x headroom — i.e. none — and would be
-  # exceeded by the next extension anyone adds.
+  # Two extensions is the current configuration: since #1720, base.yaml installs
+  # the debug probe alongside the product VSIX on every run. It costs about
+  # +24s on the median — NOT the +715s a first reading of the maximum suggests.
+  #
+  # 30m is 2.0x the observed max, and the reason is that maximum rather than any
+  # growth trend. `debug-probe-smoke` (2026082620311350) took 896.6s, 4.6x the
+  # two-extension median, and the cause is UNKNOWN. It is not the second
+  # extension: the five later two-extension runs took 182-216s. It is not a cold
+  # image pull: the full runlog shows both it and its successor pulling every
+  # layer. It was the first probe run, which is suggestive of a one-off, but that
+  # is a correlation with n=1 and not an explanation.
+  #
+  # An unexplained 4.6x excursion is a better argument for headroom than a known
+  # cost would be, because a known cost can be budgeted and an unpredictable one
+  # can only be absorbed. Sizing to the median would have been beaten by an
+  # already-observed run.
   #
   # Erring LOW here is the safe direction and that is why the headroom is
   # generous. Too low: the agent timeout fires, grace runs, artifacts flush, the

--- a/evals/msbench/config/base.yaml
+++ b/evals/msbench/config/base.yaml
@@ -50,24 +50,41 @@ timeouts:
   # first, the agent timeout never fires, runnerGraceSeconds never runs, and
   # nothing is flushed on exactly the runs that need diagnosing:
   #
-  #   7200s runner cap - ~15m setup - 15m grace => 5400s agent
+  #   7200s runner cap - 30m setup allowance - 15m grace => 4500s agent
   #
-  # The 7200s cap is MEASURED, not assumed. Every instance runlog prints
-  # `Using timeout of 7200 seconds` before the agent starts, and that value is
-  # identical in all 30 cached runs — across three days, four models
-  # (claude-sonnet-4.5, gpt-5, gpt-4.1, gpt-5.6) and multi-instance dispatches.
-  # Identical values across different payloads is what rules out its being set
-  # per dispatch, which was the open question that kept this at 18000.
+  # BOTH terms are measured, which is the difference from the value this replaces.
+  #
+  # The 7200s cap: every instance runlog prints `Using timeout of 7200 seconds`
+  # before the agent starts, identical in all 30 cached runs — across three days,
+  # four models (claude-sonnet-4.5, gpt-5, gpt-4.1, gpt-5.6) and multi-instance
+  # dispatches. Identical values across different payloads is what rules out its
+  # being set per dispatch.
+  #
+  # The setup allowance: measured as `timestamps.initialized` to the first agent
+  # step, over 23 usable cached runs (2 excluded — their own metadata reports
+  # completed before initialized, so `initialized` there is a re-download, not a
+  # run start).
+  #
+  #   min 147.9s   median 181.0s   max 896.6s
+  #
+  # 30m is 2.0x the observed max, and that headroom is bought deliberately rather
+  # than out of caution: the 896.6s outlier is `debug-probe-smoke`, the one run
+  # that installs a SECOND extension. One extra extension took setup from ~181s
+  # to ~897s. So setup is not a constant, it grows with what we install, and a
+  # third extension of similar cost lands near 1600s. A 15m allowance would have
+  # covered the observed max with 1.00x headroom — i.e. none — and would be
+  # exceeded by the next extension anyone adds.
+  #
+  # Erring LOW here is the safe direction and that is why the headroom is
+  # generous. Too low: the agent timeout fires, grace runs, artifacts flush, the
+  # run is diagnosable. Too high: the job is killed first and nothing is flushed
+  # at all. Those are not symmetric.
   #
   # This previously read 18000 (5h), derived from an *assumed* 6h GitHub-hosted
-  # runner cap. That was 2.5x the real budget, which is precisely the failure the
-  # paragraph above warns about — so the config documented the hazard while
-  # embodying it. See README.md, "Timeouts".
-  #
-  # NOTE: this leaves no margin (5400 + 900 grace + 900 setup = 7200 exactly),
-  # where the old 6h derivation kept 30m back. Nothing has come close — the
-  # longest run to date is 49m — but the first run that does will find the edge.
-  agentSeconds: 5400 # 90m
+  # runner cap — 4x the real budget. The first version of this fix read 5400,
+  # derived from the measured cap but an *assumed* 15m setup, which left exactly
+  # zero margin. See README.md, "Timeouts".
+  agentSeconds: 4500 # 75m
   # The trap. This is not agent inactivity — it fires only when the agent trace,
   # the CAPI proxy log, the Copilot Chat log AND workspace file activity are all
   # quiet. `npm install`, `azd provision`, a build or a test suite produce none

--- a/evals/msbench/config/base.yaml
+++ b/evals/msbench/config/base.yaml
@@ -40,7 +40,8 @@ modelSelector:
 # purely local wait — see README.md, "Timeouts". Do not add that flag.
 timeouts:
   # describe -> requirements -> plan -> scaffold -> build -> run -> debug, all in
-  # ONE chat session. 1h45m is a per-turn budget, not a budget for the chain.
+  # ONE chat session. The schema default of 6300 is a per-turn budget, not a
+  # budget for the chain.
   #
   # Budget, NOT an independent knob. The agent clock starts *after* the job clock
   # (container pull, VS Code + VSIX install, workspace setup, the `script:`
@@ -49,21 +50,44 @@ timeouts:
   # first, the agent timeout never fires, runnerGraceSeconds never runs, and
   # nothing is flushed on exactly the runs that need diagnosing:
   #
-  #   6h job cap - ~15m setup - 15m grace => 5h agent, with margin
+  #   7200s runner cap - ~15m setup - 15m grace => 5400s agent
   #
-  # Re-derive this if the cap is ever confirmed. GitHub documents a 6h cap for
-  # hosted runners and 5 days for self-hosted; runs report `dispatched to GitHub
-  # Actions` with run_platform='linux_container', but we could NOT verify which
-  # pool MSBench uses — that is decided by a server-side workflow we cannot read.
-  # 6h is assumed because it is the safer of the two. Raising it needs
-  # confirmation from CodeExService@microsoft.com.
-  agentSeconds: 18000 # 5h
+  # The 7200s cap is MEASURED, not assumed. Every instance runlog prints
+  # `Using timeout of 7200 seconds` before the agent starts, and that value is
+  # identical in all 30 cached runs — across three days, four models
+  # (claude-sonnet-4.5, gpt-5, gpt-4.1, gpt-5.6) and multi-instance dispatches.
+  # Identical values across different payloads is what rules out its being set
+  # per dispatch, which was the open question that kept this at 18000.
+  #
+  # This previously read 18000 (5h), derived from an *assumed* 6h GitHub-hosted
+  # runner cap. That was 2.5x the real budget, which is precisely the failure the
+  # paragraph above warns about — so the config documented the hazard while
+  # embodying it. See README.md, "Timeouts".
+  #
+  # NOTE: this leaves no margin (5400 + 900 grace + 900 setup = 7200 exactly),
+  # where the old 6h derivation kept 30m back. Nothing has come close — the
+  # longest run to date is 49m — but the first run that does will find the edge.
+  agentSeconds: 5400 # 90m
   # The trap. This is not agent inactivity — it fires only when the agent trace,
   # the CAPI proxy log, the Copilot Chat log AND workspace file activity are all
   # quiet. `npm install`, `azd provision`, a build or a test suite produce none
   # of those four for minutes at a time, so a perfectly healthy run gets killed
   # for looking idle. Quiet is not the same as stuck.
-  stallSeconds: 5400 # 90m
+  #
+  # 2700 is the schema default, chosen rather than derived — but it is not
+  # unexamined. The longest gap between agent steps in any successful cached run
+  # is 211.8s (`2026082614813342`); `scaffold-fullstack`, which runs a real
+  # `npm install` and build, peaks at 82.4s. Those gaps are an UPPER bound on
+  # all-four-quiet, since file activity continues during a step gap, so 2700
+  # sits at least 12.7x above anything observed.
+  #
+  # It must also stay strictly below agentSeconds. At the previous 5400 it would
+  # have equalled it, and a stall could never have fired before the agent budget
+  # expired — an inert timeout that reads as protection.
+  #
+  # Revisit when the deploy gate lands: `azd provision` is the one step plausibly
+  # quiet for tens of minutes, and it has never been measured here.
+  stallSeconds: 2700 # 45m
   # Time the outer runner allows for cleanup after the agent timeout. A long
   # session has far more to flush than a 5-step one (screen recording,
   # trajectory, session.sqlite), and a truncated artifact is an unreadable

--- a/evals/msbench/config/stimuli/api-only-inventory.yaml
+++ b/evals/msbench/config/stimuli/api-only-inventory.yaml
@@ -61,5 +61,5 @@ promptSteps:
 
       # Recorded, not asserted. See config/stimuli/photo-app-requirements.yaml.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/debug-generate-artifacts.yaml
+++ b/evals/msbench/config/stimuli/debug-generate-artifacts.yaml
@@ -164,5 +164,5 @@ promptSteps:
       # Recorded, not asserted. On the last step, where the `exec:` graders run.
       # See config/stimuli/photo-app-requirements.yaml.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls -la . .azure .vscode 2>&1 | head -40'
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls -la . .azure .vscode 2>&1 | head -40'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/debug-plan-approval-gate.yaml
+++ b/evals/msbench/config/stimuli/debug-plan-approval-gate.yaml
@@ -153,5 +153,5 @@ promptSteps:
       # Recorded, not asserted. On the last step, where the `exec:` graders run.
       # See config/stimuli/photo-app-requirements.yaml.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls -la . .azure .vscode 2>&1 | head -40'
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls -la . .azure .vscode 2>&1 | head -40'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/multi-service-order-processing.yaml
+++ b/evals/msbench/config/stimuli/multi-service-order-processing.yaml
@@ -56,5 +56,5 @@ promptSteps:
 
       # Recorded, not asserted. See config/stimuli/photo-app-requirements.yaml.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/no-datastore-converter.yaml
+++ b/evals/msbench/config/stimuli/no-datastore-converter.yaml
@@ -54,5 +54,5 @@ promptSteps:
 
       # Recorded, not asserted. See config/stimuli/photo-app-requirements.yaml.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/photo-app-requirements.yaml
+++ b/evals/msbench/config/stimuli/photo-app-requirements.yaml
@@ -88,5 +88,5 @@ promptSteps:
       # above goes red: no Node, Node too old to strip types, and a mis-staged tree
       # are indistinguishable from the outside. See README.md.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/plan-generation-task-app.yaml
+++ b/evals/msbench/config/stimuli/plan-generation-task-app.yaml
@@ -165,5 +165,5 @@ promptSteps:
       # Recorded, not asserted. See config/stimuli/photo-app-requirements.yaml.
       # On the last step, where the `exec:` graders above run.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/scaffold-autopilot.yaml
+++ b/evals/msbench/config/stimuli/scaffold-autopilot.yaml
@@ -106,5 +106,5 @@ promptSteps:
 
       # Recorded, not asserted. See config/stimuli/scaffold-fullstack.yaml.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls -la . .azure 2>&1 | head -40'
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls -la . .azure 2>&1 | head -40'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/scaffold-fullstack.yaml
+++ b/evals/msbench/config/stimuli/scaffold-fullstack.yaml
@@ -150,5 +150,5 @@ promptSteps:
       # precondition proves the plan was there at the start, this shows what the
       # workspace looked like at the end.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls -la . .azure 2>&1 | head -40'
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls -la . .azure 2>&1 | head -40'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/scaffold-missing-plan.yaml
+++ b/evals/msbench/config/stimuli/scaffold-missing-plan.yaml
@@ -126,5 +126,5 @@ promptSteps:
       # `.azure/project-plan.md` appears here, assets/workspace/ was not cleared
       # and the run graded the wrong premise.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls -la . .azure 2>&1 | head -40'
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls -la . .azure 2>&1 | head -40'
         assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/scaffold-unapproved-plan.yaml
+++ b/evals/msbench/config/stimuli/scaffold-unapproved-plan.yaml
@@ -122,5 +122,5 @@ promptSteps:
       # names the files it found, and this listing shows the workspace they came
       # from — which is how a seeding bug is told apart from a gate bypass.
       - comment: Environment fingerprint for triage
-        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; ls -la . .azure 2>&1 | head -40'
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls -la . .azure 2>&1 | head -40'
         assertZeroExitCode: false

--- a/evals/msbench/run.sh
+++ b/evals/msbench/run.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 
 SKIP_BUILD=0
 BUILD_ONLY=0
-STIMULUS="photo-app-requirements"
+STIMULUS="${STIMULUS:-photo-app-requirements}"
 STACK=""
 PHASE=""
 PASSTHRU=()


### PR DESCRIPTION
Five corrections where the MSBench docs or config disagreed with themselves, plus the first CI dispatch made interpretable.

## 1. The `400 BadRequest` entry was in the README twice, saying different things

Two entries in the same Troubleshooting list, one phenomenon:

| | Gap after previous run | Remedy it gave |
| --- | --- | --- |
| line 2043 | ~1s | "leave a few seconds, retry once" |
| line 2103 | ~90s | "wait a few minutes" |

Merged, keeping **both** observations rather than averaging them. Together they say something neither says alone — **the cooldown model is wrong**:

```
A   ~1s after previous finished     400
A   retried ~14s after              succeeded
B   ~90s after previous finished    400
B   retried after a few minutes     succeeded
```

No fixed minimum gap makes 14s pass *and* 90s fail. So "wait N seconds" isn't the remedy, and any specific N would be invented. What's actually established is only that **resubmitting an unchanged config works**. Written that way so nobody tunes a cooldown that isn't the mechanism. n=2.

## 2. A prediction the first scaffold run disproved

The sub-agent undercount box said *"scaffold is expected to use more of them, not fewer."*

`scaffold-fullstack` (`2026082620153444`) produced **exactly one** trajectory and made **no** `runSubagent` calls — 39 steps, 88 tool calls, all in the main trajectory. It delegated *less* than the planning run did.

Retracted in place, not deleted. The surrounding point survives and is strengthened: **you can't tell from the report whether delegation happened**, which is why summing the trajectory files is the rule rather than a precaution for phases believed to delegate.

## 3. `agentSeconds` was 4× the real runner budget — and the setup term was measured too

Every instance runlog prints, before the agent starts:

```
Using timeout of 7200 seconds
```

The README recorded this but left the config alone on two grounds: it was one observation, and the line didn't say whether 7200s is fixed per instance or set per dispatch.

**Both are now answered.** The value is identical in **all 30 cached runs** — three days, four models (`claude-sonnet-4.5`, `gpt-5`, `gpt-4.1`, `gpt-5.6`), several benchmarks, multi-instance dispatches. One run couldn't rule out a per-dispatch setting; thirty with varying payloads can.

### Both terms are measured, which took two passes to get right

A first attempt used the measured cap with an **assumed ~15m setup** and produced `5400`. That replaced an assumption-derived number with another assumption-derived number and called the result "measured" — the claim-stronger-than-the-evidence shape this suite exists to catch. It also left **exactly zero margin**: 5400 + 900 grace + 900 setup = 7200 on the nose.

So setup is now measured as `timestamps.initialized` → first agent step, over 23 usable cached runs (2 excluded: their own metadata reports `completed` *before* `initialized`, so `initialized` there is a re-download, not a run start).

| | n | min | median | max |
| --- | --- | --- | --- | --- |
| one extension | 17 | 147.9s | 171.1s | 233.2s |
| **two extensions** (current) | 6 | 182.5s | **195.5s** | **896.6s** |
| agent time (all) | 23 | 45.1s | 107.0s | 2826.1s |

Two extensions is the current configuration — since #1720, `base.yaml` installs the debug probe alongside the product VSIX on **every** run.

The ~15m assumption was almost exactly right — **and that's the trap.** It matched the observed max at **1.00× headroom**, i.e. none.

**The 896.6s maximum is unexplained, and I got its cause wrong first time.** I attributed it to the second extension, because the slowest run was `debug-probe-smoke` and that was the salient difference. Splitting the same 23 runs by whether the probe was actually installed refutes it: the second extension costs about **+24s** on the median, and the five later two-extension runs took 182–216s. A cold image pull is ruled out too — the full runlog shows that run *and* its successor pulling every layer.

That error is worth naming, because it's the one this suite keeps catching in other people's work: **the number was right and the reason was invented**, which reads identically from the outside and would have sent the next person hunting a growth trend that doesn't exist.

An unexplained 4.6× excursion is a **better** argument for headroom than a known cost: a known cost can be budgeted, an unpredictable one can only be absorbed. Sizing to the median would have been beaten by a run already in the corpus.

```
7200s cap − 30m setup allowance − 15m grace ⇒ 4500s agent
```

30m is 2.0× the observed max, sized against the growth vector rather than the current maximum.

**Erring low is the safe direction, which is why the headroom is generous rather than tight.** Too low: the agent timeout fires, `runnerGraceSeconds` runs, artifacts flush, the run is diagnosable. Too high: the job is killed first and *nothing* is flushed — on exactly the runs that most need diagnosing. Not symmetric, so the budget is sized against the bad direction. 4500s is still **1.6× the longest agent time ever observed**.

### `stallSeconds` had to move too, and that's the part worth reading

It was **also 5400** — at or above `agentSeconds`, so a stall could never fire before the agent budget expired. **A timeout that cannot fire, reading as protection.** Same shape as a gate that cannot fail, which this suite has now found in four other places.

It's now **2700**, the schema default — **taken, not derived**, and labelled as such, because no arithmetic here yields a stall threshold and inventing one would be worse than saying so.

It isn't unexamined. Longest quiet stretch in successful cached runs:

| Run | Longest gap between agent steps |
| --- | --- |
| `2026082614813342` (2-turn plan) | **211.8s** |
| `2026082620153444` (real `npm install` + build) | 82.4s |
| refusal runs | 5–13s |

Those gaps *bound* all-four-quiet from above (file activity continues within a step gap), so 2700 sits **≥12.7× above anything measured**. **`azd provision` has never been measured** — it's the one step plausibly quiet for tens of minutes, so revisit when the deploy gate lands rather than reading a mystery kill as a product failure.

## 4. The canonicalisation mechanism was forking the gate it exists to unify

`check-stimulus-comments.ts` pins the sentinel's comment because a SQL assertion has no grader filename — `comment` is its only stable identifier in stored results, so rewording one forks the gate into a second identity with no history.

It reads `config/stimuli/*.yaml` **and nothing else**. `build-config.ts` *generates* stack stimuli and held its own copy — already drifted:

```
generator   Sentinel; session data must exist or the negative checks below are vacuous
canonical   Sentinel; this turn must have produced a response or its checks are vacuous
```

So every generated stack stimulus was forking the sentinel gate, **in the one code path that creates new stimuli, guarded by a checker that couldn't see it.** The fix for a class of bug contained an instance of that class.

Canonical strings now live in `assertionIdentity.ts`, imported by both. *A rule that two literals be kept equal needs enforcing; a shared import cannot drift.*

**Widening the checker matters more than fixing the literal** — fixing one copy while the checker stays blind to the generating path leaves the same hole one commit later. It now rejects any bare comment literal in `build-config.ts`.

That's a **source lint, not a parse of real generated output**, deliberately: `build-config.ts` writes to `assets/user-overrides.yaml`, shared mutable state that `run.sh` locks during a run, so invoking the generator could clobber an in-flight submission — trading a drift bug for a grades-the-wrong-prompt bug. It can't tell whether a `gates.yaml` summary collides with a hand-written comment; it does close the hole that occurred.

**The lint found two more copies on its first run**, both real: the environment fingerprint comment and the `files`-table disk-triage comment. Verified it fires — reintroducing a literal exits 1 and names it.

## 5. Container inventory was asserted, not measured

`config/container.yaml` has **14 of 15 rows marked `evidence: asserted`** — copied from docs, never observed — and those rows decide real gate wiring.

The *generated* stimuli already swept the binaries. The **13 hand-written ones** carried three older variants that only listed directories — so whether a run measured the inventory depended on which kind of stimulus ran, and the hand-written ones are what actually gets submitted.

All of them now carry the sweep, so **the next run anybody submits, for any reason, is also a measurement** — no extra assertion, no tally change, `assertZeroExitCode: false` means it can't fail a run.

The three variants collapse only in their *shared* part; the trailing directory listing still varies, because which directories matter genuinely is per-stimulus.

## Part 2 — the first CI dispatch

`workflow_dispatch` now takes a `stimulus` input, defaulting to **`scaffold-unapproved-plan`** instead of run.sh's `photo-app-requirements`.

The first dispatches test the *pipeline* — federated auth, feed token, VSIX staging, grader staging, config generation, submission, artifact upload. None of that is a question about the product. `scaffold-unapproved-plan` is the cheapest merged stimulus **and** its answer is already known locally at 6/6 green, so **a red is unambiguous: CI is broken.** Against an unknown-answer stimulus, a red can't separate "CI is misconfigured" from "the product changed" — the one distinction the exercise exists to make. Cheapness is the lesser reason.

`STIMULUS` is read from the environment exactly as `BENCHMARK` already is, so there's one mechanism for both and `--stimulus` still wins locally.

**Also corrected "Running in CI"**, which said the workflow is manual-only because the client id isn't allowlisted. The Entra permissions have since been granted; what still blocks a dispatch is the three repository secrets, which fail in a **different step with a different error**. Left as-is, the docs would have sent the first failure to the wrong team.

## 6. CI known issue, recorded before its fix

A `workflow_dispatch` fails at `azure/login` with a subject mismatch — GitHub presents an **ID-based** subject, the federated credential is **path-based**:

```
presented:   repository_owner_id:6154722:repository_id:238360694:ref:refs/heads/feat/CoR
credential:  repo:microsoft/vscode-azureresourcegroups:ref:refs/heads/feat/CoR
```

Written up **before** the fix lands, deliberately: the next repo onboarded to MSBench hits this identically, and a known issue captured while the error text is to hand beats one reconstructed later.

Two details that are easy to lose and make it cheap to act on: **the failure costs nothing** (it happens before `run.sh`, so no run is submitted and no tokens spent), and **the fix is known-good rather than speculative** — the same identity already carries an ID-based credential for `vscode-azure`. The blocker is a subscription `ReadOnly` lock, not our config.

It also means **a red `eval` job is not evidence about the eval**. `Azure login` red is setup; `Run the MSBench eval` red is the pipeline; only a completed submission says anything about the product.

## 7. Two traps hit while doing this, now documented

**`results.json` timestamps are naive local time; trajectory steps are UTC.** Subtracting directly gives a ~7h offset — the first pass at the setup measurement produced ~25,400s for runs that completed in 240s. It was *obviously* wrong, which is the only reason it was caught; a smaller offset would have shipped.

**Total run duration bounds setup from above.** `results.json` carries `initialized` and `completed`, and a run that finished in 242s cannot contain 897s of setup — two fields, no trajectory parsing. That is what refuted the "896.6s is the new normal" claim, and it would have caught the 7h timezone error immediately too. Reach for it before parsing anything.

**A trailing `echo` after `&&` reports success unconditionally.** `cmd && check; echo "done"` prints `done` whether or not `cmd` ran. Three instances here in two days, including a `git push` that never happened but reported "pushed" — surfaced only when PR creation failed with *"No commits between feat/CoR and feat/CoR"* — and `npm run gates | tail` reporting exit 0, because a pipeline's status is the *last* command's. A false green from your own tooling deserves more suspicion than a red gate, because nothing downstream contradicts it.

## Gates

```
gates      PASS   47 assertions / 13 stimuli + generator lint clean
typecheck  PASS
drift      PASS   16 contracts
certify    PASS   86/86
stacks     PASS   2 stacks, 36 rules / 37 fixtures
```

`certify`'s only delta was `generatedAt` — **not committed**. **No MSBench run submitted**; the workflow is not dispatched, per instruction.



