### PR TITLE
Install the Azure Functions extension in the probe environment, so the func task can resolve

### DIFF
--- a/evals/debug-probe/README.md
+++ b/evals/debug-probe/README.md
@@ -359,10 +359,40 @@ outcome: hit
 Certified by `mutation-attach-with-resolvable-task-is-driven`, which exists so
 that mistake cannot be made again silently.
 
-**So the Functions stack is answerable here** — it needs
-`ms-azuretools.vscode-azurefunctions` installed in the probe environment and
-`func` on PATH, which the custom image (`msbench-1.1.0`) already carries. Until
-the extension is installed the gate declines rather than inventing a verdict.
+**So the Functions stack is answerable here.** It needs two things, and the
+custom image (`msbench-1.1.0`) already carries one:
+
+| Needed | Provides | Status |
+| --- | --- | --- |
+| `ms-azuretools.vscode-azurefunctions` | the `func` **task type**, so `preLaunchTask` resolves | added to [`msbench/config/base.yaml`](../msbench/config/base.yaml) |
+| `func` on PATH | the Functions host itself | already in the custom image |
+
+Measured on `stage-local-dev` with the extension installed into an isolated
+extensions dir — the preflight goes from declining to passing:
+
+```
+preLaunchTask "func: host start" resolves in this environment
+trigger port 127.0.0.1:7071 is free
+```
+
+**A breakpoint hit in a Functions project is not yet proven**, and the remaining
+distance is honest to state: the task chain is
+`func: host start` → `api: build` → `install`, so the project must install and
+compile inside the probe budget, and this fixture's breakpoint sits on
+`status = 'healthy'`, which only executes when PostgreSQL *and* Azurite answer.
+Locally neither runs, so the branch is unreachable; the custom image starts both
+in the phase preamble. That makes the remaining proof a container run rather than
+a local experiment.
+
+**The extension's dependency is on the extension under test, and the install
+order protects it.** `vscode-azurefunctions` depends on
+`vscode-azureresourcegroups` — us — and installing it pulls that from the
+marketplace. The wrong order would silently replace the VSIX being evaluated with
+a shipped release, and every run would grade the wrong build. Verified rather
+than assumed: with the dependency already installed, VS Code leaves it alone
+(installing `0.12.0` first, then the Functions extension, leaves `0.12.0` on
+disk). Our VSIX is the first `installExtensions` entry, so it is always in place
+first.
 
 **A launch configuration naming an adapter we do not install used to produce a
 fabricated red.** `debugpy`, `go` and `coreclr` are not in this container. With

--- a/evals/msbench/config/base.yaml
+++ b/evals/msbench/config/base.yaml
@@ -138,6 +138,44 @@ installExtensions:
   - id: ms-azuretools.cor-debug-probe
     mode: vsix
     path: /agent/assets/extensions/cor-debug-probe.vsix
