### PR TITLE
Add 8 plan-phase scenario stimuli and two requirements grader flags

### DIFF
--- a/evals/grader-certification/manifest.json
+++ b/evals/grader-certification/manifest.json
@@ -1167,6 +1167,164 @@
             "operation": "relocate",
             "replacement": "infra/main.tf",
             "expectedCode": "!noIacFound"
+        },
+        {
+            "comment": "The preview manifest is absent entirely. Until now the only preview case was previewStatus:draft, which means every failure path that runs *before* a manifest is in hand — the file missing, the file unparseable — was uncertified, and `preview` was the least-exercised validator we ship at one single case. A missing manifest is the ordinary shape of a preview step that never ran, so this is the first thing the validator should be able to say.",
+            "id": "preview-manifest-absent",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "preview",
+            "file": ".azure/.preview-temp/manifest.json",
+            "operation": "delete",
+            "expectedCode": "missingPreviewManifest"
+        },
+        {
+            "comment": "The manifest exists but is not JSON. Distinct from the case above because the remedy is different: a missing file means the preview step did not run, a corrupt one means it ran and produced garbage. Collapsing the two would send the reader to look for a step that plainly executed.",
+            "id": "preview-manifest-unparseable",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "preview",
+            "file": ".azure/.preview-temp/manifest.json",
+            "operation": "replace",
+            "search": "\"previewStatus\": \"ready\",",
+            "replacement": "\"previewStatus\": \"ready\",,",
+            "expectedCode": "invalidPreviewManifest"
+        },
+        {
+            "comment": "Paired with the case above, and the reason the pair exists: previewStatus is read *out of* the manifest, so a manifest that does not parse cannot also be meaningfully 'not ready'. Reporting previewNotReady here would name a status field inside a file the validator was never able to read. Negative because includes() cannot falsify a spurious extra code.",
+            "id": "preview-unparseable-is-not-called-not-ready",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "preview",
+            "file": ".azure/.preview-temp/manifest.json",
+            "operation": "replace",
+            "search": "\"previewStatus\": \"ready\",",
+            "replacement": "\"previewStatus\": \"ready\",,",
+            "expectedCode": "!previewNotReady"
+        },
+        {
+            "comment": "A manifest that parses, declares itself ready, and lists no pages. This is the empty-success case — the preview step reports completion having rendered nothing — and it is worth its own case because status and content are independent claims: 'ready' is the agent's assertion, pages[] is the evidence for it. Renaming the populated array rather than emptying it in place keeps the mutation to a single line while leaving the JSON valid.",
+            "id": "preview-ready-with-no-pages",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "preview",
+            "file": ".azure/.preview-temp/manifest.json",
+            "operation": "replace",
+            "search": "\"pages\": [",
+            "replacement": "\"pages\": [], \"ignoredPages\": [",
+            "expectedCode": "missingPreviewPages"
+        },
+        {
+            "comment": "A slug that is neither lowercase nor hyphen-separated. Slugs become filenames — the validator resolves `${slug}.html` on disk — so a slug carrying uppercase or an underscore is a page that cannot be found on a case-sensitive filesystem even though the manifest swears it is there. Certifying the regex matters because it is the only thing standing between a manifest entry and a broken link.",
+            "id": "preview-slug-not-kebab-case",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "preview",
+            "file": ".azure/.preview-temp/manifest.json",
+            "operation": "replace",
+            "search": "\"slug\": \"project-tracker\",",
+            "replacement": "\"slug\": \"Project_Tracker\",",
+            "expectedCode": "invalidPreviewSlug"
+        },
+        {
+            "comment": "Two pages claiming the same slug. Because slug determines the output filename, a duplicate means the second page silently overwrites the first: the manifest lists two pages, the user is shown one, and nothing about the run looks wrong. The injected page reuses the existing slug so the .html file still resolves — this isolates the collision itself rather than also tripping a missing-page check.",
+            "id": "preview-duplicate-slug",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "preview",
+            "file": ".azure/.preview-temp/manifest.json",
+            "operation": "replace",
+            "search": "\"pages\": [",
+            "replacement": "\"pages\": [ { \"slug\": \"project-tracker\", \"title\": \"Duplicate\" },",
+            "expectedCode": "duplicatePreviewSlug"
+        },
+        {
+            "comment": "A Vite frontend with no vite.config file at all. The config carries every setting that makes the dev server embeddable in the preview webview, so its absence is not a style problem — it is the difference between a preview that renders and a blank panel.",
+            "id": "frontend-scaffold-vite-config-absent",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "frontend-scaffold",
+            "file": "services/web/vite.config.ts",
+            "operation": "delete",
+            "expectedCode": "missingViteConfig"
+        },
+        {
+            "comment": "The dev server binds loopback instead of all interfaces. This is the canonical 'works on my machine' preview failure: the server starts, the terminal looks healthy, and nothing outside the container - webview or forwarded port - can reach it. Note the check's polarity: the issue fires when `host: true` is ABSENT, so the mutation must remove the good value rather than add a bad one.",
+            "id": "frontend-scaffold-dev-server-binds-loopback",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "frontend-scaffold",
+            "file": "services/web/vite.config.ts",
+            "operation": "replace",
+            "search": "host: true,",
+            "replacement": "host: false,",
+            "expectedCode": "devServerNotReachable"
+        },
+        {
+            "comment": "strictPort: true makes the dev server exit when its preferred port is taken rather than picking a free one. In a preview that starts servers it does not control the port is routinely taken, so this turns an ordinary collision into a hard failure. Same inverted polarity as the case above.",
+            "id": "frontend-scaffold-strict-port-rejects-free-port",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "frontend-scaffold",
+            "file": "services/web/vite.config.ts",
+            "operation": "replace",
+            "search": "strictPort: false,",
+            "replacement": "strictPort: true,",
+            "expectedCode": "devServerStrictPort"
+        },
+        {
+            "comment": "Characterization, not aspiration: this records what the validator does today, which is not what its issue codes suggest. A corrupt package.json makes the directory fail discovery, so the run reports frontendNotFound and `invalidFrontendPackageJson` never fires - discovery reads the manifest to decide whether a directory is a frontend at all, and loses the reason on the way. The reported message is therefore false about the workspace: services/web plainly exists with a full source tree. This is the same defect class the noPackagesFound / unparseablePackageManifest pair was written to catch. Pinned here so that fixing it is a visible, deliberate change rather than a silent one.",
+            "id": "frontend-scaffold-unparseable-manifest-loses-the-reason",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "frontend-scaffold",
+            "file": "services/web/package.json",
+            "operation": "replace",
+            "search": "\"private\": true,",
+            "replacement": "\"private\": true,,",
+            "expectedCode": "frontendNotFound"
+        },
+        {
+            "comment": "No way to start the frontend. The validator accepts either `dev` or `start`, so the mutation renames the only one present to a third name rather than deleting it - that keeps the scripts block populated and proves the check is looking for the specific contract rather than merely noticing an empty object.",
+            "id": "frontend-scaffold-no-dev-or-start-script",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "frontend-scaffold",
+            "file": "services/web/package.json",
+            "operation": "replace",
+            "search": "\"dev\": \"vite\",",
+            "replacement": "\"serve\": \"vite\",",
+            "expectedCode": "missingDevScript"
+        },
+        {
+            "comment": "The api seam directory survives but loses its entry point. This is deliberately narrower than the missingApiSeam case: the seam is still there, so the failure is that integration no longer has a single documented file to swap. Deleting one file rather than the directory is what isolates the two.",
+            "id": "frontend-scaffold-api-seam-entry-absent",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "frontend-scaffold",
+            "file": "services/web/src/api/index.ts",
+            "operation": "delete",
+            "expectedCode": "missingApiSeamEntry"
+        },
+        {
+            "comment": "Deleting the preview-state switcher outright produces no issue at all, and that is the finding. The check asks whether any file under src/api mentions PreviewDataState or previewState, so mockClient.ts referring to the module is enough to satisfy it after the module itself is gone. A mention is not an implementation: an agent can delete the switcher and keep a stray import or comment and still pass. Expecting `passed` pins the current weakness, so that strengthening the check to look for the export rather than the string turns this case red and forces a deliberate rewrite instead of leaving the gap unrecorded.",
+            "id": "frontend-scaffold-preview-state-switcher-deletion-undetected",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "frontend-scaffold",
+            "file": "services/web/src/api/previewState.ts",
+            "operation": "delete",
+            "expectedCode": "passed"
+        },
+        {
+            "comment": "The companion to the unparseable-manifest case, and the reason both are worth keeping: a frontend directory with its entire source tree intact but no package.json also reports frontendNotFound rather than missingFrontendPackageJson. Between the two, `missingFrontendPackageJson` and `invalidFrontendPackageJson` are unreachable on the discovery path - they can only fire when a caller passes an explicit frontendDirectory. Certifying the real precedence is worth more than asserting a code that never arrives.",
+            "id": "frontend-scaffold-absent-manifest-loses-the-reason",
+            "tier": "offline",
+            "fixture": "sample-agent-output",
+            "validator": "frontend-scaffold",
+            "file": "services/web/package.json",
+            "operation": "delete",
+            "expectedCode": "frontendNotFound"
         }
     ]
 }

