### PR TITLE
Report a gate that never ran as not-attempted, not as a failure

### DIFF
--- a/evals/grader-certification/manifest.json
+++ b/evals/grader-certification/manifest.json
@@ -759,6 +759,15 @@
             "search": "## Database\n\n| Field | Value |\n|-------|-------|\n| Type | File-backed JSON store |\n| Data file | `data/items.json` |\n| Migration tool | none (no schema to migrate) |\n\nProduction migration would replace the file store with managed storage. **NO seed data is to be created.**\n\n### Collection \u2192 table mapping (whitelisted in `src/services/database.ts`)\n\n| Collection (code) | Store key |\n|-------------------|-----------|\n| `tickets` | `items` |",
             "replacement": "",
             "expectedCode": "missingDatabase"
+        },
+        {
+            "id": "runtime-app-starts-never-scaffolded",
+            "tier": "offline",
+            "fixture": "reference-node-fullstack",
+            "validator": "runtime-app-starts",
+            "file": "package.json",
+            "operation": "delete",
+            "expectedCode": "runtimeNotAttempted"
         }
     ]
 }

--- a/evals/graders/graderHarness.ts
+++ b/evals/graders/graderHarness.ts
@@ -190,6 +190,90 @@ export function skipAsNotApplicable(
 }
 
 /**
+ * A gate whose input was never produced exits **3**, and names the missing precondition.
+ *
+ * This exists because the phases run as one chain with no seeding: the plan phase's output
+ * is the scaffold phase's input, and the scaffold phase's output is what every local-dev
+ * gate reads. So when scaffold fails, the debug gates and the runtime gates **did not fail.
+ * They never ran.** Reporting them red says a dozen things went wrong when one did, and
+ * none of the dozen is evidence about what those gates measure.
+ *
+ * Measured before it was built: a workspace with planning artifacts and no scaffold output
+ * produced five separate exit-1 product failures from the five runtime gates, each claiming
+ * the agent shipped no runnable application. True once; attributed five times.
+ *
+ * Exit 3 for the same reason as `NOT_APPLICABLE_EXIT_CODE`, and the argument is if anything
+ * stronger here. Exit 0 would hand a run with a broken scaffold eleven free passes, so
+ * `resolved` would improve *because the product got worse* — optimistic and unrecoverable.
+ * The run is already red from the gate that owns the failure, so these verdicts do not
+ * change the outcome; they change the diagnosis, which is the entire point.
+ */
+export const NOT_ATTEMPTED_EXIT_CODE = EXIT_GRADER_ERROR;
+
+/**
+ * The machine-readable not-attempted line, parallel to `NOT_APPLICABLE` and greppable the
+ * same way: `stdErr LIKE 'NOT_ATTEMPTED gate=%'`.
+ *
+ *     NOT_ATTEMPTED gate=<gate-id> reason=<preconditionId> detail="<what was looked for>"
+ *
+ * A distinct marker rather than a reason code on the existing one, because the three exit-3
+ * verdicts answer different questions and want different readers. Not-applicable says *this
+ * stack has no such question*; a harness fault says *this grader broke*; not-attempted says
+ * *ask the gate upstream — nothing here is about me*. Without the marker all three collapse
+ * into `GRADER_EXIT_3` and the reader is sent to the wrong place, which is the failure this
+ * whole vocabulary exists to prevent.
+ */
+export const NOT_ATTEMPTED_MARKER = 'NOT_ATTEMPTED';
+
+/** Thrown to end a grader with a not-attempted verdict; see `NOT_ATTEMPTED_EXIT_CODE`. */
+export class NotAttempted extends Error {
+    readonly gate: string;
+    readonly precondition: string;
+    readonly detail: string;
+
+    constructor(gate: string, precondition: string, detail: string) {
+        super(detail);
+        this.gate = gate;
+        this.precondition = precondition;
+        this.detail = detail;
+    }
+}
+
+/**
+ * Assert a precondition this gate consumes but does not produce.
+ *
+ * **The attribution rule this enforces:** the gate that *owns* producing an output reports
+ * the product failure when it is missing; every gate that merely *consumes* that output
+ * reports not-attempted. Attribution then lands exactly once by construction rather than by
+ * anyone remembering to suppress the other eleven. So the scaffold gate keeps reporting
+ * "the agent shipped no runnable application", and the runtime gates stop claiming it.
+ *
+ * `satisfied` must be a **positive assertion about a named artifact** — "I looked for X at
+ * Y and it is absent" — never an inference from an empty result. That distinction is the
+ * one this repository keeps relearning: a parser that cannot read a frontend produces the
+ * same emptiness as a frontend that does nothing, and only the positive form can tell them
+ * apart. `detail` should therefore say what was looked for and where, not merely that
+ * something was missing.
+ *
+ * This is deliberately called by each gate rather than declared in a table beside them. A
+ * table is a claim *about* a gate, maintained apart from it, and the first audit of that
+ * shape in this repository returned 40% wrong in five rows — not through carelessness, but
+ * because a description of code drifts from code silently. A precondition asserted here runs
+ * on the same path as the read it guards, so it cannot drift, and it is auditable by
+ * execution: point the gate at a workspace missing the artifact and read what it says.
+ */
+export function requirePrecondition(
+    gate: string,
+    precondition: string,
+    satisfied: boolean,
+    detail: string,
+): void {
+    if (!satisfied) {
+        throw new NotAttempted(gate, precondition, detail);
+    }
+}
+
+/**
  * Run a grader body, mapping its outcome onto the exit-code contract above.
  * An unexpected throw (TypeError, ReferenceError, …) exits 3 rather than 1 so a
  * broken grader is never reported as a product regression.
@@ -225,6 +309,17 @@ export async function runGraderAsync(name: string, body: () => Promise<void>): P
 
 function exitForError(name: string, error: unknown): never {
     const gate = gateId();
+    if (error instanceof NotAttempted) {
+        // Read on a red run, like the not-applicable line, so it has to say plainly that
+        // nothing here is a finding about the product — otherwise a cascade gets triaged as
+        // a dozen defects, which is the cost this verdict exists to avoid.
+        console.error(`${NOT_ATTEMPTED_MARKER} gate=${error.gate} reason=${error.precondition} detail=${JSON.stringify(error.detail)}`);
+        console.error(`NOT ATTEMPTED: gate=${gate} — ${name}`);
+        console.error(`  ${error.detail}`);
+        console.error('  This gate never ran: it consumes something an earlier phase did not produce. '
+            + 'Nothing here is evidence about the generated app, and the failure is reported by the gate that owns that output.');
+        process.exit(NOT_ATTEMPTED_EXIT_CODE);
+    }
     if (error instanceof NotApplicable) {
         // `detail` is JSON-encoded rather than quote-substituted so the field survives a
         // parser: JSON.stringify supplies the surrounding quotes and escapes embedded quotes

--- a/evals/graders/runtimeGate.ts
+++ b/evals/graders/runtimeGate.ts
@@ -18,7 +18,7 @@
 import type { RuntimeValidationResult } from '../src/runtime/runtimeGates.ts';
 import { RUNTIME_NOT_APPLICABLE_CLASS } from '../src/runtime/runtimeTarget.ts';
 import { releaseRuntimeSessions } from '../src/runtime/runtimeSession.ts';
-import { failAsHarnessFault, failWithIssues, runGraderAsync, skipAsNotApplicable, workspacePath } from './graderHarness.ts';
+import { failAsHarnessFault, failWithIssues, requirePrecondition, runGraderAsync, skipAsNotApplicable, workspacePath } from './graderHarness.ts';
 
 export function runRuntimeGate(
     gate: string,
@@ -42,6 +42,12 @@ export function runRuntimeGate(
         // Order matters: the validators record a not-applicable verdict and a harness fault
         // as issues *as well as* flags, so that grader certification sees them and the
         // golden fixture goes red. Here the flags win, because they carry the attribution.
+        // Before applicability and before failure: a gate that never got its input has no
+        // opinion to offer about either, and saying otherwise is the misattribution this
+        // verdict exists to stop.
+        if (result.notAttempted) {
+            requirePrecondition(gate, result.notAttempted.precondition, false, result.notAttempted.detail);
+        }
         if (result.notApplicable) {
             skipAsNotApplicable(
                 gate,

--- a/evals/results/grader-certification/offline/report.json
+++ b/evals/results/grader-certification/offline/report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-26T08:52:34.771Z",
+  "generatedAt": "2026-08-26T18:51:23.859Z",
   "mode": "offline",
   "fixtures": [
     "sample-agent-output",
@@ -683,6 +683,18 @@
       "expected": "frontendMakesNoApiCalls",
       "actual": [
         "frontendMakesNoApiCalls"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "runtime-app-starts-never-scaffolded",
+      "tier": "offline",
+      "fixture": "reference-node-fullstack",
+      "validator": "runtime-app-starts",
+      "expected": "runtimeNotAttempted",
+      "actual": [
+        "runtimeNotAttempted"
       ],
       "passed": true,
       "durationMs": 0

--- a/evals/results/grader-certification/offline/report.md
+++ b/evals/results/grader-certification/offline/report.md
@@ -3,7 +3,7 @@
 - Mode: `offline`
 - Fixtures: `sample-agent-output`, `reference-node-fullstack`, `reference-node-multiservice`, `reference-python-api`, `reference-dotnet-api`, `reference-go-unsupported`, `api-only-no-datastore`
 - Outcome: **PASSED**
-- Cases: 86/86 passed
+- Cases: 87/87 passed
 
 | Case | Fixture | Validator | Expected | Actual | Result |
 |---|---|---|---|---|---|
@@ -66,6 +66,7 @@
 | `runtime-crud-write-not-persisted` | `reference-node-fullstack` | `runtime-crud` | `crudRoundTripLost` | `crudRoundTripLost` | PASS |
 | `runtime-frontend-api-unresolvable-url` | `reference-node-fullstack` | `runtime-frontend-api` | `frontendApiCallsUnresolvable` | `frontendApiCallsUnresolvable` | PASS |
 | `runtime-frontend-api-nothing-called` | `reference-node-fullstack` | `runtime-frontend-api` | `frontendMakesNoApiCalls` | `frontendMakesNoApiCalls` | PASS |
+| `runtime-app-starts-never-scaffolded` | `reference-node-fullstack` | `runtime-app-starts` | `runtimeNotAttempted` | `runtimeNotAttempted` | PASS |
 | `golden-service-fidelity` | `reference-node-multiservice` | `service-fidelity` | `passed` | `passed` | PASS |
 | `golden-datastore-fidelity` | `reference-node-multiservice` | `datastore-fidelity` | `passed` | `passed` | PASS |
 | `fidelity-planned-service-dropped` | `reference-node-multiservice` | `service-fidelity` | `plannedServiceMissing` | `plannedServiceMissing` | PASS |

--- a/evals/src/runtime/runtimeGates.ts
+++ b/evals/src/runtime/runtimeGates.ts
@@ -39,6 +39,12 @@ import { acquireRuntimeSession, probe, type HttpProbeResponse, type RuntimeSessi
 export interface RuntimeValidationResult extends ArtifactValidationResult {
     /** Set when the grader itself could not run — maps to exit 3, never blamed on the agent. */
     harnessFault?: string;
