### PR TITLE
debug-probe: make the live tier (the negative controls) runnable on Windows

### DIFF
--- a/evals/debug-probe/README.md
+++ b/evals/debug-probe/README.md
@@ -150,18 +150,27 @@ A gate that cannot fail is not a gate, so both directions are proven.
 
 ```bash
 node certify.ts --offline     # 11 cases, no VS Code, ~2s — safe for CI
-node certify.ts --live        # 5 cases, real VS Code + real js-debug
+node certify.ts --live        # 7 cases, real VS Code + real js-debug
 node certify.ts               # both
 ```
 
 Useful flags: `--only=<case-id>`, `--verbose`, `--vscode=/path/to/code`.
+
+**On Windows `code` is a `.cmd`**, which `spawnSync` cannot execute, so the live
+tier resolves `Code.exe` instead — from whatever `code.cmd` is on PATH, then the
+usual install locations. Before that it died with `spawnSync code ENOENT` before
+a single case ran and reported it as seven identical *"probe did NOT activate"*
+failures, which reads as a broken probe rather than a runner that never started
+one. The live tier had therefore never been run on Windows at all. Resolution
+happens only when the live tier is actually selected, so `--offline` still needs
+no VS Code.
 
 **Offline** synthesises verdict files and asserts the grader's exit code for
 each, including the ones that must never blame the product: a missing verdict, a
 malformed verdict, an unknown outcome, and a schema-version mismatch. This
 certifies the part that assigns blame, so it runs anywhere.
 
-**Live** stages the known-good fixture plus four mutations and runs real VS Code
+**Live** stages the known-good fixture plus six mutations and runs real VS Code
 against each. The load-bearing one is `mutation-breakpoint-unreachable`, which
 puts the breakpoint on the `POST` 400 branch while triggering `GET /api/health`:
 it must go red, and red for the right reason.

--- a/evals/debug-probe/certify.ts
+++ b/evals/debug-probe/certify.ts
@@ -35,7 +35,7 @@
 import { spawn, spawnSync } from 'node:child_process';
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, delimiter, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { DebugProbeVerdict, ProbeOutcome, ProbeSpec } from './extension/src/verdict.ts';
 import { PROBE_SCHEMA_VERSION, VERDICT_RELATIVE_PATH } from './extension/src/verdict.ts';