--- a/evals/graders/validate-requirements.ts
+++ b/evals/graders/validate-requirements.ts
@@ -10,7 +10,8 @@
  * with grader certification). Only scenario-specific expectations are expressed here.
  *
  * Flags: --assert-no-frontend, --assert-blob-storage, --assert-cosmosdb,
- *        --assert-no-datastore, --assert-service-count=N
+ *        --assert-no-datastore, --assert-service-count=N,
+ *        --assert-datastore-includes=<substring>, --assert-auth-includes=<substring>
  */
 
 import { parseRequirementsJson } from '../../src/webviews/copilotOnRails/views/utils/parseRequirements.ts';
@@ -45,6 +46,43 @@ runGrader('requirements.json satisfies the requirements contract', () => {
         }
         if (recommended.length > 1) {
             fail(`"No datastore required" must not be combined with other stores, got: ${describe(recommended)}`);
+        }
+    }
+
+    // Generalises the two hard-coded store flags above. Cosmos and Blob each earned a
+    // dedicated flag before there was a second scenario needing a third store; adding
+    // MySQL or Redis the same way would be a flag per store forever. Substring rather
+    // than equality because recommendedChoice carries product names ("Azure Database
+    // for MySQL - Flexible Server"), and a stimulus should be able to say "MySQL"
+    // without pinning the exact marketing string, which changes independently of the
+    // behaviour under test.
+    const datastoreFlag = [...flags].find(flag => flag.startsWith('--assert-datastore-includes='));
+    if (datastoreFlag) {
+        const needle = datastoreFlag.slice('--assert-datastore-includes='.length);
+        if (!needle) {
+            throw new Error(`Invalid ${datastoreFlag}: expected a non-empty substring`);
+        }
+        if (!recommended.some(choice => choice.toLowerCase().includes(needle.toLowerCase()))) {
+            fail(`Expected a datastore matching "${needle}" in recommendedChoice, got: ${describe(recommended)}`);
+        }
+    }
+
+    // The shared `auth` question is mandatory in every valid artifact — the validator
+    // raises `missingAuth` without it — but no scenario in this repo has ever answered
+    // it with anything but "No auth", so the whole identity path was untested. Substring
+    // for the same reason as datastores: "Microsoft Entra ID" and "Microsoft Entra
+    // External ID" are both defensible for a given prompt, and a stimulus should be able
+    // to say "Entra" without adjudicating workforce-versus-external identity.
+    const authFlag = [...flags].find(flag => flag.startsWith('--assert-auth-includes='));
+    if (authFlag) {
+        const needle = authFlag.slice('--assert-auth-includes='.length);
+        if (!needle) {
+            throw new Error(`Invalid ${authFlag}: expected a non-empty substring`);
+        }
+        const auth = requirements.questions.find(question => question.id === 'auth' && !question.serviceId);
+        const authChoice = toArray(auth?.recommendedChoice);
+        if (!authChoice.some(choice => choice.toLowerCase().includes(needle.toLowerCase()))) {
+            fail(`Expected an auth choice matching "${needle}", got: ${describe(authChoice)}`);
         }
     }
 

