### PR TITLE
Fix the two things that were only ever wrong on the machine that matters

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -2160,6 +2160,47 @@ credential cannot be added without an owner lifting it.
 failed before concluding anything: `Azure login` red is setup, `Run the MSBench eval` red
 is the pipeline, and only a completed submission says anything about the product.
 
+### CI is the only thing that tests the runner's own portability
+
+The first dispatch that got past `azure/login` immediately found a bug that **could not
+have been found locally**, and it had been there since the file was written:
+
+```
+mktemp: too few X's in template 'msbench-run'
+```
+
+BSD `mktemp` (macOS) accepts a bare `-t PREFIX` and appends its own randomness. GNU
+`mktemp` (Linux) treats the argument as a template and refuses it unless it ends in at
+least three `X`. Every machine this has ever been run from is macOS, so the line worked
+everywhere it was tried and was wrong on the only machine that matters. The fix is
+`mktemp -t msbench-run.XXXXXX`, which both accept.
+
+**This is a category nothing else here covers.** Grader certification, the gate table,
+the hostile fixtures and `gateHealth` all run *wherever you run them* — they cannot
+detect code that is correct on every developer machine and wrong in the container. So
+the CI path is not a convenience that saves typing `./run.sh`; **it is the only
+environment that tests the runner's own portability assumptions.**
+
+The same dispatch exposed a second, quieter instance found by auditing for the first.
+`run.sh` located `results.zip` only under the two *default* data directories, but the
+workflow passes `--data_dir "$RUNNER_TEMP/msbench-data"` and msbench-cli writes to
+`<data_dir>/<run_id>/results.zip`. The lookup would have found nothing and the
+`if` around it would have skipped **silently**, so `verify-run.ts` — the check that
+separates a real result from a throttled run or one answered by the wrong model — would
+never have run in CI, while the job still reported the CLI's exit code as its verdict.
+
+That is worse than the `mktemp` failure, which at least stopped the job. `run.sh` now
+honours `--data_dir` when locating results, and **warns loudly when it cannot find
+them** rather than quietly skipping verification:
+
+```
+WARNING: run <id> completed but results.zip was not found, so
+verify-run.ts did NOT run. This result is UNVERIFIED: ...
+```
+
+An unverified run that reads exactly like a verified one is the vacuous-check failure
+this suite exists to catch, pointed at the verifier itself.
+
 **It stays manual, and not only because of setup.** Every dispatch submits a real run and
 spends real tokens, so a schedule or a PR trigger would spend on every push. Local runs
 need none of the above — `az login` plus the `MSBench User` role is enough, which is why
@@ -2278,6 +2319,22 @@ with a clear message:
   Put the echo inside the chain, check `$?` explicitly, or use `${PIPESTATUS[0]}` after a
   pipe. A false green from your own tooling is worth more suspicion than a red gate,
   because nothing downstream will contradict it.
+
+- **`mktemp -t PREFIX` is not portable, and neither is anything else you only ever run
+  on macOS.** BSD `mktemp` appends its own randomness to a bare prefix; GNU `mktemp`
+  fails with `too few X's in template` unless it ends in at least three `X`. Use
+  `mktemp -t name.XXXXXX`, which both accept. This shipped broken and stayed broken
+  because every machine here is macOS and CI had never got far enough to run it — see
+  [CI is the only thing that tests the runner's own portability](#ci-is-the-only-thing-that-tests-the-runners-own-portability).
+  The usual suspects if you are auditing: `sed -i`, `stat -f`/`stat -c`, `date -r`/`date
+  -d`, `readlink -f`, and `du -h` output formats.
+
+- **`--data_dir` moves where results land, and anything that reads them must follow.**
+  msbench-cli writes to `<data_dir>/<run_id>/results.zip`, and the *default* data dir
+  already ends in `runs` — so a custom value does **not** get a `runs` component. A
+  reader that only checks the defaults finds nothing, and if it skips silently on that,
+  `verify-run.ts` never runs and an unverified result is indistinguishable from a
+  verified one.
 
 - **`results.json` timestamps are naive local time; trajectory steps are UTC.**
   Subtracting one from the other directly yields a ~7h offset — setup times of ~25,400s

--- a/evals/msbench/run.sh
+++ b/evals/msbench/run.sh
@@ -26,6 +26,11 @@ STIMULUS="${STIMULUS:-photo-app-requirements}"
 STACK=""
 PHASE=""
 PASSTHRU=()
+# Observed, not chosen: msbench-cli writes results to `<data_dir>/<run_id>/`, and
+# `--data_dir` is a passthrough flag we do not otherwise interpret. The results
+# lookup after the run has to know where they landed, so the value is recorded
+# here while still being forwarded to the CLI unchanged.
+DATA_DIR=""
 while [ $# -gt 0 ]; do
     case "$1" in
         --skip-build) SKIP_BUILD=1 ;;
@@ -36,6 +41,14 @@ while [ $# -gt 0 ]; do
         --stack=*) STACK="${1#*=}" ;;
         --phase) shift; [ $# -gt 0 ] || { echo "--phase needs a value" >&2; exit 1; }; PHASE="$1" ;;
         --phase=*) PHASE="${1#*=}" ;;