@@ -483,13 +483,62 @@ function runLiveTier(vscodeBinary: string, only?: string): CaseResult[] {
 
 let verbose = false;
 
+/**
+ * A VS Code binary this process can actually `spawnSync`.
+ *
+ * `'code'` works on macOS and Linux, where it is a shell script on PATH. On Windows it is
+ * `code.cmd`, which `spawnSync` cannot execute without a shell — so the live tier died with
+ * `spawnSync code ENOENT` before a single case ran, and reported that as seven identical
+ * "VS Code did not finish … (probe did NOT activate)" failures.
+ *
+ * That wording is why it survived: it reads as a broken probe rather than a runner that
+ * never started one. The live tier had never been run on Windows at all, and the only way
+ * through was already knowing to pass `--vscode=`. A gate whose negative controls cannot be
+ * executed is a gate nobody can confirm still discriminates — which is the whole point of
+ * this file.
+ *
+ * `Code.exe` is resolved rather than `code.cmd` because it is directly executable. Shelling
+ * out instead would push a path containing `Microsoft VS Code` through cmd quoting for no
+ * benefit. The bin script lives at `<root>/bin/code.cmd` and the executable at
+ * `<root>/Code.exe`, so PATH still does the discovery and this only walks up from it.
+ */
+function resolveVsCode(explicit: string | undefined): string {
+    if (explicit) {
+        return explicit;
+    }
+    if (process.platform !== 'win32') {
+        return 'code';
+    }
+    const onPath = (process.env.PATH ?? '')
+        .split(delimiter)
+        .map(entry => join(entry, 'code.cmd'))
+        .find(candidate => existsSync(candidate));
+    const candidates = [
+        ...(onPath ? [resolve(dirname(onPath), '..', 'Code.exe')] : []),
+        join(process.env.LOCALAPPDATA ?? '', 'Programs', 'Microsoft VS Code', 'Code.exe'),
+        join(process.env.ProgramFiles ?? '', 'Microsoft VS Code', 'Code.exe'),
+        join(process.env['ProgramFiles(x86)'] ?? '', 'Microsoft VS Code', 'Code.exe'),
+    ];
+    const found = candidates.find(candidate => existsSync(candidate));
+    if (found) {
+        return found;
+    }
+    // Falling back to 'code' would reproduce the ENOENT this exists to prevent, and the
+    // failure would again be reported per-case as a probe that did not activate.
+    throw new Error(
+        'could not find Code.exe. The live tier spawns VS Code directly, and on Windows `code` is a\n'
+        + `.cmd that spawnSync cannot execute. Looked in:\n  ${candidates.join('\n  ')}\n`
+        + 'Pass --vscode=<path to Code.exe> to override.',
+    );
+}
+
 function main(): void {
     const args = process.argv.slice(2);
     const offlineOnly = args.includes('--offline');
     const liveOnly = args.includes('--live');
     verbose = args.includes('--verbose');
     const only = args.find(arg => arg.startsWith('--only='))?.split('=')[1];
-    const vscodeBinary = args.find(arg => arg.startsWith('--vscode='))?.split('=')[1] ?? 'code';
+    const explicitVsCode = args.find(arg => arg.startsWith('--vscode='))?.split('=')[1];
 
     const results: CaseResult[] = [];
     if (!liveOnly) {
@@ -498,7 +547,10 @@ function main(): void {
     }
     if (!offlineOnly) {
         process.stderr.write('Live tier — real VS Code, real js-debug\n');
-        results.push(...runLiveTier(vscodeBinary, only));
+        // Resolved here rather than with the other arguments: `resolveVsCode` throws when it
+        // cannot find one, and the offline tier is the CI tier and needs no VS Code at all.
+        // Resolving eagerly would make `--offline` fail on exactly the machines it is for.
+        results.push(...runLiveTier(resolveVsCode(explicitVsCode), only));
     }
 
     process.stderr.write('\n');


### PR DESCRIPTION
You asked to approach `debug-breakpoint` backwards: rather than trying to make it pass, prove it can **fail** — on the grounds that a gate which only ever passes is too easy to fool. That turned out to be the right question, and the answer is not what the 0-for-16 suggested.

## The gate does discriminate — proven end to end

`certify.ts --live` runs real VS Code and real js-debug against the known-good fixture plus six mutations. All seven behave correctly:

```
known-good                       hit                    exit 0
mutation-launch-config-renamed   launchConfigInvalid    exit 1
mutation-app-crashes-on-boot     appFailedToStart       exit 1
mutation-breakpoint-unreachable  breakpointNotHit       exit 1   <- the gate-can-fail proof
mutation-pattern-matches-nothing patternMatchedNothing  exit 3
mutation-port-squatted           probeError             exit 3
mutation-debug-adapter-missing   probeError             exit 3
```

The load-bearing one puts the breakpoint on the `POST` 400 branch while triggering `GET /api/health`. It goes red, and red for the right reason. So the gate is not passing on false positives — it discriminates all six outcomes, and separates product failures (exit 1) from harness faults (exit 3).

## But nobody on Windows could run any of that

```
FAIL  [live] known-good: VS Code did not finish: spawnSync code ENOENT (probe did NOT activate)
FAIL  [live] mutation-launch-config-renamed: ... (probe did NOT activate)
... x7
0/7 certification cases passed
```

`spawnSync('code', …)` works where `code` is a shell script. On Windows it is `code.cmd`, which `spawnSync` cannot execute — so the tier died before a single case ran.

That wording is why it survived: seven identical *"probe did NOT activate"* lines read as a broken probe, not as a runner that never started one. The only way through was already knowing to pass `--vscode=`. Same shape as the `mktemp -t` note in `msbench/README.md` — shipped broken, stayed broken, because every machine was macOS.

## The fix

Resolve `Code.exe` from whatever `code.cmd` is on PATH (`<root>/bin/code.cmd` → `<root>/Code.exe`), then the usual install locations. `Code.exe` rather than the `.cmd` because it is directly executable; shelling out would push a path containing `Microsoft VS Code` through cmd quoting for no benefit.

Resolution is **lazy**. It throws when it finds nothing, and the offline tier is the CI tier and needs no VS Code — resolving eagerly would make `--offline` fail on exactly the machines it exists for. Verified both ways.

On Windows, with no flags:

```
11/11 offline   blame mapping
 7/7  live      real VS Code, real js-debug
18/18
```

README: corrected the stale case counts (4 → 6 mutations, 5 → 7 cases) and recorded the Windows resolution.

## What actually causes the 0-for-16 — not fixed here

The gate is wired `phases: [local]` in `config/gates.yaml`. `config/phases/local.yaml` **never writes `debug-probe.json`** — only `config/phases/debug-breakpoint.yaml` does:

```
config/phases/debug-breakpoint.yaml:  cat > /workspace/debug-probe.json <<'JSON'
config/phases/local.yaml:             (nothing)
```

With no spec the probe idles, no verdict is written, and the grader correctly calls that a harness fault. Every stack run, forever. This README predicted it exactly:

> *"With no `debug-probe.json`, the gate reports exit 3 forever… that is the 'gate that cannot pass' shape displaced into the exit-3 column."*

…and the gate's own `requires: {}` row is annotated `# unreviewed`. The fix is a wiring decision — either the local phase writes a spec derived from a per-stack breakpoint declaration (so the gate finally runs behind real generated output), or it is unwired from `local` and declared a `knownGap`. Deliberately left out of this PR.
