### PR TITLE
Fail the job when the assertions failed, instead of reporting green

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -1557,6 +1557,40 @@ buffering, and fail soft on one bad artifact — sits with the MSBench KustoInge
 
 ## Is this run a result?
 
+**Two different questions, deliberately answered by two different scripts.** *Is this a
+result* and *did it pass* are not the same, and conflating them cost a run.
+
+| Question | Script | Exit codes |
+| --- | --- | --- |
+| Is this a result at all? | [`verify-run.ts`](verify-run.ts) | `0` yes · `75` throttled · `65` wrong model |
+| Did the assertions pass? | [`check-assertions.ts`](check-assertions.ts) | `0` all passed · `1` genuine red · `70` unverifiable |
+
+`verify-run.ts` deliberately does **not** answer the second, and its header says why: *"a
+genuinely red run must keep reporting as a red run, because a detector for false reds is
+worthless if it also hides true ones."* That is right, and it left a hole — nothing was
+asking whether the assertions held.
+
+Run `2026082668713928` is what the hole cost. Four assertions passed, two failed, and:
+
+```
+msbench-cli exit   0
+run.sh exit        0
+GitHub eval job    success
+```
+
+`verify-run.ts` was correct: the run *was* a result. It was simply a failing one, and
+nothing downstream contradicted the green. **A red run reporting green is the worst
+direction for this to point**, because nobody investigates green — the same asymmetry
+that decided the `NOT_APPLICABLE` exit-code ruling.
+
+`run.sh` now runs both, in order, and an **unverifiable** run is reported as a failure
+rather than a pass. That applies to three cases which are indistinguishable from the
+outside: results that cannot be located, a CLI that exits 0 without printing a `run_id`,
+and an `eval.json` that cannot be read. All exit **70**, distinct from the `1` that means
+a genuine product failure, because a harness problem and a regression need different
+people. "We could not tell" and "it passed" are the same thing to whatever reads an exit
+code, so they must not share one.
+
 A finished run is not automatically a *result*. Two things can make the results table
 mean something other than what it looks like, and neither is visible in the table:
 
@@ -2404,6 +2438,26 @@ with a clear message:
   because it explained anything: the artifact scare that prompted the enumeration turned
   out to be a read that predated the run's completion by about five minutes, and member
   order was not the cause. Noted here so nobody re-derives it as one.
