### PR TITLE
Runtime gates: resolve dependencies the way Node does, not by one directory's existence

### DIFF
--- a/evals/src/runtime/runtimeTarget.ts
+++ b/evals/src/runtime/runtimeTarget.ts
@@ -177,9 +177,13 @@ export interface RuntimeTarget {
     /** True when that package declares runtime dependencies. */
     declaresDependencies: boolean;
     /**
-     * True when `node_modules` is present. Reported rather than judged: the runtime gates
-     * treat a missing install as a harness fault ("run the build gate first"), while the
-     * debug probe does not care, because VS Code runs the `preLaunchTask` install itself.
+     * True when those dependencies are installed somewhere Node will find them. Reported
+     * rather than judged: the runtime gates treat a missing install as a harness fault ("run
+     * the build gate first"), while the debug probe does not care, because VS Code runs the
+     * `preLaunchTask` install itself.
+     *
+     * Not the same question as "does `<package>/node_modules` exist" — see
+     * `dependenciesAreInstalled`.
      */
     dependenciesInstalled: boolean;
 }
@@ -374,9 +378,64 @@ async function completeTarget(
             workspaceRoot,
             packageDirectory: manifest.directory,
             declaresDependencies: Object.keys(manifest.dependencies).length > 0,
-            dependenciesInstalled: existsSync(path.join(manifest.directory, 'node_modules')),
+            dependenciesInstalled: dependenciesAreInstalled(workspaceRoot, manifest),
         },
     };