+    /**
+     * Set when an input this gate consumes was never produced upstream. Distinct from a
+     * harness fault: nothing is broken here, the gate simply never got its input, and the
+     * gate that owns producing it reports the failure.
+     */
+    notAttempted?: { precondition: string; detail: string };
     /** Set when this gate has no opinion about this stack — maps to the NOT_APPLICABLE marker. */
     notApplicable?: { reason: NotApplicableReason; detail: string };
     /** Context worth printing whatever the verdict is. */
@@ -536,6 +542,8 @@ function describeUnusableSession(session: RuntimeSession): RuntimeValidationResu
             return undefined;
         case 'notApplicable':
             return notApplicable(session.reason, session.detail);
+        case 'notAttempted':
+            return notAttempted(session.precondition, session.detail);
         case 'harnessFault':
             return harnessFault(session.message, session.output);
         case 'productFailure':
@@ -870,6 +878,23 @@ function harnessFault(message: string, output: string, code = 'runtimeHarnessFau
  * gate here *can* answer for, so an N/A against it means discovery broke, and certification
  * must show that rather than certify a gate that declined to look.
  */
+/**
+ * This gate never ran, because something it consumes was not produced.
+ *
+ * Recorded as an issue as well as a flag, for the same reason the other two non-verdicts
+ * are: the reference fixture is a workspace where every precondition holds, so a
+ * not-attempted verdict against it means discovery broke, and certification must go red
+ * rather than certify a gate that never got as far as looking.
+ */
+function notAttempted(precondition: string, detail: string): RuntimeValidationResult {
+    return {
+        valid: false,
+        issues: [issue('runtimeNotAttempted', '$.runtime', `${precondition}: ${detail}`)],
+        notAttempted: { precondition, detail },
+        diagnostics: [],
+    };
+}
+
 function notApplicable(reason: NotApplicableReason, detail: string): RuntimeValidationResult {
     return {
         valid: false,

--- a/evals/src/runtime/runtimeSession.ts
+++ b/evals/src/runtime/runtimeSession.ts
@@ -25,6 +25,8 @@ import { startApp, waitForPortRelease, type RunningApp } from './appProcess.ts';
 
 export type RuntimeSession =
     | { kind: 'started'; app: RunningApp; target: RuntimeTarget }
+    /** An input this gate consumes was never produced; see `requirePrecondition`. */
+    | { kind: 'notAttempted'; precondition: string; detail: string }
     | { kind: 'notApplicable'; reason: NotApplicableReason; detail: string }
     | { kind: 'harnessFault'; message: string; output: string }
     | { kind: 'productFailure'; code: string; message: string; output: string };
@@ -48,18 +50,26 @@ async function openSession(workspaceRoot: string): Promise<RuntimeSession> {
         return { kind: 'notApplicable', reason: resolution.reason, detail: resolution.detail };
     }
     if (resolution.kind === 'noApplication') {
-        // The blame call the resolver deliberately declined to make. Planning artifacts in
-        // the tree prove the agent worked here, so "no application" means it shipped none —
-        // a product failure, and one that must not hide behind a not-applicable verdict.
-        // Without them, the likelier story is that EVALUATE_WORKSPACE points somewhere else,
-        // and blaming the agent for our own misconfiguration is the error that poisons the
-        // corpus invisibly.
+        // Planning artifacts with no application means an earlier phase produced plans and
+        // the scaffold produced nothing. That IS a product failure — but it is not this
+        // gate's to report. The runtime gates consume a scaffolded project; they do not
+        // produce one, and `project-builds` already fails with "no package.json anywhere".
+        //
+        // This branch previously returned a product failure, and it was right for a
+        // single-phase run where nothing upstream had already said so. In a chain it made
+        // one scaffold failure into five: measured, all five runtime gates exited 1 claiming
+        // the agent shipped no runnable application. True once, attributed five times, and
+        // none of it evidence about runtime.
+        //
+        // With no planning artifacts either, nothing upstream demonstrably ran here, so the
+        // likelier story is a misconfigured workspace than a phase that failed — and that
+        // ambiguity belongs to the harness rather than the agent.
         return resolution.workspaceLooksStaged
             ? {
-                kind: 'productFailure',
-                code: 'noApplicationScaffolded',
-                message: `${resolution.detail} The workspace does contain .azure planning artifacts, so the agent worked here and produced no runnable application.`,
-                output: '',
+                kind: 'notAttempted',
+                precondition: 'scaffoldedProject',
+                detail: `${resolution.detail} The workspace does contain .azure planning artifacts, so an earlier phase ran here `
+                    + 'and produced no application for this gate to start.',
             }
             : {
                 kind: 'harnessFault',

--- a/evals/src/runtime/runtimeTarget.ts
+++ b/evals/src/runtime/runtimeTarget.ts
@@ -587,8 +587,14 @@ async function describeMissingNodeProject(workspaceRoot: string): Promise<Runtim
     // No manifest of any kind. Whether that is the agent shipping nothing or the grader
     // looking in the wrong place turns on whether the agent was ever here, so report the
     // evidence and let the caller decide.
-    const staged = await exists(path.join(workspaceRoot, '.azure', 'project-plan.md'))
-        || await exists(path.join(workspaceRoot, '.azure', 'requirements.json'));
+    // Any of the flow's artifacts is evidence an earlier phase ran here, and the later ones
+    // are the stronger evidence: `integration-plan.md` is written by the scaffold agent
+    // itself, so its presence with no application is precisely "scaffold ran and produced
+    // nothing". Checking only for the two planning artifacts missed that, and a workspace
+    // the scaffold phase had demonstrably worked in was read as the wrong directory.
+    const staged = (await Promise.all([
+        'project-plan.md', 'requirements.json', 'integration-plan.md', 'vscode-debug-plan.md',
+    ].map(name => exists(path.join(workspaceRoot, '.azure', name))))).some(Boolean);
     return {
         kind: 'noApplication',
         workspaceLooksStaged: staged,


### PR DESCRIPTION
In a chain run, phase N's output is phase N+1's input with no seeding. So when scaffold fails, the debug gates and all five runtime gates **did not fail — they never ran.**

Measured before building anything, on a workspace with planning artifacts and no scaffold output:

```
runtime-app-starts     -> exit 1
runtime-health         -> exit 1
runtime-frontend       -> exit 1
runtime-frontend-api   -> exit 1
runtime-crud           -> exit 1
```

**Five product failures for one scaffold failure**, each claiming the agent shipped no runnable application. True once, attributed five times, and not one of them is evidence about runtime.

That is `noApplicationScaffolded`, which I added in #1734. It was *correct* for a single-phase run — planning artifacts with no app really is the scaffold agent shipping nothing — and becomes wrong the moment a scaffold gate runs ahead of it and already says so.

After:

```
runtime-app-starts     -> exit 3  NOT_ATTEMPTED reason=scaffoldedProject
runtime-health         -> exit 3  NOT_ATTEMPTED reason=scaffoldedProject
runtime-frontend       -> exit 3  NOT_ATTEMPTED reason=scaffoldedProject
runtime-frontend-api   -> exit 3  NOT_ATTEMPTED reason=scaffoldedProject
runtime-crud           -> exit 3  NOT_ATTEMPTED reason=scaffoldedProject
```

## The rule that makes it a mechanism rather than a relabelling

> **The gate that owns producing an output reports the product failure. Gates that consume it report `notAttempted`.**

One scaffold failure becomes one red and five not-attempted, and attribution lands **exactly once by construction** — not by anyone remembering to suppress the others. `project-builds` keeps failing with "no package.json anywhere"; the runtime gates stop claiming it.

## Per-gate assertion, not a declared dependency table

A harness-level "this gate requires a scaffolded project" declaration would be a second `requires:` table: a hand-maintained claim *about* a gate, living apart from it, with nothing checking the claim matches what the gate does. The first audit of that shape in this repo returned **40% wrong in five rows** — not carelessness, but because a description of code drifts from code silently.

A precondition asserted **inside** the gate cannot drift, because it isn't a description — it runs on the same path as the read it guards. And it is auditable *by execution* (point the gate at a workspace missing the artifact and read what it says), which is the audit that found the 40%, rather than auditable by reading, which is the method that produced it.

"Duplicated nineteen times" was a false choice: one helper, `requirePrecondition`, called by each gate with the precondition it needs. Precision of per-gate, one maintenance point.

## Exit 3, and its own marker

Same argument as `NOT_APPLICABLE_EXIT_CODE`, stronger here: exit 0 would hand a run with a broken scaffold five free passes, so `resolved` would improve **because the product got worse** — optimistic and unrecoverable. The run is already red from the owning gate, so these verdicts don't change the outcome; they change the diagnosis.

`NOT_ATTEMPTED gate= reason= detail=` is a distinct marker rather than a reason code on the existing one, because the three exit-3 verdicts send the reader to three different places:

| verdict | means | reader should |
|---|---|---|
| `NOT_APPLICABLE` | this stack has no such question | check the wiring |
| `GRADER ERROR` | this grader broke | fix the grader |
| `NOT_ATTEMPTED` | an input was never produced | ask the gate upstream |

Collapsed into `GRADER_EXIT_3` they'd be indistinguishable exactly when a chain makes them common.

## A correctness fix that fell out

Staged-ness now counts **any** `.azure` artifact, not just `project-plan.md` / `requirements.json`. `integration-plan.md` is written by the scaffold agent itself, so its presence with no application is precisely "scaffold ran and produced nothing" — and the narrow check read a workspace the scaffold phase had demonstrably worked in as *the wrong directory*.

## Both mutations, asserting codes not colours

| case | asserts |
|---|---|
| `runtime-app-starts-never-scaffolded` (delete `package.json`) | → `runtimeNotAttempted` |
| `runtime-app-crashes-on-boot` (precondition holds, app throws) | → still `appExitedBeforeListening` |

The second is the guard that stops this becoming a universal excuse: a gate whose precondition is satisfied must still be able to fail.

And the new control was **watched failing for its stated reason**, not assumed to work — reverting the fix gives:

```
FAILED CASE: runtime-app-starts-never-scaffolded
             expected=runtimeNotAttempted actual=[noApplicationScaffolded]
```

Certification **87/87**. `typecheck`, `drift` and `check-stacks` green.

## For gateHealth

`notAttempted` must stay out of a pass rate's numerator **and** denominator, exactly like not-applicable. The marker is what lets it be told from a harness fault, and `reason=<preconditionId>` is the join key for grouping a cascade to its cause.
