### PR TITLE
Seed the scaffold phase from real planner output, and notice when it goes stale

### DIFF
--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -669,31 +669,57 @@ property wanted here: a seed that silently failed to copy leaves the agent stari
 empty workspace, where it correctly refuses to scaffold and every assertion goes red as
 though the product were broken — after the run has been paid for.
 
-#### The seed is a checked-in fixture, and that was once rejected
+#### The seed is harvested when possible, and a checked-in fixture otherwise
 
-Both plan seeds derive from `evals/local-dev/fixtures/functions-postgres/`, the same
-fixture `evals/local-dev/eval.yaml` uses. This is the option a previous design
-deliberately avoided: `harvest-seed.mjs` (commit `cc75a4e1`, not on `feat/CoR`) promoted
-a finished MSBench run into the scaffold workspace precisely because *"checking one in
-makes that document a second source of truth: edit the planner's template and the stored
-copy still describes the old shape, so the scaffold graders keep passing against a plan
-no agent would emit."*
+[`harvest-seed.ts`](harvest-seed.ts) promotes a real plan-phase run's
+`.azure/project-plan.md` into `seeds/project-plan.md`, and `stage-workspace.ts` prefers
+it. When nothing has been harvested it falls back to
+`evals/local-dev/fixtures/functions-postgres/`, the same fixture
+`evals/local-dev/eval.yaml` uses — so the suite still runs on a machine that has never
+authenticated to MSBench.
 
-That objection is not answered here; it is **bounded**, by the second of the two
-properties that script relied on: *"It is an input, not an expected answer. No scaffold
-grader reads the plan — they assert against `resources/agents/**`. A wrong plan
+```
+npm run seed:harvest -- <plan-run-id>   # from evals/
+npm run seed:check                      # 0 fresh / 1 stale / 2 never harvested
+```
+
+The fallback is the option a previous design deliberately avoided: `harvest-seed.mjs`
+(commit `cc75a4e1`, not on `feat/CoR`) promoted a finished MSBench run into the scaffold
+workspace precisely because *"checking one in makes that document a second source of
+truth: edit the planner's template and the stored copy still describes the old shape, so
+the scaffold graders keep passing against a plan no agent would emit."*
+
+That objection is not answered by the fallback; it is **bounded**, by the second of the
+two properties that script relied on: *"It is an input, not an expected answer. No
+scaffold grader reads the plan — they assert against `resources/agents/**`. A wrong plan
 therefore makes scaffold trials fail loudly; it cannot make them pass wrongly."*
 
 The drift is therefore **fail-safe, not fail-open**. A stale plan makes real runs go red
 for a bad reason — expensive and confusing — but cannot make a broken scaffolder look