+        # Recorded AND forwarded. Both spellings, both forms — the CLI accepts
+        # `--data_dir` and `--data-dir`, so matching only one would reintroduce
+        # the silent skip this exists to prevent.
+        --data_dir|--data-dir)
+            PASSTHRU+=("$1"); shift
+            [ $# -gt 0 ] || { echo "--data_dir needs a value" >&2; exit 1; }
+            DATA_DIR="$1"; PASSTHRU+=("$1") ;;
+        --data_dir=*|--data-dir=*) DATA_DIR="${1#*=}"; PASSTHRU+=("$1") ;;
         *) PASSTHRU+=("$1") ;;
     esac
     shift
@@ -338,7 +351,13 @@ sed -n '/^promptSteps:/,/assertions:/p' "${ASSETS}/user-overrides.yaml" \
     | sed -n '2,4p' | sed 's/^/    | /'
 echo
 
-RUN_LOG="$(mktemp -t msbench-run)"
+# The XXXXXX suffix is required, not decorative. BSD mktemp (macOS) accepts a bare
+# `-t PREFIX` and appends its own randomness; GNU mktemp (Linux) treats the whole
+# argument as a template and fails with "too few X's in template" unless it ends in
+# at least three X. Every developer machine here is macOS, so `-t msbench-run`
+# worked everywhere it was ever run and broke the first time it ran on
+# ubuntu-latest. The suffixed form is accepted by both.
+RUN_LOG="$(mktemp -t msbench-run.XXXXXX)"
 trap 'rm -f "$RUN_LOG"; rmdir "$LOCK" 2>/dev/null || true' EXIT
 
 set +e
@@ -362,9 +381,33 @@ set -e
 # wrong thing", both distinct from the 1 that means a genuine red run.
 RUN_ID="$(grep -oE 'run_id=[0-9]+' "$RUN_LOG" | head -1 | cut -d= -f2 || true)"
 if [ -n "$RUN_ID" ]; then
-    RESULTS_ZIP="$(ls "${HOME}/Library/Application Support/msbench/runs/${RUN_ID}/results.zip" \
-                      "${HOME}/.local/share/msbench/runs/${RUN_ID}/results.zip" 2>/dev/null | head -1 || true)"
-    if [ -n "$RESULTS_ZIP" ]; then
+    # msbench-cli writes to `<data_dir>/<run_id>/results.zip`. The default data_dir
+    # is platform-specific (macOS Application Support, Linux XDG), and `--data_dir`
+    # overrides it outright — note the default already ends in `runs`, so a custom
+    # value does NOT get a `runs` component appended.
+    RESULTS_CANDIDATES=(
+        "${HOME}/Library/Application Support/msbench/runs/${RUN_ID}/results.zip"
+        "${HOME}/.local/share/msbench/runs/${RUN_ID}/results.zip"
+    )
+    [ -n "$DATA_DIR" ] && RESULTS_CANDIDATES=("${DATA_DIR}/${RUN_ID}/results.zip" "${RESULTS_CANDIDATES[@]}")
+
+    RESULTS_ZIP=""
+    for candidate in "${RESULTS_CANDIDATES[@]}"; do
+        if [ -f "$candidate" ]; then RESULTS_ZIP="$candidate"; break; fi
+    done
+
+    if [ -z "$RESULTS_ZIP" ]; then
+        # Loud, because the alternative is worse than a failed run. verify-run.ts is
+        # what distinguishes a genuine result from a throttled one or one answered by
+        # the wrong model. If it silently does not run, the CLI's own exit code is
+        # reported as the verdict and an unverified run reads exactly like a verified
+        # one — the vacuous-check failure this suite exists to catch, applied to the
+        # verifier itself. That is precisely what `--data_dir` used to cause in CI.
+        echo "WARNING: run ${RUN_ID} completed but results.zip was not found, so" >&2
+        echo "verify-run.ts did NOT run. This result is UNVERIFIED: a throttled run" >&2
+        echo "or one answered by a different model would look identical to a good one." >&2
+        printf '  looked in: %s\n' "${RESULTS_CANDIDATES[@]}" >&2
+    else
         SCRATCH="$(mktemp -d)"
         unzip -oq "$RESULTS_ZIP" -d "$SCRATCH" 2>/dev/null || true
         find "$SCRATCH" -name '*-output.zip' -exec unzip -oq {} -d "${SCRATCH}/out" \; 2>/dev/null || true


