### PR TITLE
fix: don't force the debug view when iterating via Next Steps

### DIFF
--- a/src/webviews/copilotOnRails/extension/controllers/LocalDevNextStepsViewController.ts
+++ b/src/webviews/copilotOnRails/extension/controllers/LocalDevNextStepsViewController.ts
@@ -50,7 +50,6 @@ export class LocalDevNextStepsViewController extends WebviewController<LocalDevN
                             return;
                         }
                         this.panel.dispose();
-                        await vscode.commands.executeCommand('workbench.view.debug');
                         await vscode.commands.executeCommand('workbench.action.chat.open', await buildChatOpenOptions(corContext, {
                             query: vscode.l10n.t('I want to keep iterating on my project'),
                         }));


### PR DESCRIPTION
The Debug Next Steps 'keep iterating' action switched the workbench to the Run and Debug view before opening chat, yanking users out of their current view. Open chat without changing the active view.

Fixes microsoft/azcode-internal#275