### PR TITLE
CoR: Fix webview syntax error from apostrophes in initial data

### DIFF
--- a/src/webviews/copilotOnRails/extension/controllers/CopilotOnRailsWebviewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/CopilotOnRailsWebviewController.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { WebviewController } from "@microsoft/vscode-azext-webview";
+import * as vscode from "vscode";
+import { escapeWebviewInitialData } from "../utils/escapeWebviewInitialData";
+
+export class CopilotOnRailsWebviewController<Configuration> extends WebviewController<Configuration> {
+    protected override getDocumentTemplate(webview?: vscode.Webview): string {
+        return escapeWebviewInitialData(super.getDocumentTemplate(webview));
+    }
+}

--- a/src/webviews/copilotOnRails/extension/controllers/CreateProjectViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/CreateProjectViewController.ts
@@ -4,7 +4,6 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, type IActionContext } from "@microsoft/vscode-azext-utils";
-import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { launchAgentAndRecordOutcome } from "../../../../commands/copilotOnRails/openChatWithAgent";
@@ -19,10 +18,11 @@ import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation
 import { openLoadingView } from "../openLoadingView";
 import { recordModel } from "../projectSession";
 import { recordRecentPrompt } from "../recentPrompts";
+import { CopilotOnRailsWebviewController } from "./CopilotOnRailsWebviewController";
 
 export type { CreateProjectViewControllerType };
 