### PR DESCRIPTION
CI reached submission for the first time and found a bug that **could not have been found locally**. Auditing for it found a second one that's worse, because it fails silently.

## Bug 1 — `mktemp`, the one CI caught

```
==> Submitting to MSBench (benchmark: vscbench.say_hello, stimulus: scaffold-unapproved-plan)
mktemp: too few X's in template 'msbench-run'
##[error]Process completed with exit code 1.
```

BSD `mktemp` (macOS) accepts a bare `-t PREFIX` and appends its own randomness. GNU `mktemp` (Linux) treats the argument as a template and refuses it unless it ends in **at least three `X`**.

Every machine this has ever been run from is macOS, so the line **worked everywhere it was tried and was wrong on the only machine that matters**. `mktemp -t msbench-run.XXXXXX` is accepted by both. (`mktemp -d` on the other line is fine — it's only the `-t` form.)

No tokens spent: it died before the submission call.

## Bug 2 — `--data_dir`, found by auditing for bug 1, and worse

The workflow passes `--data_dir "$RUNNER_TEMP/msbench-data"`. msbench-cli writes results to `<data_dir>/<run_id>/results.zip` — and the **default** data dir already ends in `runs`, so a custom value does *not* get a `runs` component appended:

```python
# msbench/config.py
def get_default_data_dir() -> Path:
    return Path(app_dirs.user_data_dir) / "runs"

# msbench/result_db/result_database.py
def get_data_dir(self, run_id: str):
    location = Path(self.data_dir) / run_id
```

`run.sh` looked only under the two **default** locations, found nothing, and the `if` around the lookup skipped **without a word**.

**So `verify-run.ts` would never have run in CI** — while the job still reported the CLI's own exit code as its verdict.

That matters because `verify-run.ts` is what separates a genuine result from:
- a **throttled** run that produced nothing (exit 75), and
- one answered by a **different model** than the one requested (exit 65).

Skipping it silently means **an unverified run reads exactly like a verified one** — the vacuous-check failure this suite exists to catch, pointed at the verifier itself. Bug 1 at least stopped the job.

### The fix

`run.sh` now records `--data_dir` while still forwarding it, checks it **first** when locating results, and **warns loudly** when it finds nothing instead of skipping:

```
WARNING: run <id> completed but results.zip was not found, so
verify-run.ts did NOT run. This result is UNVERIFIED: a throttled run
or one answered by a different model would look identical to a good one.
  looked in: ...
```

Both spellings and both forms are matched (`--data_dir`, `--data-dir`, with `=` or a following argument), because matching only one would reintroduce the silent skip.

## Verification

Parser, all four flag forms — value captured **and** forwarded unchanged:

| invocation | `DATA_DIR` | `PASSTHRU` |
| --- | --- | --- |
| `--data_dir /tmp/dd --output r.json` | `/tmp/dd` | `--data_dir /tmp/dd --output r.json` |
| `--data_dir=/tmp/dd2 --stimulus foo` | `/tmp/dd2` | `--data_dir=/tmp/dd2` |
| `--data-dir /tmp/dd3` | `/tmp/dd3` | `--data-dir /tmp/dd3` |
| *(absent)* | *(empty)* | *(empty)* |

Lookup, four scenarios including a real cached run:

```
custom data_dir, present (the CI case)  -> found /tmp/lktest/dd/2026999/results.zip
custom data_dir, absent                 -> UNVERIFIED (warns)
no data_dir, real local run             -> found ~/Library/.../2026082620153444/results.zip
no data_dir, unknown run                -> UNVERIFIED (warns)
```

Plus `bash -n`, `./run.sh --build-only` end to end (exit 0), and `gates` / `typecheck` / `drift` green.

**Stated limit:** the GNU half of the `mktemp` claim rests on the CI error text and documented behaviour — I had no Linux box available (Docker daemon down), so I did not re-test it directly. The BSD half is verified locally, and the fixed form works on BSD.

## Why this class of bug had no coverage

Grader certification, the gate table, the hostile fixtures and `gateHealth` all run **wherever you run them**. None of them can detect code that is correct on every developer machine and wrong in the container.

So the README now says it plainly: **the CI path is not a convenience that saves typing `./run.sh` — it is the only environment that tests the runner's own portability assumptions.** Two troubleshooting entries added (the `mktemp` form and the `--data_dir` relocation), with the usual BSD/GNU suspects listed for anyone auditing.