--- a/evals/msbench/config/stimuli/ai-chatbot-documents.yaml
+++ b/evals/msbench/config/stimuli/ai-chatbot-documents.yaml
@@ -1,0 +1,51 @@
+# Stimulus `ai-chatbot-documents`.
+# Concatenated onto config/base.yaml by build-config.ts.
+#
+# The most common thing a user asks for that this suite has never asked for.
+# All five existing plan stimuli are CRUD or static: task app, photo app,
+# inventory API, order processing, unit converter. None of them reaches an
+# AI service at all, so every mapping decision on that path — Azure OpenAI,
+# a retrieval store, where the source documents live — is unexercised.
+#
+# The assertion is deliberately the *storage* claim rather than the model
+# choice. "Which AI service" is a moving product judgement and would make this
+# stimulus a thermometer for Azure's naming; "the PDFs have to be stored
+# somewhere durable" is a structural consequence of the prompt that holds
+# regardless of which model gets picked. `--assert-blob-storage` already
+# expresses exactly that and needs no new grader flag.
+
+promptSteps:
+  - text: |
+      I want an internal chatbot that can answer questions about our company
+      policies. We have a few hundred PDFs and Word docs that people need to
+      search through. Staff should be able to ask it questions in plain English
+      and get an answer with a link to the source document.
+    assertions:
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      - comment: Agent should have written the requirements artifact
+        query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'
+
+      # The documents are the whole point of the app; they need somewhere durable
+      # to live. A plan that never names a document store has not planned this app.
+      - comment: requirements.json should place the source documents in Blob Storage
+        exec: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-requirements.ts --assert-blob-storage
+
+      - comment: Agent should have opened the requirements webview
+        query: SELECT COUNT(*) > 0 FROM toolCalls WHERE tool LIKE '%open_requirements_view%'
+
+      - comment: Agent should not fall back to the chat question tool
+        query: SELECT COUNT(*) = 0 FROM toolCalls WHERE tool LIKE '%askQuestion%'
+
+      - comment: Triage; are the files-asserted paths on disk at all?
+        exec: 'echo ".azure/requirements.json: $(test -f .azure/requirements.json && echo present || echo absent)"'
+        assertZeroExitCode: false
+
+      - comment: Triage; which question ids did the agent capture?
+        exec: 'grep -o "\"id\": *\"[^\"]*\"" .azure/requirements.json 2>/dev/null | head -40'
+        assertZeroExitCode: false
+
+      - comment: Environment fingerprint for triage
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java azurite psql postgres mongod redis-server; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/auth-expense-tracker.yaml
+++ b/evals/msbench/config/stimuli/auth-expense-tracker.yaml
@@ -1,0 +1,70 @@
+# Stimulus `auth-expense-tracker`.
+# Concatenated onto config/base.yaml by build-config.ts.
+#
+# No stimulus in this suite has ever asked for a user to log in. The word
+# "accounts" appears once across all five plan prompts, in `no-datastore-converter`,
+# and there it appears in the negative ("no accounts"). So the entire identity
+# and secrets path is unreached: Entra ID, and behind it Key Vault, and behind
+# that the two Key Vault conformance rules — KV-NO-PURGE (a subscription policy
+# rejects `enablePurgeProtection: false`, so it must be omitted entirely) and
+# KV-DEPLOYER-ROLE (without the Secrets Officer role assignment, the deploy
+# phase's `az keyvault secret set` fails 403).
+#
+# Both rules were written against real deployment failures. Neither can fire
+# until a plan produces a Key Vault, and nothing here has ever needed one.
+#
+# The assertion below is real, and it was nearly not written. The shared `auth`
+# question is *mandatory* in every valid artifact — `requirements.ts` raises
+# `missingAuth` without it — and `azure-project-plan/requirements.md:134` fixes
+# its option set: `No auth`, `Mock auth middleware`, `Microsoft Entra ID`,
+# `Microsoft Entra External ID`, `Auth0`, `Clerk`. Entra ID's own description is
+# "Workforce identity — sign in with org or Microsoft accounts", which is this
+# prompt restated. So the correct answer here is contracted, not a matter of
+# taste, and it is gradeable at the plan phase.
+#
+# Every scenario.json in this repo answers `auth` with "No auth". The documented
+# default is `Mock auth middleware` when there is user data, else `No auth` — so
+# a planner that ignores the prompt lands on a wrong-but-plausible value rather
+# than an empty one, which is exactly the failure a schema check cannot see.
+#
+# Substring "Entra" rather than a full label: workforce (Entra ID) versus
+# external (Entra External ID) is a defensible judgement call for some prompts,
+# and pinning one would fail correct plans for being differently correct.
+
+promptSteps:
+  - text: |
+      We need an internal expense tracker. Staff submit expenses with a receipt
+      photo, their manager approves or rejects them, and finance exports the
+      approved ones at month end. Everyone here already has a work Microsoft
+      account, so they should just sign in with that rather than making a new
+      password.
+    assertions:
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      - comment: Agent should have written the requirements artifact
+        query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'
+
+      # Also runs the full schema validation, so no separate flagless exec is needed.
+      - comment: requirements.json should select Entra ID for work-account sign-in
+        exec: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-requirements.ts --assert-auth-includes=Entra
+
+      - comment: Agent should have opened the requirements webview
+        query: SELECT COUNT(*) > 0 FROM toolCalls WHERE tool LIKE '%open_requirements_view%'
+
+      - comment: Agent should not fall back to the chat question tool
+        query: SELECT COUNT(*) = 0 FROM toolCalls WHERE tool LIKE '%askQuestion%'
+
+      - comment: Triage; are the files-asserted paths on disk at all?
+        exec: 'echo ".azure/requirements.json: $(test -f .azure/requirements.json && echo present || echo absent)"'
+        assertZeroExitCode: false
+
+      # Recorded, not asserted. Auth itself is now asserted above; this shows how
+      # secrets and Key Vault are represented, which is not yet contracted.
+      - comment: Triage; how did the planner represent sign-in and secrets?
+        exec: 'grep -io "entra\|azure ad\|active directory\|oauth\|auth\|sign.in\|identity\|key vault\|keyvault" .azure/requirements.json 2>/dev/null | sort | uniq -c | head -20'
+        assertZeroExitCode: false
+
+      - comment: Environment fingerprint for triage
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java azurite psql postgres mongod redis-server; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/cost-constrained-blog.yaml
+++ b/evals/msbench/config/stimuli/cost-constrained-blog.yaml
@@ -1,0 +1,63 @@
+# Stimulus `cost-constrained-blog`.
+# Concatenated onto config/base.yaml by build-config.ts.
+#
+# Cost is heavily contracted and never pressured. `prepare-schemas.ts` requires
+# a `costEstimate`, a `rejectedAlternatives` list, and the
+# `f1Viable` / `f1BlockReason` pair that has to move together;
+# `dependency-compatibility.md` makes native modules change the SKU choice
+# between F1 and B1. Not one existing prompt gives the planner a reason to
+# prefer the cheap option, so the entire free-tier path is chosen — if it is
+# ever chosen — without anything asking for it.
+#
+# ## Why the assertion here is only the schema contract
+#
+# `costEstimate` lives in `prepare-plan.json`, which is written by the prepare
+# phase. This suite has no prepare phase: the phase files are plan, scaffold,
+# local, deploy-scaffold, chain-probe, probe-smoke and debug-breakpoint. So
+# there is no artifact in this run that can carry a cost claim, and any
+# cost assertion written here today would be asserting against a file that is
+# never produced.
+#
+# Rather than write a green-forever check, the cost triage below is recorded and
+# not asserted — the same `assertZeroExitCode: false` shape the fingerprint uses.
+# The first run of this stimulus answers the question the assertion needs:
+# does the planner record budget pressure anywhere in `requirements.json`?
+# If it does, that becomes a real flag. If it does not, this file is the
+# evidence that cost cannot be graded before a prepare phase exists.
+
+promptSteps:
+  - text: |
+      I want to put a small personal blog online — just me posting occasionally,
+      maybe a hundred visitors a month. I'm paying for this myself so keep it as
+      cheap as you possibly can. Free would be ideal.
+    assertions:
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      - comment: Agent should have written the requirements artifact
+        query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'
+
+      # Wording is pinned to photo-app-requirements.yaml: same exec means same
+      # gate, and the comment is that gate's only identifier in stored results.
+      - comment: requirements.json satisfies the requirements contract
+        exec: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-requirements.ts
+
+      - comment: Agent should have opened the requirements webview
+        query: SELECT COUNT(*) > 0 FROM toolCalls WHERE tool LIKE '%open_requirements_view%'
+
+      - comment: Agent should not fall back to the chat question tool
+        query: SELECT COUNT(*) = 0 FROM toolCalls WHERE tool LIKE '%askQuestion%'
+
+      - comment: Triage; are the files-asserted paths on disk at all?
+        exec: 'echo ".azure/requirements.json: $(test -f .azure/requirements.json && echo present || echo absent)"'
+        assertZeroExitCode: false
+
+      # Recorded, not asserted. Decides whether budget pressure is gradeable at
+      # the plan phase at all, or only once a prepare phase exists.
+      - comment: Triage; did the planner record any cost or tier signal?
+        exec: 'grep -io "free\|cost\|budget\|tier\|sku\|f1\|b1" .azure/requirements.json 2>/dev/null | sort | uniq -c | head -20'
+        assertZeroExitCode: false
+
+      - comment: Environment fingerprint for triage
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java azurite psql postgres mongod redis-server; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/eu-data-residency-portal.yaml
+++ b/evals/msbench/config/stimuli/eu-data-residency-portal.yaml
@@ -1,0 +1,62 @@
+# Stimulus `eu-data-residency-portal`.
+# Concatenated onto config/base.yaml by build-config.ts.
+#
+# Region is a contracted, derived, and entirely unexercised field.
+# `prepare-schemas.ts:170` defines `quotaValidation.offerRestrictionsVerified`
+# as true only when every database service has a matching entry in
+# `offerRestrictions[]`; `prepare/instructions.md:58` forbids presenting a region
+# without checking quota first; and `deploy-checklist-template.md:69` requires a
+# region change to re-present the deploy approval gate showing old and new.
+#
+# All three presume a user who cares which region they land in. No prompt in
+# this suite mentions a region at all, so the region is whatever the default is,
+# every time, and none of that machinery has been asked a question.
+#
+# Data residency is also the most common form the requirement actually takes.
+# Users rarely say "deploy to West Europe"; they say the data cannot leave the
+# EU, which is a constraint the planner has to translate into a region — and
+# then keep, through quota checking and offer restrictions, without silently
+# relocating to somewhere with more capacity.
+#
+# Schema-only assertion: `quotas`, `offerRestrictions` and the region live in
+# `prepare-plan.json`, and this suite has no prepare phase. The triage records
+# whether the constraint survives the plan phase, which is what a real
+# assertion would need to stand on.
+
+promptSteps:
+  - text: |
+      We're building a customer portal for our European clients — they log in,
+      see their contracts and invoices, and download statements. Our legal team
+      is strict about this: all customer data has to stay inside the EU. It
+      cannot be stored or processed anywhere else.
+    assertions:
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      - comment: Agent should have written the requirements artifact
+        query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'
+
+      # Wording is pinned to photo-app-requirements.yaml: same exec means same
+      # gate, and the comment is that gate's only identifier in stored results.
+      - comment: requirements.json satisfies the requirements contract
+        exec: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-requirements.ts
+
+      - comment: Agent should have opened the requirements webview
+        query: SELECT COUNT(*) > 0 FROM toolCalls WHERE tool LIKE '%open_requirements_view%'
+
+      - comment: Agent should not fall back to the chat question tool
+        query: SELECT COUNT(*) = 0 FROM toolCalls WHERE tool LIKE '%askQuestion%'
+
+      - comment: Triage; are the files-asserted paths on disk at all?
+        exec: 'echo ".azure/requirements.json: $(test -f .azure/requirements.json && echo present || echo absent)"'
+        assertZeroExitCode: false
+
+      # Recorded, not asserted. A residency constraint that vanishes between the
+      # prompt and the artifact cannot be honoured by any later phase.
+      - comment: Triage; did the data-residency constraint survive into the artifact?
+        exec: 'grep -io "\bEU\b\|europe\|residency\|region\|gdpr\|sovereign\|location" .azure/requirements.json 2>/dev/null | sort | uniq -c | head -20'
+        assertZeroExitCode: false
+
+      - comment: Environment fingerprint for triage
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java azurite psql postgres mongod redis-server; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/mysql-cms.yaml
+++ b/evals/msbench/config/stimuli/mysql-cms.yaml
@@ -1,0 +1,129 @@
+# Stimulus `mysql-cms`.
+# Concatenated onto config/base.yaml by build-config.ts.
+#
+# Written to reach product logic that already exists and currently cannot fire.
+#
+# `scaffold/scripts/scaffold-conformance.ps1` carries three MySQL-specific BLOCK
+# rules — DB-TLS-ON (`require_secure_transport`), MYSQL-NO-NETWORK-BLOCK (an
+# empty `delegatedSubnetResourceId` is rejected by ARM with
+# `LinkedInvalidPropertyId`) and the MySQL half of DB-LOGIN-NOT-RESERVED. Every
+# one of them is gated on a MySQL resource appearing in the IaC, and no stimulus
+# in this suite has ever asked for MySQL: the datastore corpus is PostgreSQL,
+# Cosmos, or nothing. Three rules were written against real deployment failures
+# and have never had the chance to run.
+#
+# ── What a real run showed, which reversed this file's assertion twice ────────
+#
+# First draft asserted `MySQL`. I then talked myself out of it from the docs:
+# `azure-project-plan/requirements.md` fixes the `dataStores` option set — `No
+# datastore required` (exclusive), `Blob Storage`, `Queue Storage`, `PostgreSQL`,
+# `CosmosDB`, `Redis`, `Azure SQL` — and pins `allowFreeformInput: false`. MySQL
+# appears nowhere in it, so asserting MySQL looked like demanding a contract
+# violation: a harness fault wearing a finding's clothes. I weakened the needle
+# to `SQL`, reasoning it would match the two legal relational stores.
+#
+# Run 2026083159733325 showed both steps were wrong.
+#
+# The agent recommended `["MySQL", "Blob Storage"]`. It did not substitute a
+# listed store — it *extended the option list*, emitting `{"label": "MySQL",
+# "description": "MySQL relational database"}` while still correctly setting
+# `allowFreeformInput: false`. Graded against that real artifact:
+#
+#     --assert-datastore-includes=MySQL       MATCH
+#     --assert-datastore-includes=PostgreSQL  no match
+#     --assert-datastore-includes=Azure SQL   no match
+#     --assert-datastore-includes=SQL         MATCH  <- only because "MySQL"
+#                                                       contains "SQL"
+#
+# So `SQL` passed for the wrong reason and cannot distinguish "substituted a
+# legal store" from "invented an option" — the exact question it was rewritten to
+# ask. The assertion is back to `MySQL`, which is now backed by measurement
+# rather than by reading the option table.
+#
+# The doc and the product disagree, and the product looks right: Azure Database
+# for MySQL is a real service, `scaffold-conformance.ps1` already carries MySQL
+# BLOCK rules, and the agent reaches for it when asked. The incomplete thing is
+# the option list in `requirements.md`. That is a doc gap to raise, not something
+# to encode into a weaker gate.
+#
+# ── A second run reversed it once more, and is why this is a probe ────────────
+#
+# Run 2026083177939774 ran the corrected `MySQL` needle and went RED, with:
+#
+#     Expected a datastore matching "MySQL" in recommendedChoice, got: Blob Storage
+#
+# Same prompt, same needle, opposite outcome. The artifact explains it. The agent
+# understood the constraint completely — 28 mentions of MySQL, an explicit
+# "Tech constraint: MySQL database (team already knows it)" in its reasoning —
+# and then emitted `recommendedChoice: ["Blob Storage"]` with this rationale:
+#
+#     "Blob Storage is mandatory for image uploads. Team prefers MySQL for
+#      relational data (Azure Database for MySQL), which will be configured in
+#      the plan."
+#
+# Its `options` array was the canonical seven from `requirements.md` line 133,
+# unextended, with `allowFreeformInput: false`. So across two runs the agent met
+# the same unsatisfiable choice and resolved it two different ways:
+#
+#   run 2026083159733325  invented a MySQL option   -> user intent kept, spec broken
+#   run 2026083177939774  obeyed the fixed list     -> spec kept, user intent lost
+#
+# There is no third outcome where both hold, because the option table makes that
+# combination impossible. Run 2's result is the worse of the two on the merits: a
+# CMS whose structured requirements name no relational datastore at all.
+#
+# That is a product finding, not a harness one, and it is not this suite's to fix
+# from a stimulus. Asserting `MySQL` would be correct and would also be red on
+# roughly every other run — a shared suite cannot carry that. So the check below
+# is RECORDED, NOT ASSERTED, joining the four other constraint-fidelity probes in
+# this suite. The evidence still lands in `session.sqlite` on every run, so the
+# day the option list gains MySQL this flips back to an assertion by deleting one
+# line (`assertZeroExitCode: false`) — and until then, nothing is being hidden.
+#
+# Two runs establish that both behaviours occur. They do NOT establish a rate;
+# do not quote one.
+
+promptSteps:
+  - text: |
+      We're rebuilding our marketing site as a small CMS — editors log in, write
+      articles, upload images, and publish them. Our team already knows MySQL and
+      we have existing tooling around it, so please use MySQL for the database.
+    assertions:
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      - comment: Agent should have written the requirements artifact
+        query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'
+
+      - comment: requirements.json satisfies the requirements contract
+        exec: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-requirements.ts
+
+      # Substring, so the exact product name ("Azure Database for MySQL - Flexible
+      # Server") can change without this becoming a test of Azure's marketing copy.
+      #
+      # Recorded, not asserted: see the header. The agent cannot legally select
+      # MySQL today, so this is red about as often as it is green, and the cause
+      # is a gap in the `dataStores` option table rather than anything the agent
+      # or this harness does wrong. Delete `assertZeroExitCode: false` to re-arm
+      # once that table lists MySQL.
+      - comment: Probe; does requirements.json carry the user's stated MySQL preference?
+        exec: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-requirements.ts --assert-datastore-includes=MySQL
+        assertZeroExitCode: false
+
+      - comment: Agent should have opened the requirements webview
+        query: SELECT COUNT(*) > 0 FROM toolCalls WHERE tool LIKE '%open_requirements_view%'
+
+      - comment: Agent should not fall back to the chat question tool
+        query: SELECT COUNT(*) = 0 FROM toolCalls WHERE tool LIKE '%askQuestion%'
+
+      - comment: Triage; are the files-asserted paths on disk at all?
+        exec: 'echo ".azure/requirements.json: $(test -f .azure/requirements.json && echo present || echo absent)"'
+        assertZeroExitCode: false
+
+      - comment: Triage; which question ids did the agent capture?
+        exec: 'grep -o "\"id\": *\"[^\"]*\"" .azure/requirements.json 2>/dev/null | head -40'
+        assertZeroExitCode: false
+
+      - comment: Environment fingerprint for triage
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java azurite psql postgres mongod redis-server; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/private-internal-hr-tool.yaml
+++ b/evals/msbench/config/stimuli/private-internal-hr-tool.yaml
@@ -1,0 +1,58 @@
+# Stimulus `private-internal-hr-tool`.
+# Concatenated onto config/base.yaml by build-config.ts.
+#
+# The scaffold approval gate offers four options — `Yes / Edit plan / Private
+# access / Cancel` (approval-gates.md). Three of them are reachable by prompts
+# this suite already has. `Private access` is not: no stimulus has ever given
+# the planner a reason to consider it, so a documented branch of the product's
+# own approval gate has never been exercised by anything.
+#
+# The wider gap is public-endpoint-by-default. Every app this suite has planned
+# is meant to be reachable from the internet, so private endpoints, VNet
+# integration and `publicNetworkAccess` have no prompt behind them — and
+# `blocked-patterns.md` treats weakening exactly those controls as a HARD BLOCK,
+# a rule that presumes a scenario where they were set in the first place.
+#
+# Schema-only assertion, for the same reason as `cost-constrained-blog`:
+# networking is decided in the prepare and scaffold phases, and no phase in this
+# suite writes an artifact at the plan step that could carry a private-access
+# claim. The triage records whether the requirement survives the plan phase at
+# all, which is the prerequisite for grading it later.
+
+promptSteps:
+  - text: |
+      We need a small HR tool for tracking employee onboarding checklists.
+      This holds personal data about staff, so it must not be reachable from
+      the public internet — only people on our corporate network should be able
+      to get to it at all.
+    assertions:
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      - comment: Agent should have written the requirements artifact
+        query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'
+
+      # Wording is pinned to photo-app-requirements.yaml: same exec means same
+      # gate, and the comment is that gate's only identifier in stored results.
+      - comment: requirements.json satisfies the requirements contract
+        exec: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-requirements.ts
+
+      - comment: Agent should have opened the requirements webview
+        query: SELECT COUNT(*) > 0 FROM toolCalls WHERE tool LIKE '%open_requirements_view%'
+
+      - comment: Agent should not fall back to the chat question tool
+        query: SELECT COUNT(*) = 0 FROM toolCalls WHERE tool LIKE '%askQuestion%'
+
+      - comment: Triage; are the files-asserted paths on disk at all?
+        exec: 'echo ".azure/requirements.json: $(test -f .azure/requirements.json && echo present || echo absent)"'
+        assertZeroExitCode: false
+
+      # Recorded, not asserted. A hard networking constraint stated in the prompt
+      # either survives into the artifact or is silently dropped; this shows which.
+      - comment: Triage; did the private-network constraint survive into the artifact?
+        exec: 'grep -io "private\|vnet\|virtual network\|internal\|public.network\|endpoint\|firewall" .azure/requirements.json 2>/dev/null | sort | uniq -c | head -20'
+        assertZeroExitCode: false
+
+      - comment: Environment fingerprint for triage
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java azurite psql postgres mongod redis-server; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/realtime-whiteboard.yaml
+++ b/evals/msbench/config/stimuli/realtime-whiteboard.yaml
@@ -1,0 +1,59 @@
+# Stimulus `realtime-whiteboard`.
+# Concatenated onto config/base.yaml by build-config.ts.
+#
+# Every app this suite has planned follows the same request/response shape: a
+# browser asks, a server answers, the connection closes. A collaborative
+# whiteboard cannot work that way — it needs a connection that stays open and a
+# way to fan changes out to everyone else looking at the same board.
+#
+# That reaches hosting decisions nothing here has needed. A persistent
+# connection constrains the compute choice (Static Web Apps cannot terminate
+# one), usually pulls in a dedicated service such as Web PubSub or SignalR, and
+# raises the multi-instance question the CRUD apps never raise: with more than
+# one replica, two users on the same board can land on different instances
+# unless something carries messages between them.
+#
+# Schema-only assertion. A service count would be the obvious check and is the
+# wrong one — a defensible plan here is frontend + API, or frontend + API +
+# a realtime service, or frontend + API + a Redis backplane, and pinning an
+# exact number would fail correct plans for being differently correct. The
+# triage records which shape was chosen so a later flag can be written against
+# what the product actually does rather than what this comment guesses.
+
+promptSteps:
+  - text: |
+      I want to build a collaborative whiteboard — a few people open the same
+      board and can draw on it together, and everyone sees the strokes appear as
+      they happen. Cursors should show where other people are. It needs to feel
+      instant, not like it's refreshing.
+    assertions:
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      - comment: Agent should have written the requirements artifact
+        query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'
+
+      # Wording is pinned to photo-app-requirements.yaml: same exec means same
+      # gate, and the comment is that gate's only identifier in stored results.
+      - comment: requirements.json satisfies the requirements contract
+        exec: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-requirements.ts
+
+      - comment: Agent should have opened the requirements webview
+        query: SELECT COUNT(*) > 0 FROM toolCalls WHERE tool LIKE '%open_requirements_view%'
+
+      - comment: Agent should not fall back to the chat question tool
+        query: SELECT COUNT(*) = 0 FROM toolCalls WHERE tool LIKE '%askQuestion%'
+
+      - comment: Triage; are the files-asserted paths on disk at all?
+        exec: 'echo ".azure/requirements.json: $(test -f .azure/requirements.json && echo present || echo absent)"'
+        assertZeroExitCode: false
+
+      # Recorded, not asserted. Shows whether the persistent-connection
+      # requirement reached the plan, and which shape was chosen for it.
+      - comment: Triage; how did the planner handle the persistent-connection requirement?
+        exec: 'grep -io "websocket\|web pubsub\|signalr\|socket\|realtime\|real-time\|redis\|backplane\|polling" .azure/requirements.json 2>/dev/null | sort | uniq -c | head -20'
+        assertZeroExitCode: false
+
+      - comment: Environment fingerprint for triage
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java azurite psql postgres mongod redis-server; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        assertZeroExitCode: false