-export class CreateProjectViewController extends WebviewController<CreateProjectViewControllerType> {
+export class CreateProjectViewController extends CopilotOnRailsWebviewController<CreateProjectViewControllerType> {
     constructor(viewConfig: CreateProjectViewControllerType) {
         super(ext.context, viewConfig.title, 'createProjectView', viewConfig, ViewColumn.Active, undefined, getCopilotOnRailsBundleLocation());
 

--- a/src/webviews/copilotOnRails/extension/controllers/DeployResultViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/DeployResultViewController.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { ext } from "../../../../extensionVariables";
 import { type DeployResultData } from "../../views/utils/deployResultTypes";
 import { type DeployResultViewConfiguration, type DeployResultViewStrings } from "../../views/utils/viewConfigTypes";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
+import { CopilotOnRailsWebviewController } from "./CopilotOnRailsWebviewController";
 import { openSourceFileOrWarn } from "../utils/singletonViewHost";
 
 export type { DeployResultViewConfiguration, DeployResultViewStrings };
@@ -78,7 +78,7 @@ function getDeployResultViewStrings(): DeployResultViewStrings {
     };
 }
 
-export class DeployResultViewController extends WebviewController<DeployResultViewConfiguration> {
+export class DeployResultViewController extends CopilotOnRailsWebviewController<DeployResultViewConfiguration> {
     private resultData: DeployResultData;
     private sourceFileUri: vscode.Uri | undefined;
 

--- a/src/webviews/copilotOnRails/extension/controllers/DeploymentPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/DeploymentPlanViewController.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, type IActionContext } from "@microsoft/vscode-azext-utils";
-import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
@@ -16,6 +15,7 @@ import { callWithDiagnosticsAndTelemetryHandling, corId, setCorProp } from "../.
 import { type DeploymentPlanData } from "../../views/utils/deploymentPlanTypes";
 import { type DeploymentPlanViewConfiguration, type DeploymentPlanViewStrings } from "../../views/utils/viewConfigTypes";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
+import { CopilotOnRailsWebviewController } from "./CopilotOnRailsWebviewController";
 import { DEPLOYMENT_PLAN_TELEMETRY_PREFIX, getDeploymentPlanTelemetry } from "../utils/deploymentPlanTelemetryUtils";
 import { openSourceFileOrWarn } from "../utils/singletonViewHost";
 
@@ -70,7 +70,7 @@ function getDeploymentPlanViewStrings(): DeploymentPlanViewStrings {
     };
 }
 
-export class DeploymentPlanViewController extends WebviewController<DeploymentPlanViewConfiguration> {
+export class DeploymentPlanViewController extends CopilotOnRailsWebviewController<DeploymentPlanViewConfiguration> {
     private planData: DeploymentPlanData;
     private sourceFileUri: vscode.Uri | undefined;
 

--- a/src/webviews/copilotOnRails/extension/controllers/FrontendPreviewViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/FrontendPreviewViewController.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, type IActionContext } from "@microsoft/vscode-azext-utils";
-import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
@@ -17,6 +16,7 @@ import { CopilotOnRailsContext } from "../../../../utils/copilotOnRails/CopilotO
 import { callWithDiagnosticsAndTelemetryHandling, corId, setCorProp } from "../../../../utils/copilotOnRails/telemetryUtils";
 import { ProjectPlanStatus } from "../../views/utils/projectPlanStatus";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
+import { CopilotOnRailsWebviewController } from "./CopilotOnRailsWebviewController";
 import { type RunningDevServer, startDevServer } from "../utils/devServerManager";
 import { writeProjectPlanStatus } from "../utils/planStatus";
 
@@ -39,7 +39,7 @@ interface IncomingMessage {
  * UX. Feedback is forwarded to the scaffold agent as a chat prompt; the dev
  * server keeps running so the agent's edits hot-reload in the iframe.
  */
-export class FrontendPreviewViewController extends WebviewController<Record<string, never>> {
+export class FrontendPreviewViewController extends CopilotOnRailsWebviewController<Record<string, never>> {
     private devServer: RunningDevServer | undefined;
     private state: PreviewState = { status: 'starting' };
 

--- a/src/webviews/copilotOnRails/extension/controllers/LoadingViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/LoadingViewController.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, type IActionContext } from "@microsoft/vscode-azext-utils";
-import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { copilotOnRailsCommandIds } from "../../../../commands/copilotOnRails/registerCopilotOnRailsCommands";
@@ -12,12 +11,13 @@ import { ext } from "../../../../extensionVariables";
 import { corId, getCorProjectId } from "../../../../utils/copilotOnRails/telemetryUtils";
 import { type LoadingViewConfiguration } from "../../views/utils/viewConfigTypes";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
+import { CopilotOnRailsWebviewController } from "./CopilotOnRailsWebviewController";
 
 /**
  * Transient webview shown while Copilot generates the artifact (requirements,
  * plan, scaffold) that the next step's view will render.
  */
-export class LoadingViewController extends WebviewController<LoadingViewConfiguration> {
+export class LoadingViewController extends CopilotOnRailsWebviewController<LoadingViewConfiguration> {
     constructor(initialConfig: LoadingViewConfiguration) {
         super(ext.context, initialConfig.title, 'loadingView', initialConfig, ViewColumn.Active, undefined, getCopilotOnRailsBundleLocation());
 

--- a/src/webviews/copilotOnRails/extension/controllers/LocalDevNextStepsViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/LocalDevNextStepsViewController.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, type IActionContext } from "@microsoft/vscode-azext-utils";
-import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { buildChatOpenOptions, ensureCopilotChatReady } from "../../../../commands/copilotOnRails/openChatWithAgent";
@@ -15,10 +14,11 @@ import { callWithDiagnosticsAndTelemetryHandling, corId, setCorProp } from "../.
 import { type LocalDevNextStepsViewConfiguration } from "../../views/utils/viewConfigTypes";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
 import { openLoadingView } from "../openLoadingView";
+import { CopilotOnRailsWebviewController } from "./CopilotOnRailsWebviewController";
 
 type NextStepAction = 'iterate' | 'apiTests' | 'deploy';
 
-export class LocalDevNextStepsViewController extends WebviewController<LocalDevNextStepsViewConfiguration> {
+export class LocalDevNextStepsViewController extends CopilotOnRailsWebviewController<LocalDevNextStepsViewConfiguration> {
     constructor(initialConfig: LocalDevNextStepsViewConfiguration) {
         super(
             ext.context,

--- a/src/webviews/copilotOnRails/extension/controllers/LocalPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/LocalPlanViewController.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, type IActionContext } from "@microsoft/vscode-azext-utils";
-import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { ensureAgentInstructions } from "../../../../commands/copilotOnRails/agentInstructions";
@@ -19,8 +18,9 @@ import { armDebugPlanImplementedWatcher } from "../debugPlanImplementedWatcher";
 import { openLoadingView } from "../openLoadingView";
 import { suppressTrackedViewCloseOnce } from "../projectSession";
 import { openSourceFileOrWarn } from "../utils/singletonViewHost";
+import { CopilotOnRailsWebviewController } from "./CopilotOnRailsWebviewController";
 
-export class LocalPlanViewController extends WebviewController<Record<string, never>> {
+export class LocalPlanViewController extends CopilotOnRailsWebviewController<Record<string, never>> {
     private sourceFileUri: vscode.Uri | undefined;
     private _isRefreshingPrereqs = false;
     private _refreshPrereqsTimer: ReturnType<typeof setTimeout> | undefined;

--- a/src/webviews/copilotOnRails/extension/controllers/RequirementsViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/RequirementsViewController.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, type IActionContext, parseError } from "@microsoft/vscode-azext-utils";
-import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { launchAgentAndRecordOutcome } from "../../../../commands/copilotOnRails/openChatWithAgent";
@@ -19,6 +18,7 @@ import { openLoadingView } from "../openLoadingView";
 import { markRequirementsSubmitted } from "../openRequirementsView";
 import { suppressTrackedViewCloseOnce } from "../projectSession";
 import { getRequirementsTelemetry, REQUIREMENTS_TELEMETRY_PREFIX } from "../utils/requirementsTelemetryUtils";
+import { CopilotOnRailsWebviewController } from "./CopilotOnRailsWebviewController";
 
 interface SubmitMessage {
     command: 'submitRequirements';
@@ -31,7 +31,7 @@ interface ReadyMessage {
 
 type IncomingMessage = SubmitMessage | ReadyMessage;
 
-export class RequirementsViewController extends WebviewController<Record<string, never>> {
+export class RequirementsViewController extends CopilotOnRailsWebviewController<Record<string, never>> {
     private sourceFileUri: vscode.Uri | undefined;
     private requirementsData: RequirementsData;
 

--- a/src/webviews/copilotOnRails/extension/controllers/ScaffoldNextStepsViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/ScaffoldNextStepsViewController.ts
@@ -4,17 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, type IActionContext } from "@microsoft/vscode-azext-utils";
-import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
 import { copilotOnRailsCommandIds } from "../../../../commands/copilotOnRails/registerCopilotOnRailsCommands";
 import { ext } from "../../../../extensionVariables";
 import { callWithDiagnosticsAndTelemetryHandling, corId, setCorProp } from "../../../../utils/copilotOnRails/telemetryUtils";
 import { getCopilotOnRailsBundleLocation } from "../copilotOnRailsBundleLocation";
+import { CopilotOnRailsWebviewController } from "./CopilotOnRailsWebviewController";
 
 type ScaffoldAction = 'setupLocal' | 'deploy';
 
-export class ScaffoldNextStepsViewController extends WebviewController<Record<string, never>> {
+export class ScaffoldNextStepsViewController extends CopilotOnRailsWebviewController<Record<string, never>> {
     constructor(initialConfig: Record<string, never>) {
         super(
             ext.context,

--- a/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/ScaffoldPlanViewController.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, type IActionContext } from "@microsoft/vscode-azext-utils";
-import { WebviewController } from "@microsoft/vscode-azext-webview";
 import * as path from "path";
 import * as vscode from "vscode";
 import { ViewColumn } from "vscode";
@@ -24,11 +23,12 @@ import { replaceProjectPlanStatus, writeProjectPlanStatusAtUri } from "../utils/
 import { PREVIEW_FOLDER_RELATIVE_PATH, readPreviewPages, type PreviewPagesResult } from "../utils/previewPagesReader";
 import { getScaffoldPlanTelemetry, SCAFFOLD_PLAN_TELEMETRY_PREFIX } from "../utils/scaffoldPlanTelemetryUtils";
 import { openSourceFileOrWarn } from "../utils/singletonViewHost";
+import { CopilotOnRailsWebviewController } from "./CopilotOnRailsWebviewController";
 
 /** Prompt to raise max requests for guided runs below this threshold. */
 const MIN_RECOMMENDED_MAX_REQUESTS = 1000;
 
-export class ScaffoldPlanViewController extends WebviewController<Record<string, never>> {
+export class ScaffoldPlanViewController extends CopilotOnRailsWebviewController<Record<string, never>> {
     private sourceFileUri: vscode.Uri | undefined;
     private planData: ScaffoldPlanData;
     private previewFolderUri: vscode.Uri | undefined;

--- a/src/webviews/copilotOnRails/extension/utils/escapeWebviewInitialData.ts
+++ b/src/webviews/copilotOnRails/extension/utils/escapeWebviewInitialData.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const INITIAL_DATA_PREFIX = `_initialData: '`;
+const INITIAL_DATA_SUFFIX = `'\n`;
+
+/**
+ * encodeURIComponent leaves apostrophes unescaped. The shared webview template
+ * embeds its encoded initial data in a single-quoted JavaScript literal, so
+ * escape any apostrophes in that value before VS Code parses the document.
+ */
+export function escapeWebviewInitialData(template: string): string {
+    const prefixIndex = template.indexOf(INITIAL_DATA_PREFIX);
+    if (prefixIndex < 0) {
+        return template;
+    }
+
+    const valueStart = prefixIndex + INITIAL_DATA_PREFIX.length;
+    const valueEnd = template.indexOf(INITIAL_DATA_SUFFIX, valueStart);
+    if (valueEnd < 0) {
+        throw new Error('Unable to locate the end of the webview initial data.');
+    }
+
+    const escapedValue = template.slice(valueStart, valueEnd).replace(/'/g, '%27');
+    return template.slice(0, valueStart) + escapedValue + template.slice(valueEnd);
+}

--- a/src/webviews/copilotOnRails/extension/utils/previewPagesReader.ts
+++ b/src/webviews/copilotOnRails/extension/utils/previewPagesReader.ts
@@ -113,10 +113,9 @@ function preparePreviewHtml(html: string, themeCss: string | undefined): string 
 
 /**
  * Remove any author-supplied executable content. The preview iframe runs with
- * `allow-scripts` so the webview's trusted navigation bridge can drive page
- * switching — author HTML must never be able to run code, so `<script>` tags,
- * inline `on*=…` handlers, and `javascript:` URLs are stripped before the HTML
- * reaches the iframe.
+ * scripts disabled, and the host handles page switching directly. Strip
+ * `<script>` tags, inline `on*=…` handlers, and `javascript:` URLs as defense in
+ * depth before the HTML reaches the iframe.
  */
 function stripAuthorScripts(html: string): string {
     return html

--- a/src/webviews/copilotOnRails/views/components/UiPreviewCard.tsx
+++ b/src/webviews/copilotOnRails/views/components/UiPreviewCard.tsx
@@ -5,7 +5,7 @@
 
 import { Button, Spinner, Tooltip } from '@fluentui/react-components';
 import { CommentEditRegular } from '@fluentui/react-icons';
-import { useEffect, useMemo, useState, type JSX } from 'react';
+import { useMemo, useState, type JSX, type SyntheticEvent } from 'react';
 import { type PaletteEntry, type ScaffoldPlanSection, type PreviewPage, type PreviewStatus } from '../utils/parseScaffoldPlanMarkdown';
 
 interface UiPreviewCardProps {
@@ -36,23 +36,6 @@ interface UiPreviewCardProps {
 }
 
 /**
- * Append the trusted navigation bridge to a preview page's HTML. The bridge is
- * the ONLY script allowed to run in the preview iframe (author scripts are
- * stripped in `previewPagesReader`). It turns a click on a cross-page link
- * (`data-preview-nav="<slug>"`, produced by the reader) into a `previewNavigate`
- * message the card handles by switching tabs, and neutralizes any other
- * navigation so a stray link can't break the sandboxed `about:srcdoc` document.
- * It is stamped with the host CSP nonce so it satisfies the inherited
- * `script-src 'nonce-…'` policy; if the nonce is ever wrong the script is simply
- * blocked and the links fall back to inert `#` anchors (no navigation, but
- * nothing breaks).
- */
-function withNavigationBridge(html: string, nonce: string): string {
-    const bridge = `<script${nonce ? ` nonce="${nonce}"` : ''}>(function(){document.addEventListener('click',function(e){var a=e.target&&e.target.closest?e.target.closest('a'):null;if(!a)return;var slug=a.getAttribute('data-preview-nav');if(slug){e.preventDefault();parent.postMessage({command:'previewNavigate',slug:slug},'*');return;}var href=a.getAttribute('href')||'';if(href&&href.charAt(0)!=='#'){e.preventDefault();}},true);})();</script>`;
-    return html.includes('</body>') ? html.replace('</body>', `${bridge}</body>`) : html + bridge;
-}
-
-/**
  * Read-only view of Section 6 (Design System & UI). The preview itself is a
  * sandboxed iframe loaded with planner-generated HTML/CSS; below it a per-color
  * hex selector lets the user recolor the design. Each pick is applied to the
@@ -67,33 +50,6 @@ export const UiPreviewCard = ({ section, disabled, previewPages, previewStatus, 
     // Live CSS-variable overrides keyed by `--color-*` name. Applied to the
     // iframe HTML on every render so a hex pick recolors the preview instantly.
     const [overrides, setOverrides] = useState<Record<string, string>>({});
-
-    // CSP nonce from the host document — stamped onto the injected navigation
-    // bridge so it satisfies the (inherited) `script-src 'nonce-…'` policy when it
-    // runs inside the sandboxed srcdoc iframe. The base webview template renders
-    // its bootstrap as `<script type="module" nonce="…">`, so read the nonce off
-    // it (the `.nonce` IDL property returns the real value even after the DOM
-    // hides the content attribute).
-    const nonce = useMemo(() => {
-        const el = document.querySelector('script[type="module"]') as HTMLScriptElement | null;
-        return el?.nonce ?? '';
-    }, []);
-
-    // A click on an in-preview cross-page link posts its target slug up from the
-    // sandboxed iframe (via the injected bridge); switch to that page's tab.
-    useEffect(() => {
-        const handler = (event: MessageEvent): void => {
-            const data = event.data as { command?: string; slug?: string } | undefined;
-            if (data?.command === 'previewNavigate' && typeof data.slug === 'string') {
-                const idx = previewPages.findIndex(p => p.slug === data.slug);
-                if (idx >= 0) {
-                    setActivePageIdx(idx);
-                }
-            }
-        };
-        window.addEventListener('message', handler);
-        return () => window.removeEventListener('message', handler);
-    }, [previewPages]);
 
     // The card shows two things: the iframe preview and a color picker.
     // Render whenever either has content — if there's truly nothing to show,
@@ -123,8 +79,8 @@ export const UiPreviewCard = ({ section, disabled, previewPages, previewStatus, 
     // inlined as a trailing `:root { … }` block so the iframe recolors the moment
     // a hex is picked — no regeneration, no feedback round-trip.
     const displayedHtml = useMemo(
-        () => (activePage?.html ? withNavigationBridge(applyOverrides(activePage.html, { ...baseOverrides, ...overrides }), nonce) : undefined),
-        [activePage?.html, baseOverrides, overrides, nonce],
+        () => (activePage?.html ? applyOverrides(activePage.html, { ...baseOverrides, ...overrides }) : undefined),
+        [activePage?.html, baseOverrides, overrides],
     );
 
     if (palette.length === 0 && !hasPages) {
@@ -137,6 +93,31 @@ export const UiPreviewCard = ({ section, disabled, previewPages, previewStatus, 
         const cssVar = cssVarForToken(entry.token);
         setOverrides(prev => ({ ...prev, [cssVar]: newHex }));
         onPaletteChange(entry.token, entry.hex, newHex);
+    };
+
+    const handlePreviewLoad = (event: SyntheticEvent<HTMLIFrameElement>): void => {
+        event.currentTarget.contentDocument?.addEventListener('click', (clickEvent: MouseEvent): void => {
+            const target = clickEvent.target as Element | null;
+            const anchor = target?.closest?.('a');
+            if (!anchor) {
+                return;
+            }
+
+            const slug = anchor.getAttribute('data-preview-nav');
+            if (slug) {
+                clickEvent.preventDefault();
+                const idx = previewPages.findIndex(page => page.slug === slug);
+                if (idx >= 0) {
+                    setActivePageIdx(idx);
+                }
+                return;
+            }
+
+            const href = anchor.getAttribute('href') ?? '';
+            if (href && !href.startsWith('#')) {
+                clickEvent.preventDefault();
+            }
+        }, true);
     };
 
     return (
@@ -196,7 +177,8 @@ export const UiPreviewCard = ({ section, disabled, previewPages, previewStatus, 
                         className='uiPreviewCard__iframe'
                         title={`UI preview for ${activePage.title}`}
                         srcDoc={displayedHtml}
-                        sandbox='allow-same-origin allow-scripts'
+                        sandbox='allow-same-origin'
+                        onLoad={handlePreviewLoad}
                     />
                 )}
             </div>

--- a/test/copilotOnRails/escapeWebviewInitialData.test.ts
+++ b/test/copilotOnRails/escapeWebviewInitialData.test.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { escapeWebviewInitialData } from '../../src/webviews/copilotOnRails/extension/utils/escapeWebviewInitialData';
+
+suite('escapeWebviewInitialData', () => {
+    test('escapes apostrophes only inside the encoded initial data', () => {
+        const template = [
+            `script-src 'self';`,
+            `_initialData: '%7B%22prompt%22%3A%22I'd%20like%20an%20app%22%7D'`,
+            `};`,
+        ].join('\n');
+
+        const escaped = escapeWebviewInitialData(template);
+
+        assert.strictEqual(
+            escaped,
+            [
+                `script-src 'self';`,
+                `_initialData: '%7B%22prompt%22%3A%22I%27d%20like%20an%20app%22%7D'`,
+                `};`,
+            ].join('\n'),
+        );
+    });
+
+    test('leaves templates without the shared initial-data marker unchanged', () => {
+        const template = '<html><body>No inline configuration</body></html>';
+        assert.strictEqual(escapeWebviewInitialData(template), template);
+    });
+});


### PR DESCRIPTION
This fixes that issue where I could not see the initial webview for creating a project.

The shared webview template embeds encodeURIComponent output inside a single-quoted JS literal, but encodeURIComponent does not escape apostrophes. A persisted prompt such as an "I'd like an app" prompt produced a "SyntaxError: Unexpected identifier" that blocked the webview from loading. Add CopilotOnRailsWebviewController to escape apostrophes in the initial-data literal and route every Copilot on Rails view through it.

Also drop allow-scripts from the UI preview iframe (which triggered the sandbox-escape warning) and handle preview navigation from the host on iframe load instead of an injected in-iframe script.