+- **Name the field that answers your question before you read one.** Every status
+  surface here has a neighbouring field that looks like the answer and isn't, and
+  reading the neighbour has now cost four separate investigations in two days:
+
+  | Question | Field that answers it | Adjacent field that does not |
+  | --- | --- | --- |
+  | Did the assertions pass? | `eval.json` → `<instance>.resolved`, `<instance>.details[].passed` | the GitHub job status, `msbench-cli` exit code |
+  | Did the CI job fail, or was it cancelled? | the API's `conclusion` | `gh pr checks`, which renders both as `fail` |
+  | Did that command succeed? | `$?` of the command | `$?` after a pipe (that's the *last* stage — use `${PIPESTATUS[0]}`) |
+
+  The trap in `eval.json` is worth spelling out because it caught the person
+  diagnosing it: `resolved` is nested **per instance**, so reading it at the top
+  level returns `undefined`. A check written one way round then reports "not
+  resolved" for the right answer by the wrong route; written the other way round
+  it finds no `passed: false` at the top level and reports a **pass**. Shape:
+
+  ```json
+  { "say_hello": { "resolved": false, "details": [ { "comment": "...", "passed": false } ] } }
+  ```
+
 - **A trailing `echo` after `&&` reports success unconditionally.** `cmd && check; echo
   "done"` prints `done` whether or not `cmd` ran, because `;` is not `&&` — and if
   anything earlier in the chain fails, everything after the `&&` is skipped while the

--- a/evals/msbench/check-assertions.ts
+++ b/evals/msbench/check-assertions.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Decide whether a finished MSBench run's assertions actually *passed*, and make
+ * that the process exit code.
+ *
+ * This exists because a run whose assertions failed was reporting green. Run
+ * 2026082668713928 finished with 4 assertions passing and 2 failing, and:
+ *
+ *   msbench-cli exit   0
+ *   run.sh exit        0
+ *   GitHub eval job    success
+ *
+ * Nothing downstream contradicted any of that. A red run reporting green is the
+ * worst direction for this failure to point, because nobody investigates green —
+ * the same asymmetry that decided the NOT_APPLICABLE exit-code ruling.
+ *
+ * WHY THIS IS NOT PART OF verify-run.ts
+ *
+ * `verify-run.ts` answers a different question — *is this run a result at all*,
+ * i.e. was the agent throttled (75) or did a different model answer (65). Its
+ * header is explicit that "a genuinely red run must keep reporting as a red run,
+ * because a detector for false reds is worthless if it also hides true ones". It
+ * did its job on that run: the run WAS a result. It just happened to be a failing
+ * one, and nothing was asking that question.
+ *
+ * Folding "did it pass" into it would blur the distinction that makes 75 and 65
+ * meaningful. Two questions, two scripts, two exit codes.
+ *
+ * THE SHAPE OF eval.json, WHICH IS ITSELF A TRAP
+ *
+ *   { "<instance>": { "resolved": false, "details": [ { comment, query, passed, error } ] } }
+ *
+ * `resolved` is nested PER INSTANCE. Reading it at the top level yields
+ * `undefined`, which is falsy, which an incautious check would report as "not
+ * resolved" for the right answer by the wrong route — or, worse, a check written
+ * the other way round would see no `passed: false` at the top level and report a
+ * pass. This script reads the instance objects, and fails loudly when it cannot
+ * find any rather than treating an unreadable report as a pass.
+ *
+ * Runs straight off source via Node's built-in type stripping — no build step.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface AssertionDetail {
+    readonly comment?: string;
+    readonly query?: string;
+    readonly exec?: string;
+    readonly passed?: boolean;
+    readonly error?: string | null;
+}
+
+interface InstanceResult {
+    readonly resolved?: boolean;
+    readonly details?: AssertionDetail[];
+}
+
+/** `0` all assertions passed. `1` a genuine red run. `70` the report could not be read. */
+const EXIT_OK = 0;
+const EXIT_RED = 1;
+const EXIT_UNREADABLE = 70; // EX_SOFTWARE
+
+function findEvalJson(root: string): string | undefined {
+    const stack = [root];
+    while (stack.length) {
+        const dir = stack.pop()!;
+        let entries: string[];
+        try {
+            entries = readdirSync(dir);
+        } catch {
+            continue;
+        }
+        for (const entry of entries) {
+            const full = join(dir, entry);
+            let isDirectory: boolean;
+            try {
+                isDirectory = statSync(full).isDirectory();
+            } catch {
+                continue;
+            }
+            if (isDirectory) {
+                stack.push(full);
+            } else if (entry === 'eval.json') {
+                return full;
+            }
+        }
+    }
+    return undefined;
+}
+
+function main(): void {
+    const root = process.argv[2];
+    if (!root || !existsSync(root)) {
+        console.error(`check-assertions.ts: no such directory: ${root ?? '(none given)'}`);
+        process.exit(EXIT_UNREADABLE);
+    }
+
+    const path = findEvalJson(root);
+    if (!path) {
+        // Deliberately not a pass. An unreadable report is the same epistemic
+        // position as an unrun check, and this whole script exists because that
+        // position was being reported as green.
+        console.error(
+            `check-assertions.ts: no eval.json under ${root}.\n` +
+            `Cannot tell whether the assertions passed, so this is NOT reported as a pass.`
+        );
+        process.exit(EXIT_UNREADABLE);
+    }
+
+    let report: Record<string, InstanceResult>;
+    try {
+        report = JSON.parse(readFileSync(path, 'utf8'));
+    } catch (err) {
+        console.error(`check-assertions.ts: ${path} is not readable JSON: ${(err as Error).message}`);
+        process.exit(EXIT_UNREADABLE);
+    }
+
+    const instances = Object.entries(report).filter(([, value]) => value && typeof value === 'object');
+    if (instances.length === 0) {
+        console.error(`check-assertions.ts: ${path} contains no instances.`);
+        process.exit(EXIT_UNREADABLE);
+    }
+
+    const failures: string[] = [];
+    let total = 0;
+
+    for (const [name, instance] of instances) {
+        const details = instance.details ?? [];
+        total += details.length;
+
+        for (const detail of details) {
+            if (detail.passed !== true) {
+                const label = detail.comment ?? detail.query ?? detail.exec ?? '(unnamed assertion)';
+                failures.push(`  ${name}: ${label}${detail.error ? ` [${detail.error}]` : ''}`);
+            }
+        }
+
+        // `resolved` is checked as well as the details, not instead of them. They
+        // are computed from the same data, so they should never disagree — and if
+        // they ever do, that disagreement is itself worth failing on rather than
+        // silently trusting whichever one this script happened to read.
+        if (instance.resolved !== true) {
+            const anyDetailFailed = details.some(d => d.passed !== true);
+            if (!anyDetailFailed) {
+                failures.push(
+                    `  ${name}: resolved is ${JSON.stringify(instance.resolved)} while every assertion passed — ` +
+                    `report is internally inconsistent`
+                );
+            }
+        }
+    }
+
+    if (failures.length > 0) {
+        console.error(
+            `\n${failures.length} of ${total} assertion(s) FAILED:\n${failures.join('\n')}\n\n` +
+            `This run is a genuine red. It is reported as a failure so it cannot be read as a\n` +
+            `pass — an MSBench job that succeeds only tells you the job ran, not that the\n` +
+            `assertions held. Read the transcript before concluding it is a product\n` +
+            `regression: see README.md, "Is this run a result?".`
+        );
+        process.exit(EXIT_RED);
+    }
+
+    console.log(`✔ all ${total} assertion(s) passed across ${instances.length} instance(s).`);
+    process.exit(EXIT_OK);
+}
+
+main();