--- a/evals/msbench/config/stimuli/scheduled-nightly-report.yaml
+++ b/evals/msbench/config/stimuli/scheduled-nightly-report.yaml
@@ -1,0 +1,55 @@
+# Stimulus `scheduled-nightly-report`.
+# Concatenated onto config/base.yaml by build-config.ts.
+#
+# Every existing stimulus asks for something a person interacts with. This one
+# asks for something nobody looks at: a job that wakes up, does work, and goes
+# back to sleep. That single difference reaches two things the suite has never
+# tested.
+#
+# First, a service with no HTTP endpoint. The deploy artifact contract in
+# deploy-checklist-template.md expects every code-hosting service to appear in
+# `deploy-result.json.endpoints[]`, and a timer-triggered function is the
+# ordinary, correct case where that does not hold. Whether the product handles
+# it or quietly reports a partial deploy is currently unknown.
+#
+# Second, "no UI" as an *inference* rather than an instruction. The one existing
+# no-frontend stimulus (`api-only-inventory`) is told "Just the API, no UI
+# needed" in the prompt. Here nothing says it — the absence of a frontend has to
+# be derived from what the app is. That is the harder and more realistic claim,
+# and it is why the same `--assert-no-frontend` flag means something different
+# in this file than it does there.
+
+promptSteps:
+  - text: |
+      Every night I need something that pulls yesterday's sales numbers out of
+      our database, builds a summary, and emails it to the leadership team.
+      It just needs to run on a schedule — nobody's going to open it.
+    assertions:
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      - comment: Agent should have written the requirements artifact
+        query: SELECT COUNT(*) > 0 FROM files WHERE path LIKE '%.azure/requirements.json'
+
+      # Nothing in the prompt says "no UI" — it has to be inferred from "nobody's
+      # going to open it". A scaffolded React app here is wasted infrastructure.
+      - comment: requirements.json should infer that a scheduled job needs no frontend
+        exec: node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-requirements.ts --assert-no-frontend
+
+      - comment: Agent should have opened the requirements webview
+        query: SELECT COUNT(*) > 0 FROM toolCalls WHERE tool LIKE '%open_requirements_view%'
+
+      - comment: Agent should not fall back to the chat question tool
+        query: SELECT COUNT(*) = 0 FROM toolCalls WHERE tool LIKE '%askQuestion%'
+
+      - comment: Triage; are the files-asserted paths on disk at all?
+        exec: 'echo ".azure/requirements.json: $(test -f .azure/requirements.json && echo present || echo absent)"'
+        assertZeroExitCode: false
+
+      - comment: Triage; which question ids did the agent capture?
+        exec: 'grep -o "\"id\": *\"[^\"]*\"" .azure/requirements.json 2>/dev/null | head -40'
+        assertZeroExitCode: false
+
+      - comment: Environment fingerprint for triage
+        exec: 'uname -sm; echo "cwd=$(pwd)"; echo "node=$(node --version 2>&1 || echo MISSING)"; for b in node npm python3 pip3 func go dotnet docker azd java azurite psql postgres mongod redis-server; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; ls /agent/assets/graders/evals/graders 2>&1 | head'
+        assertZeroExitCode: false

