### PR TITLE
Fix lint on feat/CoR: ignore grader-certification fixtures as a tree

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,9 +13,20 @@ export default defineConfig([
         ignores: [
             'api/dist/**',
             'api/out/**',
-            'evals/grader-certification/reference-node-fullstack/**',
-            'evals/grader-certification/reference-node-multiservice/**',
-            'evals/grader-certification/sample-agent-output/**',
+            // The grader-certification fixtures are inputs to the graders, not source.
+            // They are deliberately non-conforming — browser JS using `document` and
+            // `fetch`, CommonJS `require()`, no license headers, and
+            // `unapproved-plan-refusal/.azure/refusal-bait/draft-server.ts`, which is a
+            // file the agent is supposed to REFUSE to write and which exists so a grader
+            // can prove it notices. Linting them is a category error.
+            //
+            // Ignored as a whole tree rather than one directory at a time. The previous
+            // form listed three of the twelve fixture directories, so adding a fixture
+            // meant remembering to add an ignore entry — and #1755 added
+            // `reference-node-postgres` and the refusal bait without one, which broke
+            // lint on feat/CoR for every unrelated PR. Nine of the twelve were passing
+            // only because they contain no JS or TS.
+            'evals/grader-certification/**',
             'evals/msbench/.staged/**',
             'evals/vscode-parity/**',
             'src/webviews/copilotOnRails/views/react-shim.js',


### PR DESCRIPTION
`npm run lint` is failing on `feat/CoR` — [run 33442879412](https://github.com/microsoft/vscode-azureresourcegroups/actions/runs/33442879412) — with 31 errors, all in `evals/grader-certification`. Every PR that runs the Build job inherits the failure.

## Why the fixtures fail lint legitimately

They are inputs to the graders, not source, and they are deliberately non-conforming:

| File | Why eslint objects | Why it is correct as-is |
| --- | --- | --- |
| `reference-node-postgres/public/app.js` | `document`, `fetch` undefined | it is browser JS |
| `reference-node-postgres/src/server.js` | `require()` imports, missing header | it is a CommonJS sample project |
| `unapproved-plan-refusal/.azure/refusal-bait/draft-server.ts` | not found by the project service | it is a file the agent is supposed to **refuse** to write, deliberately outside any tsconfig, and it exists so a grader can prove it notices |

Linting them is a category error — they are test data.

## Why the whole tree

The ignore list already recognised this, but enumerated **3 of the 12** fixture directories by name. #1755 added `reference-node-postgres` and the refusal bait without adding entries, and lint broke.

The other nine were passing only because they contain no JS or TS — `reference-dotnet-api`, `reference-python-api` and `reference-go-unsupported` would each break the build the day someone adds a Node file.

So enumeration is the bug, not just the symptom: it makes every new fixture a chance to break lint on somebody else's PR, and the breakage surfaces a long way from its cause.

## Verification

`npm run lint` — the exact CI command, `eslint --max-warnings 0` — exits **0** with this change and fails with **31 errors** without it. Confirmed locally against a clean `npm install` on this branch.

One-line change plus comment; no product code touched.
