### PR TITLE
fix: let users reopen the progress view after closing it early

### DIFF
--- a/docs/copilot-create-project.md
+++ b/docs/copilot-create-project.md
@@ -298,6 +298,12 @@ Development → Deploy) and their status.
   <img src="images/copilot-create-project/12-azure-project-progress-tree.png" alt="Azure Project progress tree" />
 </p>
 
+**Reopening the progress view.** While a phase is running, Copilot shows a transient progress view
+(*"Copilot is working…"*) that bridges to the next surface. If you close that tab early, a
+**Show Copilot progress** item appears in the status bar (Source: **Azure Resources**) that reopens it — so
+dismissing the view never leaves you without visible progress. It disappears automatically once the flow moves
+on to its next surface.
+
 ## Autopilot mode
 
 Autopilot runs the whole pipeline **unattended** — no approval gates, no Next Steps prompts. It activates when

--- a/src/commands/copilotOnRails/registerCopilotOnRailsCommands.ts
+++ b/src/commands/copilotOnRails/registerCopilotOnRailsCommands.ts
@@ -15,6 +15,7 @@ import { openDeployResultViewFromWorkspace } from '../../webviews/copilotOnRails
 import { openFrontendPreviewView } from '../../webviews/copilotOnRails/extension/openFrontendPreviewView';
 import { openLocalDevNextStepsView } from '../../webviews/copilotOnRails/extension/openLocalDevNextStepsView';
 import { openLocalPlanViewFromWorkspace } from '../../webviews/copilotOnRails/extension/openLocalPlanView';
+import { reopenLoadingView } from '../../webviews/copilotOnRails/extension/openLoadingView';
 import { openRequirementsViewFromWorkspace } from '../../webviews/copilotOnRails/extension/openRequirementsView';
 import { openScaffoldNextStepsView } from '../../webviews/copilotOnRails/extension/openScaffoldNextStepsView';
 import { openPlanViewFromWorkspace } from '../../webviews/copilotOnRails/extension/openScaffoldPlanView';
@@ -46,6 +47,7 @@ export const copilotOnRailsCommandIds = {
     openDeployResultView: corId('openDeployResultView'),
 
     resumeProjectWithCopilot: corId('resumeProjectWithCopilot'),
+    showProgressView: corId('showProgressView'),
     refreshProjectTree: `${azureProjectId}.refresh`,
     inspectDiagnostics: corId('inspectDiagnostics'),
     reportIssue: corId('reportIssue'),
@@ -141,6 +143,7 @@ export function registerCopilotOnRailsCommands(): void {
     registerCopilotOnRailsCommand(copilotOnRailsCommandIds.openDeployResultView, openDeployResultViewFromWorkspace);
 
     registerCopilotOnRailsCommand(copilotOnRailsCommandIds.resumeProjectWithCopilot, resumeProjectWithCopilot);
+    registerCommand(copilotOnRailsCommandIds.showProgressView, () => reopenLoadingView());
     registerCommand(copilotOnRailsCommandIds.refreshProjectTree, () => ext.actions.refreshProjectTree());
     registerCommand(copilotOnRailsCommandIds.inspectDiagnostics, inspectDiagnostics);
     registerCommand(copilotOnRailsCommandIds.reportIssue, reportIssue);

--- a/src/webviews/copilotOnRails/extension/openLoadingView.ts
+++ b/src/webviews/copilotOnRails/extension/openLoadingView.ts
@@ -4,15 +4,36 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from "vscode";
+import { copilotOnRailsCommandIds } from "../../../commands/copilotOnRails/registerCopilotOnRailsCommands";
+import { ext } from "../../../extensionVariables";
 import { type LoadingViewConfiguration } from "../views/utils/viewConfigTypes";
 import { LoadingViewController } from "./controllers/LoadingViewController";
 
 let controller: LoadingViewController | undefined;
 
 /**
+ * The config the loading view was last shown with, kept so the progress surface
+ * can be reopened after the user closes its tab early.
+ */
+let lastConfig: LoadingViewConfiguration | undefined;
+
+/**
+ * True while {@link closeLoadingView} is disposing the panel, so the dispose
+ * handler can tell a programmatic phase hand-off apart from the user closing the
+ * progress tab themselves.
+ */
+let closingProgrammatically = false;
+
+/** Status-bar affordance offering to reopen the progress view after an early close. */
+let reopenStatusBarItem: vscode.StatusBarItem | undefined;
+
+/**
  * Show or update the transient loading view used to bridge workflow steps
  */
 export function openLoadingView(config: LoadingViewConfiguration): void {
+    lastConfig = config;
+    hideReopenAffordance();
+
     if (controller) {
         controller.updateConfig(config);
         controller.revealToForeground(vscode.ViewColumn.Active);
@@ -23,15 +44,60 @@ export function openLoadingView(config: LoadingViewConfiguration): void {
     controller.revealToForeground(vscode.ViewColumn.Active);
     controller.panel.onDidDispose(() => {
         controller = undefined;
+        // A dispose we didn't initiate means the user closed the progress tab
+        // while work was still in flight. Surface a one-click way back instead
+        // of stranding them with no visible progress.
+        if (!closingProgrammatically) {
+            showReopenAffordance();
+        }
     });
 }
 
 /** Dispose the loading view, if any. Safe to call when no loading view is open. */
 export function closeLoadingView(): void {
-    controller?.panel.dispose();
+    closingProgrammatically = true;
+    try {
+        controller?.panel.dispose();
+    } finally {
+        closingProgrammatically = false;
+    }
     controller = undefined;
+    // A programmatic close means the flow moved on to its next surface, so the
+    // progress view is intentionally gone — drop the reopen affordance and the
+    // stale config it would reopen.
+    lastConfig = undefined;
+    hideReopenAffordance();
 }
 
 export function isLoadingViewOpen(): boolean {
     return controller !== undefined;
+}
+
+/**
+ * Reopens the progress view with the config it last displayed. Backs the
+ * "Show Copilot progress" affordance shown after an early close. No-op when
+ * there is nothing to reopen.
+ */
+export function reopenLoadingView(): void {
+    if (lastConfig) {
+        openLoadingView(lastConfig);
+    }
+}
+
+function showReopenAffordance(): void {
+    if (!lastConfig) {
+        return;
+    }
+    if (!reopenStatusBarItem) {
+        reopenStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 99);
+        reopenStatusBarItem.command = copilotOnRailsCommandIds.showProgressView;
+        reopenStatusBarItem.text = `$(loading~spin) ${vscode.l10n.t('Show Copilot progress')}`;
+        reopenStatusBarItem.tooltip = vscode.l10n.t('Reopen the Copilot progress view you closed');
+        ext.context.subscriptions.push(reopenStatusBarItem);
+    }
+    reopenStatusBarItem.show();
+}
+
+function hideReopenAffordance(): void {
+    reopenStatusBarItem?.hide();
 }


### PR DESCRIPTION
The transient 'Copilot is working' progress view had no way back once its tab was closed while a phase was still running. Track the last-shown config, distinguish a user close from a programmatic hand-off, and surface a 'Show Copilot progress' status-bar item that reopens it. The affordance clears automatically when the flow advances to its next surface.

Fixes microsoft/azcode-internal#274