--- a/evals/msbench/run.sh
+++ b/evals/msbench/run.sh
@@ -380,6 +380,15 @@ set -e
 # verdict; exit 75 means "not a result, retry later" and 65 means "measured the
 # wrong thing", both distinct from the 1 that means a genuine red run.
 RUN_ID="$(grep -oE 'run_id=[0-9]+' "$RUN_LOG" | head -1 | cut -d= -f2 || true)"
+if [ -z "$RUN_ID" ] && [ "$CLI_STATUS" -eq 0 ]; then
+    # The CLI reported success without printing a run id, so there is nothing to
+    # fetch and nothing to verify. Same ruling as the missing-results branch
+    # below: unknown is reported as failure, because an exit code cannot say
+    # "we could not tell" and the reader will take 0 as "it passed".
+    echo "ERROR: msbench-cli exited 0 but printed no run_id, so no results could be" >&2
+    echo "located and this run is UNVERIFIED. Reported as a failure rather than a pass." >&2
+    exit 70
+fi
 if [ -n "$RUN_ID" ]; then
     # msbench-cli writes to `<data_dir>/<run_id>/results.zip`. The default data_dir
     # is platform-specific (macOS Application Support, Linux XDG), and `--data_dir`
@@ -397,16 +406,23 @@ if [ -n "$RUN_ID" ]; then
     done
 
     if [ -z "$RESULTS_ZIP" ]; then
-        # Loud, because the alternative is worse than a failed run. verify-run.ts is
-        # what distinguishes a genuine result from a throttled one or one answered by
-        # the wrong model. If it silently does not run, the CLI's own exit code is
-        # reported as the verdict and an unverified run reads exactly like a verified
-        # one — the vacuous-check failure this suite exists to catch, applied to the
-        # verifier itself. That is precisely what `--data_dir` used to cause in CI.
-        echo "WARNING: run ${RUN_ID} completed but results.zip was not found, so" >&2
-        echo "verify-run.ts did NOT run. This result is UNVERIFIED: a throttled run" >&2
-        echo "or one answered by a different model would look identical to a good one." >&2
+        # Loud AND fatal. verify-run.ts is what distinguishes a genuine result from
+        # a throttled one or one answered by the wrong model, and check-assertions.ts
+        # is what says whether the assertions held. Neither can run without the
+        # results, so at this point the run's verdict is simply unknown.
+        #
+        # Unknown is reported as failure, not as success. "We could not tell" and
+        # "it passed" are the same thing to anyone reading an exit code, and the
+        # whole reason this block exists is that the second reading is
+        # unrecoverable — nobody investigates green. Exit 70 (EX_SOFTWARE) rather
+        # than 1, so an unverifiable run is distinguishable from a genuinely red
+        # one; a harness problem and a product regression need different people.
+        echo "ERROR: run ${RUN_ID} completed but results.zip was not found, so neither" >&2
+        echo "verify-run.ts nor check-assertions.ts could run. This run is UNVERIFIED:" >&2
+        echo "a throttled run, a wrong-model run, and a run whose assertions failed all" >&2
+        echo "look identical from here. Reported as a failure rather than a pass." >&2
         printf '  looked in: %s\n' "${RESULTS_CANDIDATES[@]}" >&2
+        exit 70
     else
         SCRATCH="$(mktemp -d)"
         unzip -oq "$RESULTS_ZIP" -d "$SCRATCH" 2>/dev/null || true
@@ -417,9 +433,29 @@ if [ -n "$RUN_ID" ]; then
         VERIFY_STATUS=$?
         set -e
 
-        rm -rf "$SCRATCH"
         if [ "$VERIFY_STATUS" -ne 0 ]; then
+            rm -rf "$SCRATCH"
             exit "$VERIFY_STATUS"
