### PR TITLE
Probe the one mechanism a phase chain can still use, before building on it

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -1138,6 +1138,101 @@ multi-turn stimuli straightforward. `llm_responses.response` is user-facing pros
 only, excluding tool output and thinking blocks, so substring assertions don't
 false-match text the agent merely read.
 
+## Chaining phases in one run, and the hand-off we cannot test
+
+A run that carries a project from requirements through to local debugging has to move
+between *phases*, and `chatMode` is set per config — one mode per run. So a chain needs
+the mode to change **within** a run. There were two candidate mechanisms, and one of them
+is already refuted.
+
+### The product's own hand-off cannot drive it
+
+In production the *agent* moves the flow along: the scaffold agent calls
+`start_project_integrate`, the frontend preview's **Approve UI** button fires the same
+command. It is tempting to let that drive a chain — it would be the most faithful test
+available, because the product would be doing exactly what it does for a user.
+
+It cannot, and the reason is a deliberate design decision rather than an accident.
+`launchAgentChat` in
+[`src/commands/copilotOnRails/openChatWithAgent.ts`](../../src/commands/copilotOnRails/openChatWithAgent.ts)
+does this on **every** hand-off — integrate, local dev, debug generate, deploy:
+
+```ts
+// Fresh chat session per phase hand-off: agents coordinate through the `.azure/*` plan
+// files on disk, not chat history, so a clean session keeps each agent focused on its phase.
+await vscode.commands.executeCommand('workbench.action.chat.newChat');
+await vscode.commands.executeCommand('workbench.action.chat.open', { mode: agentName, query, ... });
+```
+
+`promptSteps` feeds **one** chat session, and the assertion tables are populated from it.
+A hand-off that opens a new session moves the work somewhere the harness is not watching:
+the driven agent goes quiet and the run reads as one that died after turn 0. Those two
+commands are also fire-and-forget — `projectSession.ts` records that they *"return no
+session handle"* and that stable VS Code exposes no event for a chat session being closed
+or cleared, so there is nothing to follow either.
+
+**This was settled by reading the product rather than by running anything.** It is worth
+saying because the alternative — build the chain, watch it fail, guess why — costs a full
+product run and answers ambiguously.
+
+### So it is a *phase chain*, not an end-to-end test
+
+The remaining mechanism is `promptSteps[].chatMode`, where the **harness** performs the
+transition. That is a faithful test of the agents and a **simulation of the hand-off**.
+
+Do not call it end-to-end. A misleading name is its own defect — it is what stops the next
+person looking — and "E2E: green" would be read as covering the hand-off, which it does
+not. What such a chain does and does not establish:
+
+| | Covered |
+| --- | --- |
+| Each phase's agent behaves correctly given the previous phase's output | yes |
+| Phase N's real artifacts are phase N+1's input, with no seeding | yes |
+| The hand-off tool was **called**, with the right arguments | yes |
+| The hand-off **succeeded** — `newChat` fired, the new session got the right mode, the reload guard held | **no** |
+
+### The hand-off gap, and the one thing that would still catch it
+
+The hand-off's own failure modes are untestable in MSBench as configured, for the reason
+above. That is a real coverage gap and it is recorded here rather than papered over, so
+nobody spends a day rediscovering that `newChat` is fire-and-forget.
+
+One thing softens it, and it is worth being precise about how much. After a real hand-off
+the receiving agent does work that lands on disk, so a **downstream artifact's absence is
+detectable** even though the transition itself is not observable. That turns "untestable"
+into "we would notice if it broke" — a materially weaker claim than testing it, but not
+nothing.
+
+Be careful about *which* artifact, though. `azure-project-integrate` is contracted to
+**read** `.azure/integration-plan.md`, not to write one — the scaffold agent wrote it as a
+hand-off brief. So the presence of that file proves the scaffold phase ran, not that the
+integrate phase did. Any absence-based check has to name an artifact the *receiving* agent
+produces, or it silently tests the wrong phase.
+
+### `chain-mechanism-probe`
+
+`promptSteps[].chatMode` is schema-declared and **runner-unverified**, and so is what it
+does to the conversation. [`config/stimuli/chain-mechanism-probe.yaml`](config/stimuli/chain-mechanism-probe.yaml)
+is the cheap run that settles both, sized like `debug-probe-smoke`: two turns, trivial
+prompts, no artifacts.
+
+1. **Does the override change which agent answers?** Turn 1 overrides to
+   `azure-debug-plan` and is asked to name its own mode.
+2. **Does turn 1 inherit turn 0's conversation?** Turn 0 emits a marker token; turn 1 is
+   asserted not to reproduce it, *and* to say `NO-PRIOR-CONTEXT` explicitly.
+
+The second question matters more, and it decides two things at once. **Fidelity** — the
+product starts a fresh session per phase, so if the runner merely relabels the mode inside
+one conversation, every phase inherits its predecessor's transcript, which the product
+never does. And **cost** — that is the superlinear curve already measured here, where one
+extra turn multiplied total tokens by 6.3x because each step re-sends a growing
+transcript. Across four phases it is the difference between fitting inside
+`agentSeconds: 4500` and not.
+
+Both halves of question 2 are needed. An absence alone is ambiguous: an agent told to
+reply with one word may simply not have quoted the earlier message even though it could
+see it. The explicit denial is what turns silence into evidence.
+
 ## Multi-turn stimuli
 
 `promptSteps` is natively multi-turn: each entry is one user message into the **same**

--- a/evals/msbench/config/phases/chain-probe.yaml
+++ b/evals/msbench/config/phases/chain-probe.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/vscode-copilot-evaluation/main/doc/references/TestConfig.schema.json
+
+# Phase: `chain-probe` — harness mechanics only. The product is not under test.
+#
+# Sibling of `probe-smoke`, and for the same reason: it answers a question about
+# the *harness* without paying for a product run to do it. The question here is
+# whether `promptSteps[].chatMode` is honoured by the runner, and what it does to
+# the conversation when it is.
+#
+# WHY THIS PHASE SETS A TOP-LEVEL chatMode AND probe-smoke DOES NOT
+#
+# `probe-smoke` deliberately sets none, so no product agent loads and the run
+# stays near-free. This probe cannot do that: the thing under test IS the
+# per-step `chatMode` override, and an override needs something to override.
+#
+# The two modes named by the stimulus are real product agents, so the agent
+# definitions have to be on disk for the custom modes to resolve — hence the
+# same VSIX-unpack seeding the `plan` phase does. Without it, an unresolved
+# custom mode silently opens the default Agent (see `launchAgentChat` in
+# src/commands/copilotOnRails/openChatWithAgent.ts), which would look exactly
+# like "the runner ignored chatMode" while meaning something completely
+# different. That ambiguity is the one this probe exists to remove, so it must
+# not be reintroduced by the setup.
+#
+# The prompts still ask the agents to do nothing, so this stays cheap: what is
+# being measured is which agent answers and what it can see, not what it builds.
+#
+# snapshotWorkspace is left at its default. Nothing here asserts on `files`, and
+# the run writes no artifacts worth snapshotting either way.
+
+chatMode: azure-project-plan
+
+# Seed the agent definitions out of the VSIX, exactly as the `plan` phase does.
+# Copied rather than shared because a phase file is the unit a stimulus selects;
+# see config/phases/plan.yaml for the reasoning about keeping instructions in
+# step with the build under test.
+script: |
+  set -eux
+  VSIX=/agent/assets/extensions/vscode-azureresourcegroups.vsix
+  rm -rf /tmp/corext && mkdir -p /tmp/corext
+  unzip -q -o "$VSIX" 'extension/resources/agents/*' -d /tmp/corext
+  mkdir -p /workspace/.github/agents
+  cp -r /tmp/corext/extension/resources/agents/. /workspace/.github/agents/
+  ls -la /workspace/.github/agents/

--- a/evals/msbench/config/stimuli/chain-mechanism-probe.yaml
+++ b/evals/msbench/config/stimuli/chain-mechanism-probe.yaml
@@ -1,0 +1,172 @@
+# phase: chain-probe
+#
+# Stimulus `chain-mechanism-probe` — the cheapest run that can answer the two
+# questions a phase chain is blocked on.
+#
+#   1. Does `promptSteps[].chatMode` actually change which agent answers?
+#   2. Does step 1 inherit step 0's conversation?
+#
+# Both are currently assumptions. (1) is schema-declared and runner-unverified.
+# (2) has never been asked, and matters more.
+#
+# WHY THIS RUN EXISTS RATHER THAN A DIRECT ATTEMPT AT THE CHAIN
+#
+# The alternative was to build the four-phase chain and read the failure. That
+# costs a full product run — the scaffold phase alone was 874s and ~2.6M tokens —
+# and it answers ambiguously: a chain that misbehaves could be the runner
+# ignoring `chatMode`, or the agents behaving badly, or the transcript growing
+# past what the models handle. This run separates the harness question from the
+# product question, so the expensive run only has to answer one of them.
+#
+# WHAT WAS ALREADY SETTLED WITHOUT A RUN, AND WHY IT IS NOT ASKED HERE
+#
+# The other candidate mechanism was to let the *product* drive the transition:
+# the scaffold agent calls `start_project_integrate`, and the flow moves on. That
+# was refuted by reading the source rather than by running anything.
+# `launchAgentChat` (src/commands/copilotOnRails/openChatWithAgent.ts:141) does:
+#
+#     await vscode.commands.executeCommand('workbench.action.chat.newChat');
+#     await vscode.commands.executeCommand('workbench.action.chat.open', { mode: agentName, query });
+#
+# with the comment "Fresh chat session per phase hand-off: agents coordinate
+# through the `.azure/*` plan files on disk, not chat history". Every hand-off in
+# the flow takes that path. `promptSteps` drives ONE session, so the product's
+# hand-off would move the work into a session the harness is not watching, and
+# the run would read as an agent that stopped after turn 0. No run needed to know
+# that, and none was spent.
+#
+# WHY QUESTION 2 IS THE IMPORTANT ONE
+#
+# Question 1 is binary and its failure is loud: if the override is ignored, the
+# same agent answers twice and assertion 3 goes red. Question 2 is quiet, and it
+# decides two separate things.
+#
+#   Fidelity. The product gives every phase a FRESH session — that is what the
+#   `newChat` above is. If the runner instead relabels the mode inside one
+#   conversation, then a "chain" has each phase inheriting its predecessor's
+#   transcript, which is a shape the product never produces. The chain would
+#   still run; it would just be testing something the product does not do.
+#
+#   Cost. Shared transcript is the superlinear curve already measured here: one
+#   extra turn multiplied total tokens by 6.3x, because every step re-sends a
+#   transcript that is itself growing. Across four phases that is the difference
+#   between a run that fits inside `agentSeconds: 4500` and one that does not.
+#
+# So assertion 4 is the one to read first. It is also the one most likely to be
+# misread: see its comment for why a green there is weaker evidence than it looks.
+
+promptSteps:
+  # ─── Turn 0: azure-project-plan (inherited from the phase) ─────────────────
+  #
+  # No `chatMode` key, deliberately. This step takes the phase's top-level mode,
+  # which establishes the baseline: whatever answers here is what the config says
+  # should answer. If the override in step 1 changes nothing, both turns look
+  # like this one.
+  #
+  # The marker phrase is the instrument for question 2. It has to be a string
+  # that cannot plausibly appear in step 1's answer by chance, and that the agent
+  # will emit verbatim — hence a nonsense token rather than an English phrase.
+  - text: |
+      Reply with exactly this word and nothing else: ZEBRAFISH-7741
+
+      Do not create, modify or read any files. Do not call any tools. Do not
+      explain. This is a connectivity check.
+    assertions:
+      # Liveness sentinel — must come first, and one per turn. Every other check
+      # in this stimulus is about which agent spoke and what it could see; all of
+      # them pass trivially against an empty table.
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      # Question 2's setup, asserted rather than assumed. If the agent did not
+      # emit the marker, assertion 4 below cannot distinguish "step 1 could not
+      # see step 0" from "there was nothing to see" — a false green on the
+      # question this run exists to answer.
+      - comment: Turn 0 emitted the marker, so the inheritance check below is meaningful
+        query: SELECT COUNT(*) > 0 FROM llm_responses WHERE response LIKE '%ZEBRAFISH-7741%'
+
+  # ─── Turn 1: azure-debug-plan, via the per-step override ───────────────────
+  #
+  # THE MECHANISM UNDER TEST. `azure-debug-plan` is chosen because it is a real
+  # shipped agent, it is a plausible later phase in a real chain, and its
+  # instructions differ enough from `azure-project-plan` that an agent running
+  # under it can say so. Nothing about this turn requires it to do debug work.
+  - chatMode: azure-debug-plan
+    text: |
+      Two questions. Answer both in one short reply, nothing else.
+
+      First: state the name of the chat mode or agent you are currently running
+      as, exactly as it is configured.
+
+      Second: state whether any earlier message exists in this conversation. If
+      one does, quote it verbatim. If this is the first message you have seen,
+      reply with exactly: NO-PRIOR-CONTEXT
+
+      Do not create, modify or read any files. Do not call any tools.
+    assertions:
+      # Second sentinel. A run that completes turn 0 and dies before turn 1 would
+      # otherwise leave every check below vacuously true — and this stimulus is
+      # unusually exposed to that, because two of its three remaining assertions
+      # are negative.
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      # QUESTION 1: did the override take effect?
+      #
+      # Scoped to step 1 by the implied stepIndex filter, so this is specifically
+      # "the agent answering the SECOND turn named the overridden mode". A green
+      # here means the runner honours `promptSteps[].chatMode` and mechanism (a)
+      # is real.
+      #
+      # Deliberately matched on the mode name rather than on behaviour. Behaviour
+      # would be the stronger evidence, but it costs a real product run to
+      # observe and would fail for reasons unrelated to the mechanism.
+      - comment: Turn 1 ran under the overridden chat mode
+        query: SELECT COUNT(*) > 0 FROM llm_responses WHERE response LIKE '%azure-debug-plan%'
+
+      # QUESTION 2: does turn 1 inherit turn 0's conversation?
+      #
+      # READ THIS ONE FIRST, and read it carefully — a green is weaker evidence
+      # than it looks.
+      #
+      #   RED   => the runner relabels the mode within ONE conversation. The
+      #            chain would work, but every phase would inherit its
+      #            predecessor's transcript: unfaithful to the product, which
+      #            starts a fresh session per hand-off, and expensive, since the
+      #            transcript compounds across four phases.
+      #
+      #   GREEN => turn 1 could not see the marker. That is CONSISTENT with a
+      #            fresh session per step, which is what we want — but it is not
+      #            proof of one. An agent that was told "reply with only X" may
+      #            simply not have quoted the earlier message even though it
+      #            could see it. The companion assertion below is what makes the
+      #            green mean something: the agent is asked to say NO-PRIOR-CONTEXT
+      #            explicitly, so silence and denial are distinguishable.
+      #
+      # Both are needed. Neither alone settles it.
+      - comment: Turn 1 did not reproduce turn 0's marker
+        query: SELECT COUNT(*) = 0 FROM llm_responses WHERE response LIKE '%ZEBRAFISH-7741%'
+
+      # The other half of question 2. An explicit denial is positive evidence of
+      # a fresh session, where the absence above is only an absence.
+      #
+      # This is the assertion most likely to go red for a boring reason — the
+      # agent paraphrasing rather than emitting the exact token. If it is red
+      # while the assertion above is green, read the transcript before concluding
+      # anything: that combination is ambiguous by construction, and the raw
+      # response says which it was.
+      - comment: Turn 1 reported no prior context, so the absence above is a denial rather than silence
+        query: SELECT COUNT(*) > 0 FROM llm_responses WHERE response LIKE '%NO-PRIOR-CONTEXT%'
+
+      # Recorded, never asserted. `assertZeroExitCode: false` puts the output in
+      # the `exec` table without generating a check, so it cannot fail the run or
+      # change the assertion count.
+      #
+      # Worth reading whenever any assertion above is red: an unresolved custom
+      # mode silently opens the default Agent rather than erroring, which looks
+      # identical from the outside to "the runner ignored chatMode" and has a
+      # completely different fix. This lists what the phase script actually
+      # seeded, which separates the two.
+      - comment: Fingerprint; seeded agent definitions and environment
+        assertZeroExitCode: false
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "--- seeded agents ---"; ls -la /workspace/.github/agents/ 2>&1 | head -30'


### PR DESCRIPTION
A chain from requirements → plan → scaffold → local dev needs `chatMode` to change **within one run**. Two mechanisms were candidates. **One is now refuted for $0 by reading the product**; this adds the cheap run that settles the other before anything gets built on it.

## Refuted: the product's own hand-off cannot drive a chain

The attractive option was letting the *product* move the flow along — the scaffold agent calls `start_project_integrate`, the preview's **Approve UI** button fires the same command. A chain driven that way would be the product doing exactly what it does for a real user.

It can't work, and it's a deliberate design decision rather than an accident. `launchAgentChat` does this on **every** hand-off — integrate, local dev, debug generate, deploy:

```ts
// Fresh chat session per phase hand-off: agents coordinate through the `.azure/*` plan
// files on disk, not chat history, so a clean session keeps each agent focused on its phase.
await vscode.commands.executeCommand('workbench.action.chat.newChat');
await vscode.commands.executeCommand('workbench.action.chat.open', { mode: agentName, query, ... });
```

`promptSteps` drives **one** session and the assertion tables come from it. A hand-off that opens a new session moves the work somewhere the harness isn't watching — the driven agent goes quiet and the run reads as one that died after turn 0. Those commands are fire-and-forget too: `projectSession.ts` records they *"return no session handle"* and that stable VS Code exposes no event for a chat session being closed, so there's nothing to follow either.

**This also inverts the fidelity argument that motivated the option.** One session carrying every phase is *not* "what the product does" — the product starts a fresh session per phase. Neither mechanism reproduces that.

Settled by reading source. The alternative — build the chain, watch it fail, guess why — costs a full product run and answers ambiguously.

## The probe

Two turns, trivial prompts, no artifacts, sized like `debug-probe-smoke`.

**Q1 — does `promptSteps[].chatMode` change which agent answers?** Turn 1 overrides to `azure-debug-plan` and is asked to name its own mode.

**Q2 — does turn 1 inherit turn 0's conversation?** Turn 0 emits `ZEBRAFISH-7741`; turn 1 must not reproduce it **and** must say `NO-PRIOR-CONTEXT`.

### Q2 is the one that matters, and it wasn't in the original framing

It decides two things at once:

- **Fidelity.** The product gives each phase a *fresh* session. If the runner merely relabels the mode inside one conversation, every phase inherits its predecessor's transcript — a shape the product never produces.
- **Cost.** That's the superlinear curve already measured here: one extra turn multiplied total tokens by **6.3×**, because each step re-sends a growing transcript. Across four phases it's the difference between fitting inside `agentSeconds: 4500` and not.

### Why both halves of Q2 are asserted

An absence alone is ambiguous — an agent told to reply with one word may not quote an earlier message it *can* see. The explicit denial turns silence into evidence. Turn 0's marker is asserted **present** for the same reason: without it, a green on the inheritance check can't distinguish "could not see" from "nothing to see".

### Why the phase seeds agents despite asking for no work

An unresolved custom mode **silently opens the default Agent** rather than erroring. That is indistinguishable from "the runner ignored `chatMode`" and has a completely different fix — the exact ambiguity this probe exists to remove, so the setup must not reintroduce it.

## Validated before spending anything

Checked the generated config against the real `TestConfig.schema.json`: every top-level key, every prompt-step key, every assertion variant.

```
top-level chatMode: azure-project-plan
  step 0  chatMode=(inherit)        assertions=2
  step 1  chatMode=azure-debug-plan assertions=5
SCHEMA OK: every key and assertion variant valid
```

`promptSteps` items are `additionalProperties: false`, so a typo'd key would be rejected **in-container after the queue wait**, not here. Worth the check.

## Naming, and the gap it keeps honest

The README calls the result a **phase chain**, never end-to-end. The harness performs the transition the product performs in production, so the hand-off's own failure modes go untested — whether `newChat` fires, whether the new session gets the right mode, whether the reload guard holds. "E2E: green" would be read as covering them, and a misleading name is its own defect.

| | Covered |
| --- | --- |
| Each phase's agent behaves correctly given the previous phase's output | yes |
| Phase N's real artifacts are phase N+1's input, no seeding | yes |
| The hand-off tool was **called**, with the right arguments | yes |
| The hand-off **succeeded** | **no** |

**One correction to how that gap might be softened.** A downstream artifact's absence is detectable even though the transition isn't — but it must be an artifact the *receiving* agent produces. `.azure/integration-plan.md` is written by the **scaffold** agent as a brief and only *read* by `azure-project-integrate`, so its presence proves the phase **before** the hand-off ran, not the phase after. An absence check naming it would silently test the wrong phase.

## Gates

`gates` · `typecheck` · `drift` green; all 14 stimuli build.

**No run submitted.** The probe is ready to dispatch on request.