--- a/evals/results/grader-certification/offline/report.json
+++ b/evals/results/grader-certification/offline/report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-31T17:29:46.088Z",
+  "generatedAt": "2026-09-01T03:52:25.615Z",
   "mode": "offline",
   "fixtures": [
     "sample-agent-output",
@@ -419,6 +419,172 @@
       "expected": "missingDatabase",
       "actual": [
         "missingDatabase"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "preview-manifest-absent",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "preview",
+      "expected": "missingPreviewManifest",
+      "actual": [
+        "missingPreviewManifest"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "preview-manifest-unparseable",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "preview",
+      "expected": "invalidPreviewManifest",
+      "actual": [
+        "invalidPreviewManifest"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "preview-unparseable-is-not-called-not-ready",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "preview",
+      "expected": "!previewNotReady",
+      "actual": [
+        "invalidPreviewManifest"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "preview-ready-with-no-pages",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "preview",
+      "expected": "missingPreviewPages",
+      "actual": [
+        "missingPreviewPages"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "preview-slug-not-kebab-case",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "preview",
+      "expected": "invalidPreviewSlug",
+      "actual": [
+        "invalidPreviewSlug"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "preview-duplicate-slug",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "preview",
+      "expected": "duplicatePreviewSlug",
+      "actual": [
+        "duplicatePreviewSlug"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "frontend-scaffold-vite-config-absent",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "frontend-scaffold",
+      "expected": "missingViteConfig",
+      "actual": [
+        "missingViteConfig"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "frontend-scaffold-dev-server-binds-loopback",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "frontend-scaffold",
+      "expected": "devServerNotReachable",
+      "actual": [
+        "devServerNotReachable"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "frontend-scaffold-strict-port-rejects-free-port",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "frontend-scaffold",
+      "expected": "devServerStrictPort",
+      "actual": [
+        "devServerStrictPort"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "frontend-scaffold-unparseable-manifest-loses-the-reason",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "frontend-scaffold",
+      "expected": "frontendNotFound",
+      "actual": [
+        "frontendNotFound"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "frontend-scaffold-no-dev-or-start-script",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "frontend-scaffold",
+      "expected": "missingDevScript",
+      "actual": [
+        "missingDevScript"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "frontend-scaffold-api-seam-entry-absent",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "frontend-scaffold",
+      "expected": "missingApiSeamEntry",
+      "actual": [
+        "missingApiSeamEntry"
+      ],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "frontend-scaffold-preview-state-switcher-deletion-undetected",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "frontend-scaffold",
+      "expected": "passed",
+      "actual": [],
+      "passed": true,
+      "durationMs": 0
+    },
+    {
+      "id": "frontend-scaffold-absent-manifest-loses-the-reason",
+      "tier": "offline",
+      "fixture": "sample-agent-output",
+      "validator": "frontend-scaffold",
+      "expected": "frontendNotFound",
+      "actual": [
+        "frontendNotFound"
       ],
       "passed": true,
       "durationMs": 0

--- a/evals/results/grader-certification/offline/report.md
+++ b/evals/results/grader-certification/offline/report.md
@@ -3,7 +3,7 @@
 - Mode: `offline`
 - Fixtures: `sample-agent-output`, `reference-node-fullstack`, `reference-node-multiservice`, `reference-python-api`, `reference-dotnet-api`, `reference-go-unsupported`, `debug-probe-verdict`, `unapproved-plan-refusal`, `api-only-no-datastore`, `reference-iac-bicep`
 - Outcome: **PASSED**
-- Cases: 125/125 passed
+- Cases: 139/139 passed
 
 | Case | Fixture | Validator | Expected | Actual | Result |
 |---|---|---|---|---|---|
@@ -43,6 +43,20 @@
 | `integration-plan-port-inside-run-command` | `sample-agent-output` | `integration-plan` | `passed` | `passed` | PASS |
 | `integration-plan-missing-backend-port` | `sample-agent-output` | `integration-plan` | `missingBackendPort` | `missingBackendPort` | PASS |
 | `integration-plan-database-section-dropped` | `sample-agent-output` | `integration-plan` | `missingDatabase` | `missingDatabase` | PASS |
+| `preview-manifest-absent` | `sample-agent-output` | `preview` | `missingPreviewManifest` | `missingPreviewManifest` | PASS |
+| `preview-manifest-unparseable` | `sample-agent-output` | `preview` | `invalidPreviewManifest` | `invalidPreviewManifest` | PASS |
+| `preview-unparseable-is-not-called-not-ready` | `sample-agent-output` | `preview` | `!previewNotReady` | `invalidPreviewManifest` | PASS |
+| `preview-ready-with-no-pages` | `sample-agent-output` | `preview` | `missingPreviewPages` | `missingPreviewPages` | PASS |
+| `preview-slug-not-kebab-case` | `sample-agent-output` | `preview` | `invalidPreviewSlug` | `invalidPreviewSlug` | PASS |
+| `preview-duplicate-slug` | `sample-agent-output` | `preview` | `duplicatePreviewSlug` | `duplicatePreviewSlug` | PASS |
+| `frontend-scaffold-vite-config-absent` | `sample-agent-output` | `frontend-scaffold` | `missingViteConfig` | `missingViteConfig` | PASS |
+| `frontend-scaffold-dev-server-binds-loopback` | `sample-agent-output` | `frontend-scaffold` | `devServerNotReachable` | `devServerNotReachable` | PASS |
+| `frontend-scaffold-strict-port-rejects-free-port` | `sample-agent-output` | `frontend-scaffold` | `devServerStrictPort` | `devServerStrictPort` | PASS |
+| `frontend-scaffold-unparseable-manifest-loses-the-reason` | `sample-agent-output` | `frontend-scaffold` | `frontendNotFound` | `frontendNotFound` | PASS |
+| `frontend-scaffold-no-dev-or-start-script` | `sample-agent-output` | `frontend-scaffold` | `missingDevScript` | `missingDevScript` | PASS |
+| `frontend-scaffold-api-seam-entry-absent` | `sample-agent-output` | `frontend-scaffold` | `missingApiSeamEntry` | `missingApiSeamEntry` | PASS |
+| `frontend-scaffold-preview-state-switcher-deletion-undetected` | `sample-agent-output` | `frontend-scaffold` | `passed` | `passed` | PASS |
+| `frontend-scaffold-absent-manifest-loses-the-reason` | `sample-agent-output` | `frontend-scaffold` | `frontendNotFound` | `frontendNotFound` | PASS |
 | `golden-debug-plan` | `reference-node-fullstack` | `debug-plan` | `passed` | `passed` | PASS |
 | `golden-debug-config` | `reference-node-fullstack` | `debug-config` | `passed` | `passed` | PASS |
 | `golden-debug-artifacts` | `reference-node-fullstack` | `debug-artifacts` | `passed` | `passed` | PASS |


### PR DESCRIPTION
Adds 8 plan-phase stimuli and two `validate-requirements.ts` flags. All 8 were run against live agents before this PR was opened.

## Why

The plan-phase corpus covered four app shapes — a photo app, an API-only inventory service, a no-datastore converter, a task app. Ordinary requests a user would actually make (I need login, keep the data in the EU, we already use MySQL) had never been put in front of the graders.

## What was run

| stimulus | constraint under test | check | run | result |
|---|---|---|---|---|
| `auth-expense-tracker` | identity is required | `--assert-auth-includes=Entra` | `2026083158957999` | 5/5 |
| `ai-chatbot-documents` | document storage | `--assert-blob-storage` | `2026083160386928` | 5/5 |
| `scheduled-nightly-report` | no frontend at all | `--assert-no-frontend` | `2026083160830938` | 5/5 |
| `mysql-cms` | unlisted database | probe (see below) | `...59733325` / `...77939774` | see below |
| `cost-constrained-blog` | budget ceiling | schema + probe | `2026083161269955` | 5/5 |
| `private-internal-hr-tool` | no public ingress | schema + probe | `2026083161668243` | 5/5 |
| `realtime-whiteboard` | persistent connections | schema + probe | `2026083162132945` | 5/5 |
| `eu-data-residency-portal` | EU data residency | schema + probe | `2026083165493260` | 5/5 |

Four carry semantic assertions. Four record probes instead, because the constraint reaches `requirements.json` only as free text — asserting a field the artifact does not structure yet would be asserting a shape rather than a behaviour.

## Grader flags

`--assert-datastore-includes=<substring>` generalises the hard-coded Cosmos and Blob flags, which were on track to become one flag per store. `--assert-auth-includes=<substring>` reaches the shared `auth` question, which is mandatory in every valid artifact (`requirements.ts` raises `missingAuth` without it) but which no scenario had ever answered with anything but "No auth" — so the identity path was untested.

Both take substrings so a stimulus can say `MySQL` or `Entra` without pinning Azure marketing strings. Both throw on an empty needle, so a flag that *cannot* fail is not mistaken for a flag that passed. Each was tested positive **and** negative before use.

Covered by 14 new certification mutations (95 -> 109). Certification: **139/139** (137 mine + 2 from #1755, post-rebase).

## `mysql-cms` ships as a probe, and found a product bug

Prompt says *"please use MySQL for the database."* Two runs, same prompt, opposite outcomes:

| run | `recommendedChoice` | |
|---|---|---|
| `2026083159733325` | `["MySQL", "Blob Storage"]` | invented a MySQL option — user intent kept, spec broken |
| `2026083177939774` | `["Blob Storage"]` | obeyed the fixed list — spec kept, **user intent lost** |

The agent understood the constraint in both (28 MySQL mentions; explicit *"Tech constraint: MySQL"*). Run 2's own rationale: *"Team prefers MySQL for relational data (Azure Database for MySQL), which will be configured in the plan"* — and then it emitted no relational datastore at all, for a CMS.

Root cause is not the agent. `azure-project-plan/requirements.md` line 133 fixes the `dataStores` options to `No datastore required, Blob Storage, Queue Storage, PostgreSQL, CosmosDB, Redis, Azure SQL` with `allowFreeformInput: false`. MySQL is absent, so the choice is unsatisfiable and the agent improvises differently per run. Meanwhile `azure-deploy` supports MySQL across **17 files** — `scaffold-conformance.ps1` (9 mentions, incl. three MySQL-only BLOCK rules), `bicep-patterns-data.md` (6), `database-post-deploy.md` (5), `service-mapping.md` (4), `sku-quota-validation.md` (3). The pipeline is MySQL-capable end to end *except at the point where the user states the requirement.*

Asserting `MySQL` would be correct and red about half the time, which a shared suite cannot carry. So it is recorded, not asserted; the evidence still lands in `session.sqlite` every run. **Adding MySQL to that option table re-arms it by deleting one line.** Filed separately rather than fixed here to keep this PR to test cases. Two runs establish that both behaviours occur — they do not establish a rate.

## Second finding

The agent **preserves data-residency constraints but drops network-isolation ones.** `eu-data-residency-portal` carried 6x EU / 6x residency / 2x region into `requirements.json`; `private-internal-hr-tool` carried only 4x "internal", with zero `private` / `vnet` / `endpoint` / `firewall`, despite an equally plain "must not be reachable from the public internet". A selective loss, not a general one. Found by a probe — an assertion would have said nothing.

## Validation

All 9 checks green: `gates` (23 stimuli), `typecheck`, `stacks:check`, `imports:self-test`, `clean-machine:check`, `drift`, `msbench:self-test`, `seed:self-test`, `certify` 139/139.

## Merge note

Rebased onto `feat/CoR` after #1755 landed. The only conflicts were the two *generated* certification reports, resolved by regenerating rather than picking a side. `manifest.json` auto-merged: my 14 mutations and #1755's 2 coexist at **139/139**, and `gates` now reports 19 staged graders (up from 13) with #1755's runtime graders alongside these. Full suite re-run green after the rebase.

#1755 adds certification manifest entries around L894; these are at the tail. No conflict expected, but whoever lands second should rebase.
