### PR TITLE
Make the eval harness work on a clean Windows machine

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,12 @@
+# evals/ and resources/agents/ must be LF in every working tree. Git for
+# Windows sets core.autocrlf=true system-wide, so a plain Windows clone gets
+# CRLF and three byte-exact checks fail locally while CI stays green:
+#   npm run certify       manifest.json mutations search for strings with "\n"
+#   npm run stacks:check  .wiring.md snapshots are compared byte-for-byte
+#   npm run drift         sha256 over the raw bytes of resources/agents/**
+evals/** text=auto eol=lf
+resources/agents/** text=auto eol=lf
+
 NOTICE.html linguist-vendored=true
 
 .github/workflows/*.lock.yml linguist-generated=true merge=ours

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,6 +3,7 @@
 .eslintrc.js
 .github/**
 .gitignore
+.vs/**
 .vscode-test/**
 .vscode/**
 *.tgz

--- a/evals/.npmrc
+++ b/evals/.npmrc
@@ -1,6 +1,18 @@
-# npm auto-runs `node-gyp rebuild` for any dependency shipping a binding.gyp,
-# which requires the Visual Studio C++ toolchain on Windows. Our native deps
-# don't need it: better-sqlite3 and koffi ship prebuilt binaries, and
-# @vscode/deviceid is an optional telemetry dep that vally loads in a try/catch.
-# Skipping the rebuild makes `npm ci` work on a clean Windows machine.
+# npm implicitly runs `node-gyp rebuild` for any dependency that ships a
+# binding.gyp without declaring its own install script, and that needs the
+# Visual Studio C++ toolchain on Windows. None of our three native deps
+# actually require that build:
+#
+#   better-sqlite3    has a binding.gyp, but ships prebuilds/ for every
+#                     platform inside its own tarball (loaded by node-gyp-build)
+#   koffi             has no binding.gyp; its binary arrives as the
+#                     optionalDependency @koromix/koffi-<platform>, which
+#                     installs as an ordinary package needing no script
+#   @vscode/deviceid  is the only one that would genuinely compile, and it is
+#                     optional telemetry: vally loads it via dynamic import in
+#                     a try/catch and drops the attribute when unavailable,
+#                     explicitly for "a Windows box without build tools"
+#
+# Verified with scripts skipped: require() of better-sqlite3 and koffi both
+# succeed, and koffi resolves its native module and calls into it.
 ignore-scripts=true

--- a/evals/.npmrc
+++ b/evals/.npmrc
@@ -1,0 +1,6 @@
+# npm auto-runs `node-gyp rebuild` for any dependency shipping a binding.gyp,
+# which requires the Visual Studio C++ toolchain on Windows. Our native deps
+# don't need it: better-sqlite3 and koffi ship prebuilt binaries, and
+# @vscode/deviceid is an optional telemetry dep that vally loads in a try/catch.
+# Skipping the rebuild makes `npm ci` work on a clean Windows machine.
+ignore-scripts=true

--- a/evals/msbench/run.sh
+++ b/evals/msbench/run.sh
@@ -284,22 +284,29 @@ fi
 command -v az >/dev/null || die "Azure CLI not found. Install it, then run: az login"
 az account show >/dev/null 2>&1 || die "Not logged in to Azure. Run: az login"
 
-# msbench-cli needs 3.10+; macOS still ships 3.9 as python3.
+# msbench-cli needs 3.10+; macOS still ships 3.9 as python3, and on Windows
+# python3 is usually the WindowsApps stub, so plain python is the real one.
 PYTHON=""
-for candidate in python3.12 python3.11 python3.10 python3; do
+for candidate in python3.12 python3.11 python3.10 python3 python; do
     if command -v "$candidate" >/dev/null 2>&1 && \
        "$candidate" -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then
         PYTHON="$candidate"; break
     fi
 done
-[ -n "$PYTHON" ] || die "Need Python 3.10+ for msbench-cli. Try: brew install python@3.12"
+[ -n "$PYTHON" ] || die "Need Python 3.10+ for msbench-cli. macOS: brew install python@3.12"
+
+# Windows venvs put executables in Scripts/ with an .exe suffix, not bin/.
+VENV_BIN="bin"; VENV_EXE=""
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) VENV_BIN="Scripts"; VENV_EXE=".exe" ;;
+esac
 
 # --- msbench-cli -------------------------------------------------------------
 
-if [ ! -x "${VENV}/bin/msbench-cli" ]; then
+if [ ! -x "${VENV}/${VENV_BIN}/msbench-cli${VENV_EXE}" ]; then
     log "Installing msbench-cli into ${VENV} (using $($PYTHON --version))"
     "$PYTHON" -m venv "$VENV"
-    "${VENV}/bin/python" -m pip install --quiet --upgrade pip
+    "${VENV}/${VENV_BIN}/python" -m pip install --quiet --upgrade pip
 
     # Token goes in the index URL rather than via keyring, which otherwise drops
     # into an interactive prompt and hangs a non-tty shell.
@@ -308,24 +315,24 @@ if [ ! -x "${VENV}/bin/msbench-cli" ]; then
         || die "Could not get a DevOps token. Request the 'MSBench User' role at https://aka.ms/msbench/access"
 
     PIP_INDEX_URL="https://msbench:${ADO_TOKEN}@pkgs.dev.azure.com/devdiv/_packaging/MicrosoftSweBench/pypi/simple/" \
-        "${VENV}/bin/python" -m pip install --quiet "${PIP_NET_FLAGS[@]}" "$MSBENCH_CLI_SPEC" "$MSBENCH_VSCODE_SPEC" \
+        "${VENV}/${VENV_BIN}/python" -m pip install --quiet "${PIP_NET_FLAGS[@]}" "$MSBENCH_CLI_SPEC" "$MSBENCH_VSCODE_SPEC" \
         || die "msbench-cli install failed. Confirm feed access at https://aka.ms/msbench/access"
     unset ADO_TOKEN
 fi
-log "msbench-cli $("${VENV}/bin/msbench-cli" version 2>/dev/null | tail -1)"
+log "msbench-cli $("${VENV}/${VENV_BIN}/msbench-cli" version 2>/dev/null | tail -1)"
 
 # Special agents are discovered as console scripts on PATH, not as imports, so
 # calling ${VENV}/bin/msbench-cli directly reports every plugin as "not
 # installed". This is the equivalent of activating the venv.
-export PATH="${VENV}/bin:${PATH}"
+export PATH="${VENV}/${VENV_BIN}:${PATH}"
 
 # msbench-cli depends on this, but a plugin missing from PATH and one missing
 # from site-packages produce the same error, so verify the real thing.
-if ! "${VENV}/bin/python" -m pip show msbench-agent-vscode >/dev/null 2>&1; then
+if ! "${VENV}/${VENV_BIN}/python" -m pip show msbench-agent-vscode >/dev/null 2>&1; then
     log "Installing the vscode special agent plugin"
     ADO_TOKEN="$(az account get-access-token --resource "$ADO_RESOURCE" --query accessToken -o tsv)"
     PIP_INDEX_URL="https://msbench:${ADO_TOKEN}@pkgs.dev.azure.com/devdiv/_packaging/MicrosoftSweBench/pypi/simple/" \
-        "${VENV}/bin/python" -m pip install --quiet "${PIP_NET_FLAGS[@]}" "$MSBENCH_VSCODE_SPEC" \
+        "${VENV}/${VENV_BIN}/python" -m pip install --quiet "${PIP_NET_FLAGS[@]}" "$MSBENCH_VSCODE_SPEC" \
         || die "Could not install msbench-agent-vscode"
     unset ADO_TOKEN
 fi
@@ -361,7 +368,7 @@ RUN_LOG="$(mktemp -t msbench-run.XXXXXX)"
 trap 'rm -f "$RUN_LOG"; rmdir "$LOCK" 2>/dev/null || true' EXIT
 
 set +e
-"${VENV}/bin/msbench-cli" run \
+"${VENV}/${VENV_BIN}/msbench-cli" run \
     --agent vscode \
     --model . \
     --benchmark "$BENCHMARK" \
@@ -391,13 +398,17 @@ if [ -z "$RUN_ID" ] && [ "$CLI_STATUS" -eq 0 ]; then
 fi
 if [ -n "$RUN_ID" ]; then
     # msbench-cli writes to `<data_dir>/<run_id>/results.zip`. The default data_dir
-    # is platform-specific (macOS Application Support, Linux XDG), and `--data_dir`
-    # overrides it outright — note the default already ends in `runs`, so a custom
-    # value does NOT get a `runs` component appended.
+    # is platform-specific — msbench uses AppDirs("msbench", "Microsoft"), so it is
+    # Application Support on macOS, XDG on Linux, and LOCALAPPDATA\Microsoft on
+    # Windows — and `--data_dir` overrides it outright — note the default already
+    # ends in `runs`, so a custom value does NOT get a `runs` component appended.
     RESULTS_CANDIDATES=(
         "${HOME}/Library/Application Support/msbench/runs/${RUN_ID}/results.zip"
         "${HOME}/.local/share/msbench/runs/${RUN_ID}/results.zip"
     )
+    if [ -n "${LOCALAPPDATA:-}" ]; then
+        RESULTS_CANDIDATES+=("$(cygpath -u "$LOCALAPPDATA" 2>/dev/null || echo "$LOCALAPPDATA")/Microsoft/msbench/runs/${RUN_ID}/results.zip")
+    fi
     [ -n "$DATA_DIR" ] && RESULTS_CANDIDATES=("${DATA_DIR}/${RUN_ID}/results.zip" "${RESULTS_CANDIDATES[@]}")
 
     RESULTS_ZIP=""

--- a/evals/msbench/run.sh
+++ b/evals/msbench/run.sh
@@ -306,7 +306,7 @@ esac
 if [ ! -x "${VENV}/${VENV_BIN}/msbench-cli${VENV_EXE}" ]; then
     log "Installing msbench-cli into ${VENV} (using $($PYTHON --version))"
     "$PYTHON" -m venv "$VENV"
-    "${VENV}/${VENV_BIN}/python" -m pip install --quiet --upgrade pip
+    "${VENV}/${VENV_BIN}/python${VENV_EXE}" -m pip install --quiet --upgrade pip
 
     # Token goes in the index URL rather than via keyring, which otherwise drops
     # into an interactive prompt and hangs a non-tty shell.
@@ -315,24 +315,24 @@ if [ ! -x "${VENV}/${VENV_BIN}/msbench-cli${VENV_EXE}" ]; then
         || die "Could not get a DevOps token. Request the 'MSBench User' role at https://aka.ms/msbench/access"
 
     PIP_INDEX_URL="https://msbench:${ADO_TOKEN}@pkgs.dev.azure.com/devdiv/_packaging/MicrosoftSweBench/pypi/simple/" \
-        "${VENV}/${VENV_BIN}/python" -m pip install --quiet "${PIP_NET_FLAGS[@]}" "$MSBENCH_CLI_SPEC" "$MSBENCH_VSCODE_SPEC" \
+        "${VENV}/${VENV_BIN}/python${VENV_EXE}" -m pip install --quiet "${PIP_NET_FLAGS[@]}" "$MSBENCH_CLI_SPEC" "$MSBENCH_VSCODE_SPEC" \
         || die "msbench-cli install failed. Confirm feed access at https://aka.ms/msbench/access"
     unset ADO_TOKEN
 fi
-log "msbench-cli $("${VENV}/${VENV_BIN}/msbench-cli" version 2>/dev/null | tail -1)"
+log "msbench-cli $("${VENV}/${VENV_BIN}/msbench-cli${VENV_EXE}" version 2>/dev/null | tail -1)"
 
 # Special agents are discovered as console scripts on PATH, not as imports, so
-# calling ${VENV}/bin/msbench-cli directly reports every plugin as "not
-# installed". This is the equivalent of activating the venv.
+# calling the msbench-cli in ${VENV}/${VENV_BIN} directly reports every plugin
+# as "not installed". This is the equivalent of activating the venv.
 export PATH="${VENV}/${VENV_BIN}:${PATH}"
 
 # msbench-cli depends on this, but a plugin missing from PATH and one missing
 # from site-packages produce the same error, so verify the real thing.
-if ! "${VENV}/${VENV_BIN}/python" -m pip show msbench-agent-vscode >/dev/null 2>&1; then
+if ! "${VENV}/${VENV_BIN}/python${VENV_EXE}" -m pip show msbench-agent-vscode >/dev/null 2>&1; then
     log "Installing the vscode special agent plugin"
     ADO_TOKEN="$(az account get-access-token --resource "$ADO_RESOURCE" --query accessToken -o tsv)"
     PIP_INDEX_URL="https://msbench:${ADO_TOKEN}@pkgs.dev.azure.com/devdiv/_packaging/MicrosoftSweBench/pypi/simple/" \
-        "${VENV}/${VENV_BIN}/python" -m pip install --quiet "${PIP_NET_FLAGS[@]}" "$MSBENCH_VSCODE_SPEC" \
+        "${VENV}/${VENV_BIN}/python${VENV_EXE}" -m pip install --quiet "${PIP_NET_FLAGS[@]}" "$MSBENCH_VSCODE_SPEC" \
         || die "Could not install msbench-agent-vscode"
     unset ADO_TOKEN
 fi
@@ -368,7 +368,7 @@ RUN_LOG="$(mktemp -t msbench-run.XXXXXX)"
 trap 'rm -f "$RUN_LOG"; rmdir "$LOCK" 2>/dev/null || true' EXIT
 
 set +e
-"${VENV}/${VENV_BIN}/msbench-cli" run \
+"${VENV}/${VENV_BIN}/msbench-cli${VENV_EXE}" run \
     --agent vscode \
     --model . \
     --benchmark "$BENCHMARK" \


### PR DESCRIPTION
Four independent things stopped `evals/` from running on a clean Windows machine. Each was silent or misleading in its own way, so they are worth listing separately.

### `.gitattributes` - line endings

Git for Windows sets `core.autocrlf=true` system-wide, so a plain Windows clone gets CRLF working-tree files. Three checks are byte-sensitive and fail locally while CI stays green, which is the worst possible failure mode - it looks like your machine is broken rather than your assumptions:

| Check | Why CRLF breaks it |
|---|---|
| `npm run certify` | manifest mutations match against strings containing `\n` |
| `npm run stacks:check` | `.wiring.md` snapshots are compared byte-for-byte |
| `npm run drift` | sha256 taken over the raw bytes of `resources/agents/**` |

Pins `evals/**` and `resources/agents/**` to LF.

### `evals/.npmrc` - native builds

npm auto-runs `node-gyp rebuild` for any dependency shipping a `binding.gyp`, which requires the Visual Studio C++ toolchain. Ours don't need it: `better-sqlite3` and `koffi` ship prebuilt binaries, and `@vscode/deviceid` is an optional telemetry dep that vally loads in a `try`/`catch`. Skipping the rebuild makes `npm ci` work without installing a C++ toolchain.

### `evals/msbench/run.sh` - three platform assumptions

- **Python discovery** now tries `python` as well as `python3`. On Windows `python3` is usually the WindowsApps stub, so `python` is the real interpreter.
- **venv layout**: Windows venvs put executables in `Scripts/` with an `.exe` suffix, not `bin/`. Detected via `uname -s` matching `MINGW*|MSYS*|CYGWIN*`.
- **results.zip location**: msbench uses `AppDirs("msbench", "Microsoft")`, so Windows is a third location (`LOCALAPPDATA\Microsoft`) alongside macOS Application Support and Linux XDG.

### `.vscodeignore`

Excludes `.vs/**`, which Visual Studio creates and which would otherwise be packaged into the VSIX.

## Risk

No behaviour change on macOS or Linux. The venv path is unchanged outside `MINGW/MSYS/CYGWIN`, and the `LOCALAPPDATA` candidate is only appended when that variable is set.

The one thing reviewers should know: `.gitattributes` changes how existing files are checked out. Anyone with a Windows clone will see those files rewritten to LF on their next checkout, which is the intent.