+}
+
+/**
+ * Whether this package's declared dependencies are installed somewhere Node will find them.
+ *
+ * Node resolves a bare specifier by walking `node_modules` up the directory chain, and npm
+ * workspaces **hoist** shared dependencies to the monorepo root. So a workspace package can be
+ * completely and correctly installed while its own directory has no `node_modules` at all —
+ * which is precisely the layout architecture.md prescribes
+ * (`"workspaces": ["services/functions", "services/web", "services/shared"]`).
+ *
+ * Testing only `<package>/node_modules` therefore reds a correctly-installed project. Measured,
+ * at full price, on two runs of the same stack that differ in nothing else:
+ *
+ *   2026083152684407  `npm --prefix services/functions install`     -> local node_modules, gates ran
+ *   2026083167798590  `npm install --workspace=services/functions`  -> hoisted to the root,
+ *                     all five runtime gates reported "declares dependencies but has no
+ *                     node_modules" while `project-builds` passed on the same tree
+ *
+ * Both invocations are correct npm. The gates were grading which one the agent happened to
+ * pick, and reporting the difference as a harness fault — a red with nothing to say about the
+ * product, from a precondition that exists specifically to avoid inventing one.
+ *
+ * Two deliberate choices:
+ *
+ * - **Presence on disk, not `require.resolve`.** Resolution applies `exports` conditions, so an
+ *   ESM-only dependency (`"type": "module"` exposing only an `import` condition) throws
+ *   `ERR_PACKAGE_PATH_NOT_EXPORTED` under CJS resolution and would be reported as missing. The
+ *   question here is only whether an install happened; a directory answers that without
+ *   inheriting condition semantics.
+ * - **Bounded at `workspaceRoot`.** Node itself walks to the filesystem root, but this runs on
+ *   developer machines too, where an unbounded walk out of a fixture would find the repository's
+ *   own `node_modules` and report an uninstalled project as installed — the false green this
+ *   precondition exists to prevent, one directory up.
+ */
+function dependenciesAreInstalled(workspaceRoot: string, manifest: PackageManifest): boolean {
+    // `every` on no dependencies is true, which is the right answer: nothing to install.
+    return Object.keys(manifest.dependencies)
+        .every(name => isInstalledFrom(manifest.directory, workspaceRoot, name));
+}
+
+/** One dependency, resolved the way Node looks for it: `node_modules` up the chain. */
+function isInstalledFrom(fromDirectory: string, workspaceRoot: string, name: string): boolean {
+    const stopAt = path.resolve(workspaceRoot);
+    let dir = path.resolve(fromDirectory);
+    for (;;) {
+        if (existsSync(path.join(dir, 'node_modules', name))) {
+            return true;
+        }
+        const parent = path.dirname(dir);
+        if (dir === stopAt || parent === dir) {
+            return false;
+        }
+        dir = parent;
+    }
 }
 
 async function resolveFromLaunchConfiguration(

--- a/evals/src/runtime/runtimeTarget.ts
+++ b/evals/src/runtime/runtimeTarget.ts
@@ -384,30 +384,6 @@ async function completeTarget(
 }
 
 /**
- * Whether this package's declared dependencies are installed somewhere Node will find them.
- *
- * Node resolves a bare specifier by walking `node_modules` up the directory chain, and npm
- * workspaces **hoist** shared dependencies to the monorepo root. So a workspace package can be
- * completely and correctly installed while its own directory has no `node_modules` at all —
- * which is precisely the layout architecture.md prescribes
- * (`"workspaces": ["services/functions", "services/web", "services/shared"]`).
- *
- * Testing only `<package>/node_modules` therefore reds a correctly-installed project. Measured,
- * at full price, on two runs of the same stack that differ in nothing else:
- *
- *   2026083152684407  `npm --prefix services/functions install`     -> local node_modules, gates ran
- *   2026083167798590  `npm install --workspace=services/functions`  -> hoisted to the root,
- *                     all five runtime gates reported "declares dependencies but has no
- *                     node_modules" while `project-builds` passed on the same tree
- *
- * Both invocations are correct npm. The gates were grading which one the agent happened to
- * pick, and reporting the difference as a harness fault — a red with nothing to say about the
- * product, from a precondition that exists specifically to avoid inventing one.
- *
- * Two deliberate choices:
- *
- * - **Presence on disk, not `require.resolve`.** Resolution applies `exports` conditions, so an
- *   ESM-only dependency (`"type": "module"` exposing only an `import` condition) throws
  *   `ERR_PACKAGE_PATH_NOT_EXPORTED` under CJS resolution and would be reported as missing. The
  *   question here is only whether an install happened; a directory answers that without
  *   inheriting condition semantics.


### PR DESCRIPTION
Found while re-running #1758's confirming eval. Two runs of `react-functions-postgres`/`local` that differ in nothing but which equivalent `npm` command the agent chose:

| Run | Install command | Result |
|---|---|---|
| [`2026083152684407`](https://msbenchapp.azurewebsites.net/run-analysis/2026083152684407) | `npm --prefix services/functions install` | local `node_modules`; gates ran, `runtime-app-starts` + `runtime-health` **passed** |
| [`2026083167798590`](https://msbenchapp.azurewebsites.net/run-analysis/2026083167798590) | `npm install --workspace=services/functions` | hoisted to `/workspace/node_modules`; **all five** runtime gates exit 3 |

The second run's gates all said:

```
GRADER ERROR: gate=runtime-app-starts — could not run —
/workspace/services/functions declares dependencies but has no node_modules,
so the app cannot start. Run validate-project-builds (or npm install) first.
```

…on a tree where `project-builds` **passed**. A passing build gate and five gates claiming nothing is installed cannot both be describing the product.

## Cause

`runtimeTarget.ts` tested `existsSync(<package>/node_modules)`. Node resolves a bare specifier by walking `node_modules` *up* the directory chain, and npm workspaces hoist to the monorepo root — which is exactly the layout `architecture.md` prescribes (`workspaces: [services/functions, services/web, services/shared]`). So a fully installed workspace legitimately has no `node_modules` of its own, and the one precondition whose purpose is to avoid inventing a failure invented one.

## Fix

Walk up for each declared dependency, mirroring Node. Two deliberate choices, both recorded in the code:

- **Presence on disk, not `require.resolve`** — resolution applies `exports` conditions, so an ESM-only dependency throws `ERR_PACKAGE_PATH_NOT_EXPORTED` under CJS resolution and would be reported missing. That trades this false negative for a subtler one.
- **Bounded at `workspaceRoot`** — Node walks to the filesystem root; this also runs on developer machines, where an unbounded walk out of a fixture finds the repo's own `node_modules` and reports an uninstalled project as installed.

## Verification

Six fixtures covering both real run layouts. The fix passes all six; the previous implementation fails exactly one — `hoisted`, i.e. run `2026083167798590` — and no safety case changes:

```
local     (npm --prefix ...)                 true   was true
hoisted   (npm install -w ...)               true   was FALSE
split     (hoist + nested version pin)       true   was true
partial   (one dep missing)                  false  was false
none      (never installed)                  false  was false
bounded   (node_modules ABOVE workspaceRoot) false  was false
```

`drift`, `typecheck`, `imports:self-test`, `certify`, `stacks:check`, `gates`, `lint`, `clean-machine:check` all pass.

## Not done

No permanent self-test wired into `contracts`. The six fixtures above were scratch. Happy to add one if you want this guarded the way `imports:self-test` and `msbench:self-test` are — it is the kind of rule this repo usually turns into a mechanism.