-green, which is the failure that would actually matter. What is given up is the drift
-control: `harvest-seed.mjs` had a `--check` mode that reported seed freshness and exited
-1 when stale. Nothing here replaces it. See
-[`config/stimuli/README.md`](config/stimuli/README.md).
+green, which is the failure that would actually matter.
+
+What used to be missing was the drift *control*: `harvest-seed.mjs` had a `--check` mode
+that reported seed freshness and exited 1 when stale, and for a while nothing replaced
+it. `npm run seed:check` does. Harvesting records `agent-assets.lock.json`'s
+`agentAssetsHash` in `seeds/provenance.json`, and the check compares it against the lock
+today — no run, no model, no network, because the question "is this plan still
+representative?" is really "have the planner's instructions changed since it was
+captured?". Its exit 2 (never harvested) is deliberately neither pass nor fail, for the
+reason [#1747](https://github.com/microsoft/vscode-azureresourcegroups/pull/1747) settled
+for gates that never ran. See [`config/stimuli/README.md`](config/stimuli/README.md).
+
+Harvesting is free: `msbench-cli extract` downloads a stored blob and never touches a
+model, and the run's `files` table holds the **full text** of everything the agent wrote.
+[`extraction.ts`](extraction.ts) is shared with [`regrade.ts`](regrade.ts), which rebuilds
+a whole workspace the same way.
+
+Both recipes rewrite the single `**Status**:` line, including the approved one. That
+matters more for a harvested plan than for the fixture, whose status was already
+`Approved`: an agent leaves whatever status it likes behind, so normalising both
+directions is what keeps the pair's sole difference the approval status.
 
 The seed names (`approved-fullstack`, `unapproved-plan`) are that script's own target
-names, reused so that switching to harvested seeds later is a no-op at the stimulus
-level.
+names, reused so that switching to harvested seeds is a no-op at the stimulus level.
 
 #### The `files` table is not a filesystem listing
 

--- a/evals/msbench/README.md
+++ b/evals/msbench/README.md
@@ -713,6 +713,40 @@ model, and the run's `files` table holds the **full text** of everything the age
 [`extraction.ts`](extraction.ts) is shared with [`regrade.ts`](regrade.ts), which rebuilds
 a whole workspace the same way.
 
+##### Verifying it
+
+Two halves, because only one of them can run without credentials.
+
+**Credential-free, and the half CI runs.** `npm run seed:self-test` asserts everything
+between the `files` table and the seed on disk against synthetic extractions: that the
+last write of a plan wins rather than the first, that a plan with no `**Status**:` line is
+rejected at harvest rather than at staging, that the three freshness states stay distinct,
+and — the four that matter most — that an empty `files` table, a run that wrote no plan,
+two candidate plans, and a malformed plan each fail with their *own* message. Those would
+otherwise all arrive as the same confusing red run.
+
+It runs in PR CI as a `check-clean-machine.ts` entrypoint, which also proves the harvester
+imports no packages, so it works on the bare host `run.sh` promises.
+
+**The real link, which needs `msbench-cli` on PATH and `az login`.** Point it at a plan
+run that actually produced a plan — `plan-generation-task-app` did, and its id is in
+[Verified result](#verified-result):
+
+```bash
+cd evals
+npm run seed:harvest -- 2026082614813342   # free: downloads a stored blob
+npm run seed:check                          # 0 fresh
+node msbench/stage-workspace.ts scaffold-fullstack
+```
+
+The last command prints which source it used, and staging a harvested plan is the actual
+proof: `.azure/project-plan.md` in `assets/workspace/` should be the planner's own
+document with `**Status**: Approved`. **Until someone runs that, the link is unproven** —
+`seed:check` reports exit 2 and the suite is still seeding from the fixture.
+
+No `npm ci` is needed for any of it. `harvest-seed.ts` imports only Node builtins, which
+is what the clean-machine entrypoint above exists to keep true.
+
 Both recipes rewrite the single `**Status**:` line, including the approved one. That
 matters more for a harvested plan than for the fixture, whose status was already
 `Approved`: an agent leaves whatever status it likes behind, so normalising both

--- a/evals/msbench/check-clean-machine.ts
+++ b/evals/msbench/check-clean-machine.ts
@@ -98,6 +98,9 @@ const ENTRYPOINTS = [
     { script: 'evals/msbench/stage-graders.ts', args: [] as string[], stagesPackages: true },
     { script: 'evals/msbench/build-config.ts', args: ['photo-app-requirements'] },
     { script: 'evals/msbench/verify-run.ts', args: ['--self-test'] },
+    // Doubles as this suite's harvest coverage: the self-test needs no credentials and
+    // touches no real seed, so the one place it can run is exactly here.
+    { script: 'evals/msbench/harvest-seed.ts', args: ['--self-test'] },
 ];
 
 const failures: string[] = [];

--- a/evals/msbench/config/stimuli/README.md
+++ b/evals/msbench/config/stimuli/README.md
@@ -169,8 +169,9 @@ says so, because the artifact validators have nothing frontend-shaped to inspect
 
 ## What the checked-in seed gives up
 
-`stage-workspace.ts` derives its seeds from a checked-in fixture. That is the
-option `harvest-seed.mjs` was written to avoid, and the objection is real:
+`stage-workspace.ts` falls back to a checked-in fixture when nothing has been
+harvested. That is the option `harvest-seed.mjs` was written to avoid, and the
+objection is real:
 
 > Checking one in makes that document a second source of truth: edit the
 > planner's template and the stored copy still describes the old shape, so the
@@ -186,8 +187,35 @@ So the drift is **fail-safe, not fail-open**: a stale plan makes real runs go re
 for a bad reason — expensive and confusing — but cannot make a broken scaffolder
 look green. The risk is accepted knowingly, not argued away.
 
-The concrete thing lost is the drift control: `harvest-seed.mjs` had a `--check`
-mode that reported seed freshness and exited 1 when the seed was stale, hashed
-against `resources/agents/**`. The checked-in fixture has no equivalent, so
-nothing detects that drift automatically. `npm run drift` in `evals/` covers the
-agent contracts themselves, not the fixture's agreement with them.
+### The drift control is back
+
+For a while the concrete thing lost was the drift *control*: `harvest-seed.mjs`
+had a `--check` mode that reported seed freshness and exited 1 when stale, and
+nothing replaced it. [`harvest-seed.ts`](../../harvest-seed.ts) does now:
+
+```
+npm run seed:harvest -- <plan-run-id>   # promote a real plan-phase run's document
+npm run seed:check                      # 0 fresh / 1 stale / 2 never harvested
+```
+
+Harvesting writes `msbench/seeds/project-plan.md` plus a `provenance.json`
+recording the run it came from and `agent-assets.lock.json`'s `agentAssetsHash`
+at the time. `--check` compares that hash against the lock today, so it needs no
+run, no model and no network. When a harvested plan is present it wins; the
+fixture is the floor that keeps the suite runnable on a machine that has never
+authenticated to MSBench.
+
+Note the division of labour, because the two look similar and are not:
+`npm run drift` checks the agent contracts against themselves, while
+`npm run seed:check` checks whether the *stored plan* still agrees with them.
+
+Exit 2 is deliberately neither pass nor fail. A seed nobody has harvested is not
+a seed that was checked and found current, and collapsing the two is how "we
+could not tell" starts reading as "it passed" — the ruling #1747 already made for
+gates that never ran.
+
+Both seeds are still derived from one document by rewriting the single
+`**Status**:` line, including the approved one. That matters more for a harvested
+plan than it did for the fixture: the agent leaves whatever status it likes
+behind, and normalising both directions is what keeps the pair's sole difference
+the approval status.

--- a/evals/msbench/extraction.ts
+++ b/evals/msbench/extraction.ts
@@ -1,0 +1,162 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Downloading a finished MSBench run's stored results, and finding the per-instance
+ * output trees inside it.
+ *
+ * Extraction is **free** — it reads a stored blob and never touches a model — and that
+ * single property is what both consumers are built on:
+ *
+ *   - `regrade.ts`      re-judges a past run against today's graders for zero tokens.
+ *   - `harvest-seed.ts` promotes a past run's `.azure/project-plan.md` into the scaffold
+ *                       seed, so the scaffold phase starts from real planner output
+ *                       rather than a hand-maintained fixture.
+ *
+ * This lives in its own module because those two want the *same* download and the *same*
+ * notion of "which instances does this extraction contain", and the second arrived long
+ * after the first. Copying it would put the `msbench-cli`-not-on-PATH message, the
+ * auth-failure hint, and — the one that actually matters — the rule that an instance
+ * with no `session.sqlite` is *reported* rather than skipped, in two places that drift.
+ *
+ * Runs straight off source via Node's built-in type stripping — no build step.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+/**
+ * A tool fault rather than a product verdict.
+ *
+ * Both consumers print `.message` alone rather than a stack, so every throw site has to
+ * carry a complete explanation including what to do about it.
+ */
+export class MsBenchToolError extends Error { }
+
+/** Where extractions are cached when no explicit directory is given. Gitignored. */
+export const CACHE_ROOT = join(import.meta.dirname, '.regrade');
+
+export interface Instance {
+    /** Directory name minus the `-output` suffix, e.g. `vscbench.eval.x86_64.say_hello`. */
+    name: string;
+    vscOutput: string;
+    sqlitePath: string;
+    configPath: string;
+    evalJsonPath: string;
+}
+
+export interface ExtractRequest {
+    runId?: string;
+    /** Re-use an existing extraction and skip the download entirely. */
+    extractedDir?: string;
+    /** Where to extract. Defaults to `<CACHE_ROOT>/<run-id>`. */
+    extractDir?: string;
+    /** Narrow the download to a single instance. */
+    instance?: string;
+    /** Download again even when the target directory already holds a usable extraction. */
+    refresh?: boolean;
+}
+
+/**
+ * Callers route diagnostics differently — `regrade.ts` sends them to stderr under
+ * `--json` so stdout stays one parseable document — so the sink is theirs to choose.
+ */
+type Logger = (message: string) => void;
+
+/**
+ * `extract` is free — it only downloads a stored results blob and never touches a
+ * model — but it is not instant, so an existing extraction is reused by default.
+ */
+export function resolveExtraction(request: ExtractRequest, log: Logger = console.log): string {
+    if (request.extractedDir) {
+        const dir = resolve(request.extractedDir);
+        if (!existsSync(dir)) {
+            throw new MsBenchToolError(`--extracted ${dir} does not exist`);
+        }
+        return dir;
+    }
+
+    const { runId, instance: wanted } = request;
+    if (!runId) {
+        throw new MsBenchToolError('No run id to extract');
+    }
+
+    const dir = resolve(request.extractDir ?? join(CACHE_ROOT, runId));
+    // Only reuse a cache that actually holds what was asked for: a cache built by
+    // an earlier `--instance A` must not silently satisfy a later `--instance B`.
+    const cached = findInstances(dir).instances;
+    const satisfiesRequest = cached.length > 0 &&
+        (!wanted || cached.some(candidate => matchesInstance(candidate.name, wanted)));
+
+    if (!request.refresh && satisfiesRequest) {
+        log(`Reusing extraction at ${dir} (--refresh to re-download)`);
+        return dir;
+    }
+
+    mkdirSync(dirname(dir), { recursive: true });
+    const args = ['extract', '--run_id', runId, '--output', dir];
+    if (wanted) {
+        args.push('--instance', wanted);
+    }
+
+    log(`$ msbench-cli ${args.join(' ')}`);
+    const result = spawnSync('msbench-cli', args, { stdio: 'inherit' });
+    if (result.error && (result.error as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new MsBenchToolError(
+            'msbench-cli is not on PATH. Run:\n' +
+            '  export PATH="$HOME/.msbench-venv/bin:$PATH"\n' +
+            'Invoking it by absolute path breaks its plugin discovery, so it has to be on PATH.'
+        );
+    }
+    if (result.status !== 0) {
+        throw new MsBenchToolError(
+            `msbench-cli extract exited ${result.status}. If this is an auth failure, run \`az login\` — ` +
+            'extraction reads a stored blob and needs an Azure identity.'
+        );
+    }
+    return dir;
+}
+
+/** `say_hello` should select `vscbench.eval.x86_64.say_hello`, but not by accident. */
+export function matchesInstance(name: string, requested: string): boolean {
+    return name === requested || name.endsWith(`.${requested}`) || name.includes(requested);
+}
+
+/**
+ * An MSBench extraction holds one `<instance>-output/output/vsc-output` tree per
+ * instance. A directory with no `session.sqlite` is *reported* rather than
+ * quietly skipped: that is an instance whose output blob never arrived —
+ * infrastructure failing rather than a verdict — and dropping it silently would
+ * let a partial extraction report a clean bill of health.
+ */
+export function findInstances(root: string): { instances: Instance[]; incomplete: string[] } {
+    if (!existsSync(root)) {
+        return { instances: [], incomplete: [] };
+    }
+    const instances: Instance[] = [];
+    const incomplete: string[] = [];
+
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
+        if (!entry.isDirectory() || !entry.name.endsWith('-output')) {
+            continue;
+        }
+        const vscOutput = join(root, entry.name, 'output', 'vsc-output');
+        const sqlitePath = join(vscOutput, 'session.sqlite');
+        const name = entry.name.replace(/-output$/, '');
+        if (!existsSync(sqlitePath)) {
+            incomplete.push(name);
+            continue;
+        }
+        instances.push({
+            name,
+            vscOutput,
+            sqlitePath,
+            configPath: join(vscOutput, 'configs', 'final-agent-config.json'),
+            evalJsonPath: join(vscOutput, 'eval.json'),
+        });
+    }
+    return { instances: instances.sort((a, b) => a.name.localeCompare(b.name)), incomplete };
+}

--- a/evals/msbench/harvest-seed.ts
+++ b/evals/msbench/harvest-seed.ts
@@ -63,12 +63,14 @@
  * `npm run seed:check` pass it.
  */
 
-import { resolve } from 'node:path';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { findInstances, matchesInstance, MsBenchToolError, resolveExtraction, type Instance } from './extraction.ts';
 import {
     checkFreshness, currentAgentAssetsHash, EXIT_FRESH, EXIT_NOT_HARVESTED, EXIT_STALE, EXIT_TOOL_ERROR,
-    HARVESTED_PLAN, PROVENANCE_PATH, writeSeed, type Freshness, type Provenance,
+    freshnessOf, HARVESTED_PLAN, PROVENANCE_PATH, writeSeed, type Freshness, type Provenance,
 } from './seed-store.ts';
 
 /** Anchored to the `.azure/` directory so a stray `docs/project-plan.md` cannot match. */
@@ -88,6 +90,8 @@ Options:
                     provenance that cannot name its run is not auditable.
   --check           Report whether the harvested seed is still current, and exit
                     0 (fresh) / 1 (stale) / 2 (never harvested).
+  --self-test       Assert this tool's behaviour against synthetic extractions.
+                    Needs no credentials and touches no real seed.
   -h, --help        Show this help.
 
 Harvesting requires \`msbench-cli\` on PATH; --check is purely local:
@@ -261,6 +265,170 @@ function harvest(runId: string, wanted: string | undefined, extractedDir: string
 }
 
 // ---------------------------------------------------------------------------
+// Self-test
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert this tool's behaviour against synthetic extractions. Run with
+ * `node harvest-seed.ts --self-test`.
+ *
+ * The real link — harvesting a genuine plan out of a genuine MSBench run — needs
+ * `msbench-cli` and an Azure identity, so it cannot run in PR CI. What *can* run is
+ * everything between the `files` table and the seed on disk, which is where all the
+ * decisions live. A synthetic `session.sqlite` is a faithful stand-in for that half:
+ * `regrade.ts` documents the schema this reads, and the rows here are the same shape.
+ *
+ * It matters that the failure cases are covered rather than just the happy path. Four of
+ * the five assertions below are about *distinguishing* failures that would otherwise
+ * arrive as the same confusing red run — an empty table and an agent that wrote no plan
+ * are one keystroke apart in the query and a day apart in the diagnosis.
+ *
+ * Nothing here touches the real `seeds/` directory: the harvest pieces are called
+ * individually rather than through `harvest()`, and the freshness states go through the
+ * pure `freshnessOf`.
+ */
+function selfTest(): number {
+    const failures: string[] = [];
+    const root = mkdtempSync(join(tmpdir(), 'harvest-seed-selftest-'));
+
+    const check = (name: string, run: () => void): void => {
+        try {
+            run();
+            console.log(`  ok    ${name}`);
+        } catch (error) {
+            failures.push(name);
+            console.log(`  FAIL  ${name}`);
+            console.log(`          ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`);
+        }
+    };
+
+    /** Build one synthetic extraction and return the instance inside it. */
+    const build = (name: string, rows: [string, string, number][]): Instance => {
+        const dir = join(root, name);
+        const vsc = join(dir, `vscbench.eval.x86_64.${name}-output`, 'output', 'vsc-output');
+        mkdirSync(vsc, { recursive: true });
+        const db = new DatabaseSync(join(vsc, 'session.sqlite'));
+        db.exec('CREATE TABLE files (id INTEGER PRIMARY KEY, path TEXT, content TEXT, stepIndex INTEGER)');
+        const insert = db.prepare('INSERT INTO files (path, content, stepIndex) VALUES (?, ?, ?)');
+        for (const [path, content, stepIndex] of rows) {
+            insert.run(path, content, stepIndex);
+        }
+        db.close();
+        return selectInstance(dir, undefined);
+    };
+
+    const expectThrows = (fragment: string, run: () => void): void => {
+        let message: string | undefined;
+        try {
+            run();
+        } catch (error) {
+            message = error instanceof Error ? error.message : String(error);
+        }
+        if (message === undefined) {
+            throw new Error(`expected a failure mentioning ${JSON.stringify(fragment)}, but it succeeded`);
+        }
+        if (!message.includes(fragment)) {
+            throw new Error(`expected ${JSON.stringify(fragment)}, got: ${message.split('\n')[0]}`);
+        }
+    };
+
+    try {
+        console.log('Harvest');
+
+        check('the last write of the plan wins, not the first', () => {
+            const instance = build('supersede', [
+                ['.azure/project-plan.md', '**Status**: Planning\n\nearly draft\n', 0],
+                ['.azure/project-plan.md', '**Status**: Planning\n\nfinal\n', 1],
+            ]);
+            const { content } = readPlanFromRun(instance);
+            if (!content.includes('final') || content.includes('early draft')) {
+                throw new Error(`took the wrong revision: ${JSON.stringify(content)}`);
+            }
+        });
+
+        // `snapshotWorkspace: false` and "the agent declined to write a plan" are the two
+        // findings this pair keeps apart. Both would otherwise read as "no plan found".
+        check('an empty files table is reported as a captured-nothing run', () => {
+            const instance = build('empty', []);
+            expectThrows('the files table is empty', () => readPlanFromRun(instance));
+        });
+
+        check('a run that wrote files but no plan says so differently', () => {
+            const instance = build('noplan', [['.azure/requirements.json', '{}', 0]]);
+            expectThrows('no .azure/project-plan.md among the', () => readPlanFromRun(instance));
+        });
+
+        check('two candidate plans are refused rather than guessed between', () => {
+            const instance = build('ambiguous', [
+                ['.azure/project-plan.md', '**Status**: Planning\n', 0],
+                ['nested/.azure/project-plan.md', '**Status**: Planning\n', 0],
+            ]);
+            expectThrows('candidate plans', () => readPlanFromRun(instance));
+        });
+
+        // Without this the seed pair silently stops discriminating: both members would
+        // carry the same status and `scaffold-unapproved-plan` becomes a copy of
+        // `scaffold-fullstack` that still reports green.
+        check('a plan with no status line is rejected at harvest, not at staging', () => {
+            expectThrows("'**Status**: ...' lines", () => assertPlanIsUsable('# Plan\n\nno status\n', 'synthetic'));
+        });
+
+        check('a plan with two status lines is rejected too', () => {
+            expectThrows("'**Status**: ...' lines", () =>
+                assertPlanIsUsable('**Status**: Approved\n**Status**: Planning\n', 'synthetic'));
+        });
+
+        console.log('\nFreshness');
+
+        const provenance: Provenance = {
+            runId: '2026082614813342',
+            instance: 'vscbench.eval.x86_64.plan',
+            harvestedAt: '2026-08-26T00:00:00.000Z',
+            agentAssetsHash: 'a'.repeat(64),
+            sourcePath: '.azure/project-plan.md',
+        };
+
+        check('a matching hash is fresh', () => {
+            const state = freshnessOf(provenance, 'a'.repeat(64)).state;
+            if (state !== 'fresh') {
+                throw new Error(`expected fresh, got ${state}`);
+            }
+        });
+
+        check('a changed hash is stale, and not merely unknown', () => {
+            const state = freshnessOf(provenance, 'b'.repeat(64)).state;
+            if (state !== 'stale') {
+                throw new Error(`expected stale, got ${state}`);
+            }
+        });
+
+        // The distinction #1747 settled: never-run is not the same as passed.
+        check('no provenance is not-harvested, which is neither fresh nor stale', () => {
+            const state = freshnessOf(null, 'a'.repeat(64)).state;
+            if (state !== 'not-harvested') {
+                throw new Error(`expected not-harvested, got ${state}`);
+            }
+        });
+
+        check('the three states map to three different exit codes', () => {
+            const codes = new Set([EXIT_FRESH, EXIT_STALE, EXIT_NOT_HARVESTED]);
+            if (codes.size !== 3) {
+                throw new Error('freshness states share an exit code, so a caller cannot tell them apart');
+            }
+        });
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+
+    if (failures.length) {
+        console.error(`\n${failures.length} harvest-seed case(s) failed.`);
+        return EXIT_TOOL_ERROR;
+    }
+    console.log('\nPASS: harvest-seed self-test.');
+    return EXIT_FRESH;
+}
+
+// ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
 
@@ -270,6 +438,7 @@ function main(): number {
     let instance: string | undefined;
     let extractedDir: string | undefined;
     let check = false;
+    let selfTestOnly = false;
 
     for (let index = 0; index < argv.length; index++) {
         const arg = argv[index];
@@ -277,6 +446,9 @@ function main(): number {
             case '-h': case '--help':
                 console.log(USAGE);
                 return EXIT_FRESH;
+            case '--self-test':
+                selfTestOnly = true;
+                break;
             case '--check':
                 check = true;
                 break;
@@ -305,6 +477,13 @@ function main(): number {
                 }
                 runId = arg;
         }
+    }
+
+    if (selfTestOnly) {
+        if (runId || check) {
+            throw new MsBenchToolError('--self-test runs alone.');
+        }
+        return selfTest();
     }
 
     if (check) {

--- a/evals/msbench/harvest-seed.ts
+++ b/evals/msbench/harvest-seed.ts
@@ -88,6 +88,9 @@ Options:
   --extracted <dir> Harvest from an already-extracted directory instead of
                     downloading. The run id is still required, because
                     provenance that cannot name its run is not auditable.
+  --extract-dir <d> Where to extract (default: evals/msbench/.regrade/<run-id>).
+                    Use a short path on Windows: these archives contain ~290
+                    character log paths, and MAX_PATH is 260.
   --check           Report whether the harvested seed is still current, and exit
                     0 (fresh) / 1 (stale) / 2 (never harvested).
   --self-test       Assert this tool's behaviour against synthetic extractions.
@@ -135,8 +138,15 @@ function reportFreshness(freshness: Freshness): number {
 
 function selectInstance(root: string, wanted: string | undefined): Instance {
     const { instances, incomplete } = findInstances(root);
+    // Two different causes, and the fix differs: the run's output blob never arrived, or
+    // the local extraction could not write every file. On Windows the second is the usual
+    // one and does not look like a path problem from here — the archives carry ~290
+    // character log paths and MAX_PATH is 260, so the unzip stops partway and
+    // `session.sqlite` is simply absent.
     const describeIncomplete = incomplete.length
-        ? `\nInstances with no session.sqlite (output blob never arrived): ${incomplete.join(', ')}`
+        ? `\nInstances with no session.sqlite: ${incomplete.join(', ')}\n` +
+        '  Either the run produced no output blob, or the extraction could not write every\n' +
+        '  file. On Windows, retry somewhere short first: --extract-dir C:\\mb'
         : '';
 
     if (instances.length === 0) {
@@ -240,8 +250,8 @@ function assertPlanIsUsable(content: string, source: string): void {
     }
 }
 
-function harvest(runId: string, wanted: string | undefined, extractedDir: string | undefined): void {
-    const root = resolveExtraction({ runId, instance: wanted, extractedDir });
+function harvest(runId: string, wanted: string | undefined, extractedDir: string | undefined, extractDir: string | undefined): void {
+    const root = resolveExtraction({ runId, instance: wanted, extractedDir, extractDir });
     const instance = selectInstance(root, wanted);
     const { path, content } = readPlanFromRun(instance);
     assertPlanIsUsable(content, `${instance.name} ${path}`);
@@ -437,6 +447,7 @@ function main(): number {
     let runId: string | undefined;
     let instance: string | undefined;
     let extractedDir: string | undefined;
+    let extractDir: string | undefined;
     let check = false;
     let selfTestOnly = false;
 
@@ -466,6 +477,14 @@ function main(): number {
                     throw new MsBenchToolError('--extracted needs a value');
                 }
                 extractedDir = value;
+                break;
+            }
+            case '--extract-dir': {
+                const value = argv[++index];
+                if (value === undefined) {
+                    throw new MsBenchToolError('--extract-dir needs a value');
+                }
+                extractDir = value;
                 break;
             }
             default:
@@ -499,7 +518,7 @@ function main(): number {
     if (!runId) {
         throw new MsBenchToolError(`Give a run id to harvest, or --check.\n\n${USAGE}`);
     }
-    harvest(runId, instance, extractedDir);
+    harvest(runId, instance, extractedDir, extractDir);
     return EXIT_FRESH;
 }
 

--- a/evals/msbench/harvest-seed.ts
+++ b/evals/msbench/harvest-seed.ts
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Promote a finished plan-phase run's `.azure/project-plan.md` into the scaffold seed,
+ * and report when that seed has gone stale.
+ *
+ *   node harvest-seed.ts 2026082614813342     # harvest a real plan from a real run
+ *   node harvest-seed.ts --check              # is the harvested seed still current?
+ *
+ * ── The problem this closes ────────────────────────────────────────────────────────
+ *
+ * The scaffold and local-dev phases need an approved `.azure/project-plan.md` on disk
+ * before turn 0, and until now it was a checked-in fixture. `stage-workspace.ts`
+ * documents the objection to that, quoting the design that rejected it first:
+ *
+ *   > Checking one in makes that document a second source of truth: edit the planner's
+ *   > template and the stored copy still describes the old shape, so the scaffold graders
+ *   > keep passing against a plan no agent would emit.
+ *
+ * The objection is bounded rather than answered — the plan is an *input, not an expected
+ * answer*, so a stale one makes scaffold trials fail **loudly** and cannot make a broken
+ * scaffolder look green. Fail-safe, not fail-open.
+ *
+ * But one thing was given up outright: the original `harvest-seed.mjs` had a `--check`
+ * that reported seed freshness and exited 1 when stale, and **nothing replaced it**. So
+ * the fixture could drift from what the planner emits with no symptom but an expensive,
+ * confusing red run. This restores both halves — the harvest and the check.
+ *
+ * ── Why the check is free, and why it hashes the agent rather than the plan ─────────
+ *
+ * A plan's shape is determined by the planner's instructions. So "is this stored plan
+ * still representative?" is really "have the planner's instructions changed since it was
+ * captured?" — and that is answerable locally, with no run, no model and no network.
+ *
+ * Harvesting records `agent-assets.lock.json`'s `agentAssetsHash` alongside the document;
+ * `--check` compares it against the lock today. See `seed-store.ts` for why the lock is
+ * read rather than recomputed.
+ *
+ * Note that this over-triggers slightly — the hash covers the planner's whole asset tree,
+ * so an edit that cannot change the plan's shape still marks the seed stale. That is the
+ * intended direction. Missing a real drift is fail-open; re-harvesting unnecessarily
+ * costs one free extraction.
+ *
+ * ── Exit codes ─────────────────────────────────────────────────────────────────────
+ *
+ *   0 — the harvested seed is current
+ *   1 — the harvested seed is stale: the planner's assets changed since it was captured
+ *   2 — nothing has been harvested, so the checked-in fixture is in use and its
+ *       freshness is *unknown*
+ *   3 — the tool itself could not run
+ *
+ * Exit 2 is deliberately neither 0 nor 1, for the reason #1747 settled for gates: a check
+ * that never ran is not the same as a check that passed, and collapsing them is how "we
+ * could not tell" starts reading as "it passed". It is separate from 1 because the two
+ * want different actions — 1 means re-harvest, 2 means nobody has started.
+ *
+ * Runs straight off source via Node's built-in type stripping — no build step. Needs
+ * `--disable-warning=ExperimentalWarning` for `node:sqlite`; `npm run seed:harvest` and
+ * `npm run seed:check` pass it.
+ */
+
+import { resolve } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { findInstances, matchesInstance, MsBenchToolError, resolveExtraction, type Instance } from './extraction.ts';
+import {
+    checkFreshness, currentAgentAssetsHash, EXIT_FRESH, EXIT_NOT_HARVESTED, EXIT_STALE, EXIT_TOOL_ERROR,
+    HARVESTED_PLAN, PROVENANCE_PATH, writeSeed, type Freshness, type Provenance,
+} from './seed-store.ts';
+
+/** Anchored to the `.azure/` directory so a stray `docs/project-plan.md` cannot match. */
+const PLAN_PATH = '.azure/project-plan.md';
+
+const USAGE = `Promote a plan-phase run's .azure/project-plan.md into the scaffold seed.
+
+Usage:
+  node harvest-seed.ts <run-id> [--instance <id>]
+  node harvest-seed.ts <run-id> --extracted <dir>
+  node harvest-seed.ts --check
+
+Options:
+  --instance <id>   Pick one instance when the run holds several.
+  --extracted <dir> Harvest from an already-extracted directory instead of
+                    downloading. The run id is still required, because
+                    provenance that cannot name its run is not auditable.
+  --check           Report whether the harvested seed is still current, and exit
+                    0 (fresh) / 1 (stale) / 2 (never harvested).
+  -h, --help        Show this help.
+
+Harvesting requires \`msbench-cli\` on PATH; --check is purely local:
+  export PATH="$HOME/.msbench-venv/bin:$PATH"`;
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+function reportFreshness(freshness: Freshness): number {
+    switch (freshness.state) {
+        case 'not-harvested':
+            console.log('Seed: not harvested.');
+            console.log(`  No ${PROVENANCE_PATH}, so the scaffold phase uses the checked-in fixture at`);
+            console.log('  evals/local-dev/fixtures/functions-postgres/.azure/project-plan.md.');
+            console.log('  That fixture is fail-safe, but its freshness is unknown. To fix that:');
+            console.log('    npm run seed:harvest -- <plan-run-id>');
+            return EXIT_NOT_HARVESTED;
+
+        case 'stale':
+            console.log('Seed: STALE.');
+            console.log(`  Harvested from run ${freshness.provenance.runId} at ${freshness.provenance.harvestedAt}`);
+            console.log(`    captured agentAssetsHash: ${freshness.provenance.agentAssetsHash}`);
+            console.log(`    current  agentAssetsHash: ${freshness.current}`);
+            console.log("  The planner's assets changed since this plan was captured, so it may describe");
+            console.log('  a shape the planner would no longer emit. Re-harvest from a run made against');
+            console.log('  the current agents.');
+            return EXIT_STALE;
+
+        case 'fresh':
+            console.log('Seed: current.');
+            console.log(`  Harvested from run ${freshness.provenance.runId} at ${freshness.provenance.harvestedAt}`);
+            console.log(`  agentAssetsHash ${freshness.provenance.agentAssetsHash} matches the lock.`);
+            return EXIT_FRESH;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Harvest
+// ---------------------------------------------------------------------------
+
+function selectInstance(root: string, wanted: string | undefined): Instance {
+    const { instances, incomplete } = findInstances(root);
+    const describeIncomplete = incomplete.length
+        ? `\nInstances with no session.sqlite (output blob never arrived): ${incomplete.join(', ')}`
+        : '';
+
+    if (instances.length === 0) {
+        throw new MsBenchToolError(`No instance output found under ${root}.${describeIncomplete}`);
+    }
+
+    const candidates = wanted
+        ? instances.filter(instance => matchesInstance(instance.name, wanted))
+        : instances;
+
+    if (candidates.length === 0) {
+        throw new MsBenchToolError(
+            `No instance matches '${wanted}'. Available:\n` +
+            instances.map(instance => `  ${instance.name}`).join('\n') + describeIncomplete
+        );
+    }
+    // Refuse to guess. Picking the first of several would silently decide whose plan
+    // becomes the seed for everyone, and the provenance file would then record that
+    // accident as though it had been a deliberate choice.
+    if (candidates.length > 1) {
+        throw new MsBenchToolError(
+            `${candidates.length} instances match${wanted ? ` '${wanted}'` : ''}. Narrow with --instance:\n` +
+            candidates.map(instance => `  ${instance.name}`).join('\n')
+        );
+    }
+    return candidates[0];
+}
+
+/**
+ * Pull the run's final `.azure/project-plan.md` out of the `files` table.
+ *
+ * Highest `stepIndex` wins, which is the document as it stood when the run ended — the
+ * same rule `regrade.ts` uses to rebuild a whole workspace.
+ */
+function readPlanFromRun(instance: Instance): { path: string; content: string } {
+    const db = new DatabaseSync(instance.sqlitePath, { readOnly: true });
+    try {
+        const total = (db.prepare('SELECT COUNT(*) AS n FROM files').get() as { n: number }).n;
+        // "The table is empty" and "the agent wrote no plan" are different findings with
+        // different fixes, and an empty table makes every path query vacuously unhelpful.
+        // Saying which one happened is the difference between a five-minute fix and an
+        // afternoon.
+        if (total === 0) {
+            throw new MsBenchToolError(
+                `${instance.name}: the files table is empty.\n` +
+                'That means the run captured no workspace at all — a phase with\n' +
+                '`snapshotWorkspace: false`, or a run that produced nothing — rather than an agent\n' +
+                'that declined to write a plan. Harvest from a plan-phase run.'
+            );
+        }
+
+        const rows = db.prepare('SELECT path, content, stepIndex FROM files ORDER BY stepIndex ASC, id ASC')
+            .all() as { path: string; content: string; stepIndex: number }[];
+
+        const latest = new Map<string, string>();
+        for (const row of rows) {
+            latest.set(row.path, row.content);
+        }
+
+        const matches = [...latest].filter(([path]) => path === PLAN_PATH || path.endsWith(`/${PLAN_PATH}`));
+        if (matches.length === 0) {
+            throw new MsBenchToolError(
+                `${instance.name}: no ${PLAN_PATH} among the ${latest.size} file(s) the agent wrote.\n` +
+                'The run reached the agent but it never produced a plan, so there is nothing to\n' +
+                'promote. Harvest from a run whose plan assertion passed.'
+            );
+        }
+        if (matches.length > 1) {
+            throw new MsBenchToolError(
+                `${instance.name}: ${matches.length} candidate plans, so which one is the seed is ambiguous:\n` +
+                matches.map(([path]) => `  ${path}`).join('\n')
+            );
+        }
+
+        const [path, content] = matches[0];
+        return { path, content };
+    } finally {
+        db.close();
+    }
+}
+
+/**
+ * Fail here rather than at staging time.
+ *
+ * `stage-workspace.ts` derives both seeds by rewriting the single `**Status**:` line, and
+ * asserts there is exactly one to rewrite — because a silent no-op there turns the
+ * unapproved stimulus into a duplicate of the approved one that still reports green. A
+ * harvested document that cannot satisfy that guard has to be rejected now, on a
+ * developer machine, rather than when a paid run is already staging.
+ */
+function assertPlanIsUsable(content: string, source: string): void {
+    const matches = content.match(/^\*\*Status\*\*:\s*(.+)$/gm) ?? [];
+    if (matches.length !== 1) {
+        throw new MsBenchToolError(
+            `The harvested plan has ${matches.length} '**Status**: ...' lines; exactly one is required.\n` +
+            `  source: ${source}\n` +
+            'Both seed recipes are produced by rewriting that line, so a document without exactly\n' +
+            'one of them would make scaffold-unapproved-plan a silent duplicate of\n' +
+            'scaffold-fullstack that still reports green while testing nothing.'
+        );
+    }
+}
+
+function harvest(runId: string, wanted: string | undefined, extractedDir: string | undefined): void {
+    const root = resolveExtraction({ runId, instance: wanted, extractedDir });
+    const instance = selectInstance(root, wanted);
+    const { path, content } = readPlanFromRun(instance);
+    assertPlanIsUsable(content, `${instance.name} ${path}`);
+
+    const provenance: Provenance = {
+        runId,
+        instance: instance.name,
+        harvestedAt: new Date().toISOString(),
+        agentAssetsHash: currentAgentAssetsHash(),
+        sourcePath: path,
+    };
+    writeSeed(content, provenance);
+
+    console.log(`Harvested ${path} from ${instance.name}`);
+    console.log(`  -> ${HARVESTED_PLAN} (${content.length} bytes)`);
+    console.log(`  -> ${PROVENANCE_PATH}`);
+    console.log(`  agentAssetsHash ${provenance.agentAssetsHash}`);
+    console.log('');
+    console.log('The scaffold and local-dev phases now seed from real planner output.');
+    console.log('Commit both files: a seed only helps CI if it travels with the repository.');
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+function main(): number {
+    const argv = process.argv.slice(2);
+    let runId: string | undefined;
+    let instance: string | undefined;
+    let extractedDir: string | undefined;
+    let check = false;
+
+    for (let index = 0; index < argv.length; index++) {
+        const arg = argv[index];
+        switch (arg) {
+            case '-h': case '--help':
+                console.log(USAGE);
+                return EXIT_FRESH;
+            case '--check':
+                check = true;
+                break;
+            case '--instance': {
+                const value = argv[++index];
+                if (value === undefined) {
+                    throw new MsBenchToolError('--instance needs a value');
+                }
+                instance = value;
+                break;
+            }
+            case '--extracted': {
+                const value = argv[++index];
+                if (value === undefined) {
+                    throw new MsBenchToolError('--extracted needs a value');
+                }
+                extractedDir = value;
+                break;
+            }
+            default:
+                if (arg.startsWith('-')) {
+                    throw new MsBenchToolError(`Unknown option ${arg}\n\n${USAGE}`);
+                }
+                if (runId) {
+                    throw new MsBenchToolError(`Unexpected second run id '${arg}'`);
+                }
+                runId = arg;
+        }
+    }
+
+    if (check) {
+        if (runId) {
+            throw new MsBenchToolError('--check reports on the stored seed and takes no run id.');
+        }
+        return reportFreshness(checkFreshness());
+    }
+
+    // Required even with `--extracted`. The provenance file's whole job is to say which
+    // run a seed came from, and one that recorded a local directory path instead would
+    // be unauditable on any other machine.
+    if (!runId) {
+        throw new MsBenchToolError(`Give a run id to harvest, or --check.\n\n${USAGE}`);
+    }
+    harvest(runId, instance, extractedDir);
+    return EXIT_FRESH;
+}
+
+// Only when run directly — importing this module must not extract a run as a side effect.
+// `stage-workspace.ts` deliberately imports `seed-store.ts` instead of this file, so that
+// staging never pulls in `node:sqlite`.
+if (process.argv[1] && resolve(process.argv[1]) === import.meta.filename) {
+    try {
+        process.exit(main());
+    } catch (error) {
+        console.error(error instanceof MsBenchToolError ? error.message : error instanceof Error ? (error.stack ?? error.message) : String(error));
+        process.exit(EXIT_TOOL_ERROR);
+    }
+}

--- a/evals/msbench/regrade.ts
+++ b/evals/msbench/regrade.ts
@@ -84,17 +84,15 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, normalize, resolve, sep } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { fileURLToPath } from 'node:url';
+import { findInstances, matchesInstance, MsBenchToolError, resolveExtraction, type Instance } from './extraction.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, '..', '..');
-
-/** Default extraction cache. Gitignored; reused across iterations so re-grading is a local operation. */
-const CACHE_ROOT = join(HERE, '.regrade');
 
 /**
  * `stage-graders.ts` copies the grader tree into the container preserving
@@ -152,15 +150,6 @@ interface StoredEval {
     details: { comment: string; query: string; passed: boolean; error: string | null }[];
 }
 
-interface Instance {
-    /** Directory name minus the `-output` suffix, e.g. `vscbench.eval.x86_64.say_hello`. */
-    name: string;
-    vscOutput: string;
-    sqlitePath: string;
-    configPath: string;
-    evalJsonPath: string;
-}
-
 interface Options {
     runId?: string;
     extractedDir?: string;
@@ -172,7 +161,12 @@ interface Options {
     json: boolean;
 }
 
-class RegradeError extends Error { }
+/**
+ * A regrade-specific tool fault. Extends the shared error so the top-level handler can
+ * treat a failure raised inside `extraction.ts` exactly like one raised here — both are
+ * the tool failing rather than a product verdict, and both print a message, not a stack.
+ */
+class RegradeError extends MsBenchToolError { }
 
 /**
  * Diagnostics go to stderr whenever `--json` is on, so stdout stays a single
@@ -250,107 +244,6 @@ function parseArgs(argv: string[]): Options {
         throw new RegradeError(`Give a run id or --extracted <dir>.\n\n${USAGE}`);
     }
     return options;
-}
-
-// ---------------------------------------------------------------------------
-// Extraction
-// ---------------------------------------------------------------------------
-
-/**
- * `extract` is free — it only downloads a stored results blob and never touches a
- * model — but it is not instant, so an existing extraction is reused by default.
- */
-function resolveExtraction(options: Options): string {
-    if (options.extractedDir) {
-        const dir = resolve(options.extractedDir);
-        if (!existsSync(dir)) {
-            throw new RegradeError(`--extracted ${dir} does not exist`);
-        }
-        return dir;
-    }
-
-    // parseArgs guarantees one of runId / extractedDir, and the branch above took
-    // the extractedDir case — narrow it here rather than asserting non-null.
-    const { runId, instance: wanted } = options;
-    if (!runId) {
-        throw new RegradeError('No run id to extract');
-    }
-
-    const dir = resolve(options.extractDir ?? join(CACHE_ROOT, runId));
-    // Only reuse a cache that actually holds what was asked for: a cache built by
-    // an earlier `--instance A` must not silently satisfy a later `--instance B`.
-    const cached = findInstances(dir).instances;
-    const satisfiesRequest = cached.length > 0 &&
-        (!wanted || cached.some(candidate => matchesInstance(candidate.name, wanted)));
-
-    if (!options.refresh && satisfiesRequest) {
-        log(`Reusing extraction at ${dir} (--refresh to re-download)`);
-        return dir;
-    }
-
-    mkdirSync(dirname(dir), { recursive: true });
-    const args = ['extract', '--run_id', runId, '--output', dir];
-    if (wanted) {
-        args.push('--instance', wanted);
-    }
-
-    log(`$ msbench-cli ${args.join(' ')}`);
-    const result = spawnSync('msbench-cli', args, { stdio: 'inherit' });
-    if (result.error && (result.error as NodeJS.ErrnoException).code === 'ENOENT') {
-        throw new RegradeError(
-            'msbench-cli is not on PATH. Run:\n' +
-            '  export PATH="$HOME/.msbench-venv/bin:$PATH"\n' +
-            'Invoking it by absolute path breaks its plugin discovery, so it has to be on PATH.'
-        );
-    }
-    if (result.status !== 0) {
-        throw new RegradeError(
-            `msbench-cli extract exited ${result.status}. If this is an auth failure, run \`az login\` — ` +
-            'extraction reads a stored blob and needs an Azure identity.'
-        );
-    }
-    return dir;
-}
-
-/** `say_hello` should select `vscbench.eval.x86_64.say_hello`, but not by accident. */
-function matchesInstance(name: string, requested: string): boolean {
-    return name === requested || name.endsWith(`.${requested}`) || name.includes(requested);
-}
-
-/**
- * An MSBench extraction holds one `<instance>-output/output/vsc-output` tree per
- * instance. A directory with no `session.sqlite` is *reported* rather than
- * quietly skipped: that is an instance whose output blob never arrived —
- * infrastructure failing rather than a verdict — and dropping it silently would
- * let a partial extraction report a clean bill of health.
- */
-function findInstances(root: string): { instances: Instance[]; incomplete: string[] } {
-    if (!existsSync(root)) {
-        return { instances: [], incomplete: [] };
-    }
-    const instances: Instance[] = [];
-    const incomplete: string[] = [];
-
-    for (const entry of readdirSync(root, { withFileTypes: true })) {
-        if (!entry.isDirectory() || !entry.name.endsWith('-output')) {
-            continue;
-        }
-        const vscOutput = join(root, entry.name, 'output', 'vsc-output');
-        const sqlitePath = join(vscOutput, 'session.sqlite');
-        const name = entry.name.replace(/-output$/, '');
-        if (!existsSync(sqlitePath)) {
-            incomplete.push(name);
-            continue;
-        }
-        instances.push({
-            name,
-            vscOutput,
-            sqlitePath,
-            configPath: join(vscOutput, 'configs', 'final-agent-config.json'),
-            evalJsonPath: join(vscOutput, 'eval.json'),
-        });
-    }
-    return { instances: instances.sort((a, b) => a.name.localeCompare(b.name)), incomplete };
 }
 
 /**
@@ -984,7 +877,7 @@ async function regradeInstance(instance: Instance, options: Options): Promise<In
 async function main(): Promise<void> {
     const options = parseArgs(process.argv.slice(2));
     jsonMode = options.json;
-    const root = resolveExtraction(options);
+    const root = resolveExtraction(options, log);
 
     const { instances: discovered, incomplete } = findInstances(root);
     if (discovered.length === 0) {
@@ -1059,9 +952,13 @@ async function main(): Promise<void> {
 }
 
 main().catch((error: unknown) => {
-    // Everything that gets here — a RegradeError, but also a JSON parse, sqlite or
-    // filesystem failure — is the tool failing rather than a product verdict, so it
-    // must exit 3. Node's default of 1 would read as "a verdict changed".
-    console.error(error instanceof RegradeError ? error.message : error instanceof Error ? (error.stack ?? error.message) : String(error));
+    // Everything that gets here — a RegradeError, an extraction failure, but also a JSON
+    // parse, sqlite or filesystem failure — is the tool failing rather than a product
+    // verdict, so it must exit 3. Node's default of 1 would read as "a verdict changed".
+    //
+    // The check is against the shared base class rather than `RegradeError`, so a failure
+    // raised inside `extraction.ts` still prints its (deliberately actionable) message
+    // instead of a stack trace.
+    console.error(error instanceof MsBenchToolError ? error.message : error instanceof Error ? (error.stack ?? error.message) : String(error));
     process.exit(EXIT_GRADER_ERROR);
 });

--- a/evals/msbench/seed-store.ts
+++ b/evals/msbench/seed-store.ts
@@ -116,6 +116,22 @@ export function writeSeed(content: string, provenance: Provenance): void {
     writeFileSync(PROVENANCE_PATH, `${JSON.stringify(provenance, null, 4)}\n`);
 }
 
+/**
+ * The freshness decision, separated from the filesystem so it can be asserted directly.
+ *
+ * `checkFreshness` is the same rule wired to real paths; keeping the decision pure is
+ * what lets `--self-test` cover all three states without writing over a real harvested
+ * seed to do it.
+ */
+export function freshnessOf(provenance: Provenance | null, current: string): Freshness {
+    if (!provenance) {
+        return { state: 'not-harvested' };
+    }
+    return provenance.agentAssetsHash === current
+        ? { state: 'fresh', provenance }
+        : { state: 'stale', provenance, current };
+}
+
 export function checkFreshness(): Freshness {
     const provenance = readProvenance();
     if (!provenance) {
@@ -130,8 +146,5 @@ export function checkFreshness(): Freshness {
             'Re-harvest to restore the pair; they are only meaningful together.'
         );
     }
-    const current = currentAgentAssetsHash();
-    return provenance.agentAssetsHash === current
-        ? { state: 'fresh', provenance }
-        : { state: 'stale', provenance, current };
+    return freshnessOf(provenance, currentAgentAssetsHash());
 }

--- a/evals/msbench/seed-store.ts
+++ b/evals/msbench/seed-store.ts
@@ -1,0 +1,137 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Where the harvested scaffold seed lives, and whether it is still current.
+ *
+ * This is the half of seed provenance that touches nothing but the filesystem, split out
+ * from `harvest-seed.ts` for one concrete reason: harvesting reads a run's
+ * `session.sqlite` and therefore imports `node:sqlite`, which is experimental and prints
+ * a warning unless the process was started with `--disable-warning=ExperimentalWarning`.
+ *
+ * `stage-workspace.ts` needs to know where the seed is and where it came from, and
+ * `run.sh` invokes it as a bare `node stage-workspace.ts`. Importing the harvester there
+ * would put an experimental-runtime warning into the middle of every staged run's output
+ * for a capability that step never uses. So the dependency is inverted: the cheap half
+ * has no heavyweight imports, and the harvester builds on it.
+ *
+ * Runs straight off source via Node's built-in type stripping — no build step.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { MsBenchToolError } from './extraction.ts';
+
+const HERE = import.meta.dirname;
+const EVALS_ROOT = resolve(HERE, '..');
+
+/**
+ * Checked in, unlike `assets/`, because a seed only helps CI and other machines if it
+ * travels with the repository. `assets/` is scratch space that `run.sh` owns and wipes.
+ */
+export const SEEDS_ROOT = join(HERE, 'seeds');
+
+export const HARVESTED_PLAN = join(SEEDS_ROOT, 'project-plan.md');
+export const PROVENANCE_PATH = join(SEEDS_ROOT, 'provenance.json');
+
+/**
+ * The lock already tracks exactly the scope that decides a plan's shape
+ * (`azure-project-plan.agent.md, azure-project-plan/**, shared-references/**`) and is
+ * already gated by `npm run drift`. Reading its published hash rather than recomputing
+ * one here is deliberate: the lock *is* the contract, and a lock that were itself out of
+ * date would already have turned `drift` red.
+ */
+const LOCK_PATH = join(EVALS_ROOT, 'agent-assets.lock.json');
+
+/** The freshness vocabulary, and the exit code each state maps to. */
+export const EXIT_FRESH = 0;
+export const EXIT_STALE = 1;
+export const EXIT_NOT_HARVESTED = 2;
+export const EXIT_TOOL_ERROR = 3;
+
+export interface Provenance {
+    /** The MSBench run the document came out of. */
+    runId: string;
+    /** Which instance of that run, since a run may hold several. */
+    instance: string;
+    harvestedAt: string;
+    /** `agentAssetsHash` from `evals/agent-assets.lock.json` when this was captured. */
+    agentAssetsHash: string;
+    /** The path inside the run's workspace, recorded so a later rename is visible. */
+    sourcePath: string;
+}
+
+export type Freshness =
+    | { state: 'fresh'; provenance: Provenance }
+    | { state: 'stale'; provenance: Provenance; current: string }
+    | { state: 'not-harvested' };
+
+const REQUIRED_KEYS = ['runId', 'instance', 'harvestedAt', 'agentAssetsHash', 'sourcePath'] as const;
+
+/**
+ * The hash the lock publishes today.
+ *
+ * A missing or malformed lock is a tool error rather than a staleness verdict: it means
+ * the check could not be performed, and reporting that as "fresh" is the exact collapse
+ * the separate not-harvested state exists to avoid.
+ */
+export function currentAgentAssetsHash(): string {
+    if (!existsSync(LOCK_PATH)) {
+        throw new MsBenchToolError(
+            `Cannot read ${LOCK_PATH}.\n` +
+            'Seed freshness is defined against the agent-assets lock, so without it the check\n' +
+            'has no baseline. Run `npm run drift -- --update` from evals/ to create one.'
+        );
+    }
+    const parsed = JSON.parse(readFileSync(LOCK_PATH, 'utf8')) as { agentAssetsHash?: unknown };
+    if (typeof parsed.agentAssetsHash !== 'string' || parsed.agentAssetsHash.length === 0) {
+        throw new MsBenchToolError(`${LOCK_PATH} has no usable "agentAssetsHash".`);
+    }
+    return parsed.agentAssetsHash;
+}
+
+export function readProvenance(): Provenance | null {
+    if (!existsSync(PROVENANCE_PATH)) {
+        return null;
+    }
+    const parsed = JSON.parse(readFileSync(PROVENANCE_PATH, 'utf8')) as Partial<Provenance>;
+    for (const key of REQUIRED_KEYS) {
+        const value = parsed[key];
+        if (typeof value !== 'string' || value.length === 0) {
+            throw new MsBenchToolError(
+                `${PROVENANCE_PATH} is missing "${key}".\n` +
+                'A provenance file that cannot be read is not the same as no provenance at all —\n' +
+                're-harvest rather than deleting it, so the seed keeps an auditable origin.'
+            );
+        }
+    }
+    return parsed as Provenance;
+}
+
+export function writeSeed(content: string, provenance: Provenance): void {
+    mkdirSync(SEEDS_ROOT, { recursive: true });
+    writeFileSync(HARVESTED_PLAN, content);
+    writeFileSync(PROVENANCE_PATH, `${JSON.stringify(provenance, null, 4)}\n`);
+}
+
+export function checkFreshness(): Freshness {
+    const provenance = readProvenance();
+    if (!provenance) {
+        return { state: 'not-harvested' };
+    }
+    // A provenance file with no document beside it is a half-finished harvest, and the
+    // seed it claims to describe does not exist. Treat that as a tool error rather than
+    // reporting a freshness verdict about a file that is not there.
+    if (!existsSync(HARVESTED_PLAN)) {
+        throw new MsBenchToolError(
+            `${PROVENANCE_PATH} exists but ${HARVESTED_PLAN} does not.\n` +
+            'Re-harvest to restore the pair; they are only meaningful together.'
+        );
+    }
+    const current = currentAgentAssetsHash();
+    return provenance.agentAssetsHash === current
+        ? { state: 'fresh', provenance }
+        : { state: 'stale', provenance, current };
+}

--- a/evals/msbench/stage-workspace.ts
+++ b/evals/msbench/stage-workspace.ts
@@ -59,10 +59,19 @@
  * accepting a known cost to get the eight merged graders in front of real agent output
  * at all, not claiming the objection has gone away.
  *
- * What we give up by not harvesting is also concrete: `harvest-seed.mjs` had a `--check`
- * mode that reported seed freshness and exited 1 when the seed was stale, hashed against
- * `resources/agents/**`. The checked-in fixture has no equivalent, so nothing detects the
- * drift automatically. See `config/stimuli/README.md`.
+ * What that leaves is a seed whose freshness nothing can vouch for, and
+ * `harvest-seed.ts` is what closes it. `harvest-seed.mjs` had a `--check` mode that
+ * reported seed freshness and exited 1 when stale, hashed against the planner's assets;
+ * for a while nothing replaced it. Now:
+ *
+ *   node harvest-seed.ts <run-id>   promotes a real plan-phase run's document into
+ *                                   `seeds/project-plan.md` with its provenance
+ *   node harvest-seed.ts --check    compares the captured `agentAssetsHash` against
+ *                                   `agent-assets.lock.json`, for free
+ *
+ * So the fixture below is the *floor*, not the only option: when a harvested plan is
+ * present it wins, and when it is absent the fixture keeps the suite runnable on a
+ * machine that has never talked to MSBench. See `config/stimuli/README.md`.
  *
  * ── Seed names ─────────────────────────────────────────────────────────────────────
  *
@@ -76,15 +85,18 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { HARVESTED_PLAN, readProvenance } from './seed-store.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const STIMULI = join(HERE, 'config', 'stimuli');
 const DEST = join(HERE, 'assets', 'workspace');
 
 /**
- * The one fixture every seed is derived from: a real, complete fullstack plan (React
- * frontend, Azure Functions backend, PostgreSQL) already used by
- * `evals/local-dev/eval.yaml` for the same purpose.
+ * The fallback fixture: a real, complete fullstack plan (React frontend, Azure Functions
+ * backend, PostgreSQL) already used by `evals/local-dev/eval.yaml` for the same purpose.
+ *
+ * Used only when nothing has been harvested. `readPlanSource` prefers
+ * `seeds/project-plan.md`, which carries provenance and can be checked for staleness.
  */
 const PLAN_FIXTURE = join(HERE, '..', 'local-dev', 'fixtures', 'functions-postgres', '.azure', 'project-plan.md');
 
@@ -124,46 +136,71 @@ const RECIPES: Record<string, Recipe> = {
     none: () => [],
 
     'approved-fullstack': () => [
-        { path: '.azure/project-plan.md', content: readPlanFixture() },
+        { path: '.azure/project-plan.md', content: withStatus(readPlanSource(), 'Approved') },
     ],
 
     'unapproved-plan': () => [
-        { path: '.azure/project-plan.md', content: withStatus(readPlanFixture(), 'Planning') },
+        { path: '.azure/project-plan.md', content: withStatus(readPlanSource(), 'Planning') },
     ],
 };
 
-function readPlanFixture(): string {
+/** The plan document both seeds derive from, and where it came from. */
+interface PlanSource {
+    readonly path: string;
+    readonly content: string;
+    readonly harvested: boolean;
+}
+
+/**
+ * Prefer a harvested plan, fall back to the checked-in fixture.
+ *
+ * The fallback is what keeps this runnable on a machine that has never authenticated to
+ * MSBench — including CI before anyone has harvested — so the preference is a quality
+ * upgrade rather than a new requirement.
+ */
+function readPlanSource(): PlanSource {
+    if (existsSync(HARVESTED_PLAN)) {
+        return { path: HARVESTED_PLAN, content: readFileSync(HARVESTED_PLAN, 'utf8'), harvested: true };
+    }
     if (!existsSync(PLAN_FIXTURE)) {
         throw new Error(
-            `The plan fixture is missing: ${PLAN_FIXTURE}\n` +
-            `Seeded stimuli derive every plan from it, so this is a hard error rather than an empty seed.`
+            `No plan to seed from. Neither exists:\n` +
+            `  harvested: ${HARVESTED_PLAN}\n` +
+            `  fixture:   ${PLAN_FIXTURE}\n` +
+            `Seeded stimuli derive every plan from one of them, so this is a hard error rather\n` +
+            `than an empty seed.`
         );
     }
-    return readFileSync(PLAN_FIXTURE, 'utf8');
+    return { path: PLAN_FIXTURE, content: readFileSync(PLAN_FIXTURE, 'utf8'), harvested: false };
 }
 
 /**
  * Rewrite the plan's status line, asserting that there was exactly one to rewrite.
  *
- * The assertion is the whole reason this is a function. A silent no-op here — the fixture
+ * The assertion is the whole reason this is a function. A silent no-op here — the source
  * renamed the field, or reformatted the line — would produce an *approved* plan under the
  * name `unapproved-plan`, which turns `scaffold-unapproved-plan` into a second copy of
  * `scaffold-fullstack`. It would still read green, and the approval gate it exists to
  * test would simply stop being tested. Failing loudly on a developer machine costs
  * nothing; the alternative costs a paid run and reports a false pass.
+ *
+ * Both recipes go through it, including the approved one whose status is usually already
+ * correct. That is deliberate: a harvested plan's status is whatever the agent left
+ * behind, so normalising both directions is what keeps the pair's sole difference the
+ * approval status — the property that makes the pair falsifiable at all.
  */
-function withStatus(plan: string, status: string): string {
+function withStatus(source: PlanSource, status: string): string {
     const statusLine = /^\*\*Status\*\*:\s*(.+)$/m;
-    const matches = plan.match(new RegExp(statusLine, 'gm')) ?? [];
+    const matches = source.content.match(new RegExp(statusLine, 'gm')) ?? [];
     if (matches.length !== 1) {
         throw new Error(
-            `Expected exactly one '**Status**: ...' line in ${PLAN_FIXTURE}, found ${matches.length}.\n` +
-            `The unapproved seed is produced by rewriting that line, and a silent no-op would make\n` +
+            `Expected exactly one '**Status**: ...' line in ${source.path}, found ${matches.length}.\n` +
+            `The seed recipes are produced by rewriting that line, and a silent no-op would make\n` +
             `stimuli/scaffold-unapproved-plan.yaml a duplicate of scaffold-fullstack.yaml that still\n` +
             `reports green while testing nothing.`
         );
     }
-    return plan.replace(statusLine, `**Status**: ${status}`);
+    return source.content.replace(statusLine, `**Status**: ${status}`);
 }
 
 /**
@@ -246,6 +283,26 @@ function main(): void {
     for (const file of files) {
         console.log(`  ${file.path}`);
     }
+    describePlanSource();
+}
+
+/**
+ * Say where the plan came from, every time.
+ *
+ * A run seeded from a stale harvest and a run seeded from the fixture fail in the same
+ * confusing way — an agent grading against a plan nobody would emit — and the only cheap
+ * way to tell them apart afterwards is to have printed it at the time.
+ */
+function describePlanSource(): void {
+    const source = readPlanSource();
+    if (!source.harvested) {
+        console.log('  plan source: checked-in fixture (nothing harvested; freshness unknown)');
+        return;
+    }
+    const provenance = readProvenance();
+    console.log(provenance
+        ? `  plan source: harvested from run ${provenance.runId} at ${provenance.harvestedAt}`
+        : `  plan source: ${HARVESTED_PLAN} (no provenance recorded)`);
 }
 
 // Only when run directly. build-config.ts imports `seedPaths`/`seedFor` from here,

--- a/evals/package.json
+++ b/evals/package.json
@@ -18,6 +18,7 @@
         "regrade": "node --disable-warning=ExperimentalWarning msbench/regrade.ts",
         "seed:harvest": "node --disable-warning=ExperimentalWarning msbench/harvest-seed.ts",
         "seed:check": "node --disable-warning=ExperimentalWarning msbench/harvest-seed.ts --check",
+        "seed:self-test": "node --disable-warning=ExperimentalWarning msbench/harvest-seed.ts --self-test",
         "gate-health": "node --disable-warning=ExperimentalWarning msbench/gate-health.ts",
         "ci:local": "node ci-local.ts",
         "msbench:self-test": "node msbench/verify-run.ts --self-test"

--- a/evals/package.json
+++ b/evals/package.json
@@ -16,6 +16,8 @@
         "certify": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON src/graderCertification.ts",
         "stacks:check": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON check-stacks.ts",
         "regrade": "node --disable-warning=ExperimentalWarning msbench/regrade.ts",
+        "seed:harvest": "node --disable-warning=ExperimentalWarning msbench/harvest-seed.ts",
+        "seed:check": "node --disable-warning=ExperimentalWarning msbench/harvest-seed.ts --check",
         "gate-health": "node --disable-warning=ExperimentalWarning msbench/gate-health.ts",
         "ci:local": "node ci-local.ts",
         "msbench:self-test": "node msbench/verify-run.ts --self-test"


### PR DESCRIPTION
Seeds the scaffold and local-dev phases from **real planner output** instead of a hand-written fixture, and restores the staleness check that was lost when the original `harvest-seed.mjs` was dropped.

Stacked on `feat/CoR`.

## The gap

`stage-workspace.ts` already documented the objection to a checked-in fixture, quoting the design that rejected it first:

> Checking one in makes that document a second source of truth: edit the planner's template and the stored copy still describes the old shape, so the scaffold graders keep passing against a plan no agent would emit.

It bounded that objection honestly — the plan is an *input, not an expected answer*, so a stale one fails **loudly** rather than passing wrongly. But it also recorded something simply missing: `harvest-seed.mjs` had a `--check` that reported seed freshness and exited 1 when stale, and **nothing replaced it**. The fixture could drift with no symptom but an expensive, confusing red run.

## What this adds

```
npm run seed:harvest -- <plan-run-id>   promote a real run's plan
npm run seed:check                      0 fresh / 1 stale / 2 never harvested
npm run seed:self-test                  10 cases, no credentials
```

Harvesting is **free**: `msbench-cli extract` downloads a stored blob and never touches a model, and the run's `files` table holds the full text of everything the agent wrote — the same property `regrade.ts` is built on. The shared download and instance discovery move into `extraction.ts` rather than being copied.

**The check hashes the agent, not the plan.** A plan's shape is decided by the planner's instructions, so *"is this still representative?"* is really *"have those instructions changed since it was captured?"* — and `agent-assets.lock.json` already publishes exactly that scope. No run, no model, no network. It over-triggers slightly, which is the intended direction: missing a real drift is fail-open, re-harvesting costs one free extraction.

**Exit 2 is deliberately neither pass nor fail**, per the ruling #1747 already made for gates that never ran.

## Verified end to end, against a real run

Run `2026082614813342` harvested cleanly: a real 11.5 KB `.azure/project-plan.md`, staged to `**Status**: Approved`, satisfying `scaffold-fullstack`'s `grep -q "^\*\*Status\*\*: Approved"` precondition. All eleven credential-free gates green.

Two things that only showed up on real data:

- **The status normalisation earns its place.** The harvested plan came back `**Status**: Planning`, because the planner leaves whatever the run ended on. Both recipes now rewrite that line, including the approved one — without it the very first real seed would have failed the gate it exists to feed.
- **The drift is real.** Same stack as the fixture (React SPA, Azure Functions, PostgreSQL, Blob Storage, Docker emulators) but 11.5 KB against 1.7 KB, with a design system, route definitions, a prerequisites table with per-item verification markers, and a Next Steps block naming `azure-project-integrate` — sections the hand-written copy has no notion of.

## Why no seed is committed

`feat/CoR` has since changed `azure-project-plan/plan.md` and `shared-references/prerequisites.md`, moving the lock from `34a55db1` to `b56ea10d`. `seed:check` correctly reports the harvested plan **STALE** — the mechanism firing on a real agent change, unprompted.

Re-harvesting it now would record the new hash against a document the *old* agents produced, which is exactly the false-fresh this exists to prevent. The tool cannot tell which agents a stored run was made against, so that judgement stays with whoever runs it.

So the fixture stays in use and `seed:check` reports **2, not harvested**. That is the honest state, and it is one free command to change after any plan-phase run against current agents.

## Testing

`harvest-seed.ts --self-test` covers everything between the `files` table and the seed on disk, wired in as a `check-clean-machine.ts` entrypoint rather than a new CI step — the existing idiom (`verify-run.ts --self-test` is already one), which also proves the harvester imports no packages and runs on the bare host `run.sh` promises.

Four of the ten cases are about telling failures *apart* rather than detecting them: an empty `files` table and an agent that wrote no plan are one keystroke apart in the query and a day apart in the diagnosis. Verified the guard can fail — sabotaging the latest-wins ordering turns the suite red on exactly that case.

## Windows note

`--extract-dir` was added because these archives carry ~290 character log paths against a 260 `MAX_PATH`, so extraction silently stopped partway and left no `session.sqlite` on a run whose blob had downloaded perfectly. The diagnostic caught it but blamed *"output blob never arrived"* — wrong layer. Both causes are named now.

Unrelated, but worth knowing: with Git for Windows' default `core.autocrlf=true`, `certify`, `drift` and `stacks:check` all fail on checked-out CRLF fixtures. `core.autocrlf=false` fixes it; a `.gitattributes` rule would fix it for everyone.