+  # The Azure Functions extension, from the marketplace rather than a VSIX because
+  # we do not build it — this is the shipping one a developer would have.
+  #
+  # It is here for exactly one reason: it provides the `func` TASK TYPE. A generated
+  # Functions project's launch configuration declares
+  # `preLaunchTask: "func: host start"` with `"type": "func"`, and without the
+  # provider that task cannot run, nothing opens the inspector port, and
+  # `debug-breakpoint` reported `appFailedToStart` — exit 1, blaming the product for
+  # a project it generated correctly.
+  #
+  # Measured, on grader-certification/stage-local-dev, with the extension installed
+  # into an isolated extensions dir:
+  #
+  #     preLaunchTask "func: host start" resolves in this environment   <- was: cannot resolve
+  #
+  # The agent's own `.azure/vscode-debug-plan.md` lists this extension as a
+  # prerequisite, so installing it makes the eval environment match the environment
+  # the plan is written for rather than granting the product a favour.
+  #
+  # ── Ordering is load-bearing, and this entry MUST stay last ──────────────────
+  #
+  # `ms-azuretools.vscode-azurefunctions` DEPENDS ON
+  # `ms-azuretools.vscode-azureresourcegroups` — the extension under test — and
+  # installing it pulls that dependency from the marketplace. Installed the wrong way
+  # round, the marketplace build would replace the VSIX we are evaluating and every
+  # run would silently grade a shipped release instead of the change under test.
+  #
+  # Verified rather than assumed: with the dependency already present, VS Code leaves
+  # it alone. Installing 0.12.0 first and then this extension leaves 0.12.0 on disk,
+  # not the marketplace version. Our VSIX is the first entry above, so it is always
+  # in place before this runs. Do not reorder these.
+  #
+  # `func` itself is a separate dependency and is NOT provided by this: it is a CLI,
+  # installed by the phase preamble and present in the custom image (msbench-1.1.0).
+  # Both are needed, and on the stock image the gate still declines rather than
+  # inventing a verdict.
+  - id: ms-azuretools.vscode-azurefunctions
+    mode: marketplace
 
 # The Vally executor approves every permission request. Without this the
 # webview-opening tools block on a confirmation nothing can answer.


### PR DESCRIPTION
Stacked on #1771. Makes `debug-breakpoint` able to answer for Azure Functions projects at all.

## The problem

The gate declines every Functions project because `preLaunchTask: "func: host start"` has `"type": "func"`, and that provider comes from `ms-azuretools.vscode-azurefunctions`, which was not installed in the probe environment. Declining is honest — it replaced a fabricated `appFailedToStart` (#1771) — but it left the gate unable to ask its question.

The agent's own `.azure/vscode-debug-plan.md` **lists this extension as a prerequisite**, so installing it makes the eval environment match the environment the plan is written for rather than granting the product a favour.

## Measured

With the extension installed into an isolated extensions dir, against `stage-local-dev`:

```
preLaunchTask "func: host start" resolves in this environment   <- was: cannot resolve
trigger port 127.0.0.1:7071 is free
```

## The dependency very nearly invalidated every run

`vscode-azurefunctions` **depends on `vscode-azureresourcegroups`** — the extension under test — and installing it pulls that dependency from the marketplace.

Installed the wrong way round, the marketplace build would replace the VSIX being evaluated, and **every run would grade a shipped release instead of the change under test**. Nothing would look wrong.

Verified rather than assumed:

```
install ms-azuretools.vscode-azureresourcegroups@0.12.0   -> v0.12.0 installed
install ms-azuretools.vscode-azurefunctions              -> v1.22.1 installed
surviving: ms-azuretools.vscode-azureresourcegroups-0.12.0   <- ours, untouched
```

VS Code leaves a satisfied dependency alone. Our VSIX is the **first** `installExtensions` entry and the new one is appended **last**, so ours is always in place first. The comment in `base.yaml` says so explicitly, because a future reorder would be silent.

## What this does not yet prove

A breakpoint hit in a Functions project. The remaining distance, stated rather than implied:

- The task chain is `func: host start` → `api: build` → `install`, so the project must install and compile inside the probe budget.
- `stage-local-dev`'s breakpoint sits on `status = 'healthy'`, which only executes when PostgreSQL **and** Azurite both answer. Locally neither runs, so that branch is unreachable.

The custom image (`msbench-1.1.0`) starts both in the phase preamble and carries `func` — so the remaining proof is a container run, not a local experiment. That is the natural follow-up once this lands.

## Also recorded

On Windows, `Code.exe` launches a window but **cannot run CLI subcommands** — `--install-extension` against it succeeds silently and installs nothing. That needs `bin/code.cmd`, which in turn cannot be `spawnSync`'d without a shell. Same family as the `resolveVsCode` fix in #1769, and it cost time twice before being pinned down.

`drift`, `typecheck`, `imports:self-test`, `certify`, `stacks:check`, `gates`, `lint`, `clean-machine:check`, `stage:check` all pass.