+        fi
+
+        # Only reached when the run IS a result. verify-run.ts answers "is this
+        # real" — throttled (75), wrong model (65) — and deliberately not "did it
+        # pass", because a detector for false reds that also hides true reds is
+        # worthless. So nothing was asking whether the assertions held.
+        #
+        # Run 2026082668713928 is what that cost: 4 assertions passed, 2 failed,
+        # and msbench-cli exited 0, run.sh exited 0, and the GitHub job reported
+        # success. A red run reporting green is the worst direction for this to
+        # point, because nothing downstream contradicts it and nobody
+        # investigates green.
+        set +e
+        node "${HERE}/check-assertions.ts" "${SCRATCH}/out"
+        ASSERTIONS_STATUS=$?
+        set -e
+
+        rm -rf "$SCRATCH"
+        if [ "$ASSERTIONS_STATUS" -ne 0 ]; then
+            exit "$ASSERTIONS_STATUS"
         fi
     fi
 fi


### PR DESCRIPTION
**CI reported green on a run whose assertions failed.** Run `2026082668713928`: 4 assertions passed, **2 failed**, and:

```
msbench-cli exit   0
run.sh exit        0
GitHub eval job    success
```

Nothing downstream contradicted any of it. A four-phase chain build was nearly authorised on the strength of a probe that had in fact failed.

## `verify-run.ts` was not at fault

It answered its own question correctly. It asks **"is this a result"** — throttled (75), wrong model (65) — and its header is explicit about why it stops there:

> a genuinely red run must keep reporting as a red run, because a detector for false reds is worthless if it also hides true ones

That run **was** a result. It was simply a failing one, and nothing was asking that question.

## The fix: a second, separate check

`check-assertions.ts` is added rather than folding "did it pass" into `verify-run.ts`, which would blur the distinction that makes 75 and 65 mean anything. Two questions, two scripts, two exit codes.

| Question | Script | Exit codes |
| --- | --- | --- |
| Is this a result at all? | `verify-run.ts` | `0` yes · `75` throttled · `65` wrong model |
| Did the assertions pass? | `check-assertions.ts` | `0` passed · `1` genuine red · `70` unverifiable |

### The `70` is the important part

Three cases are indistinguishable from the outside, and **all three previously fell through to exit 0**:

- results that cannot be located,
- a CLI that exits 0 without printing a `run_id`,
- an `eval.json` that cannot be read.

They now exit **70**. *"We could not tell"* and *"it passed"* are the same thing to whatever reads an exit code, so they must not share one — and `70` rather than `1` because a harness problem and a product regression need different people looking.

The missing-results branch previously **warned and continued**, which was the same silent green in a quieter form. It is now fatal.

## `eval.json`'s shape is itself a trap, and it caught me mid-diagnosis

```json
{ "say_hello": { "resolved": false, "details": [ { "comment": "...", "passed": false } ] } }
```

`resolved` is nested **per instance**, so reading it at the top level returns `undefined`. **I reported "resolved: null" from exactly that mistake** — reading the field adjacent to the one that answers the question, which is the error class this PR exists to fix.

A check written one way round then reports "not resolved" for the right answer by the wrong route; written the other way round it finds no `passed: false` at the top level and reports a **pass**. So `check-assertions.ts` reads the instance objects, checks `resolved` **and** the individual details, and fails when they disagree rather than trusting whichever one it happened to read.

## Verification

Testing this for real costs a run, so the script was tested directly and the exit path simulated.

| Case | Exit | Want |
| --- | --- | --- |
| the real failing run (names both failed assertions) | 1 | 1 |
| synthetic all-pass report | 0 | 0 |
| missing `eval.json` | 70 | 70 |
| missing directory | 70 | 70 |
| internally inconsistent report | 1 | 1 |

Full `run.sh` exit path, simulated end to end:

| Scenario | Exit |
| --- | --- |
| real failing run | 1 |
| genuine all-pass | 0 |
| CLI ok, no `run_id` | 70 |
| CLI itself failed | 1 (status preserved) |

Plus `bash -n`, `./run.sh --build-only` (exit 0), and `gates` / `typecheck` / `drift` green.

## README

Adds the general rule, since this is the **fourth** instance in two days:

> **Name the field that answers your question before you read one.**

| Question | Field that answers it | Adjacent field that does not |
| --- | --- | --- |
| Did the assertions pass? | `eval.json` → `<instance>.resolved`, `.details[].passed` | the GitHub job status, `msbench-cli` exit code |
| Did the CI job fail, or was it cancelled? | the API's `conclusion` | `gh pr checks`, which renders both as `fail` |
| Did that command succeed? | `$?` of the command | `$?` after a pipe — that's the *last* stage |

**No run submitted.**