### PR TITLE
Inverted breakpoint control for Functions: assert NOT hit, so a failure is the proof

### DIFF
--- a/evals/debug-probe/README.md
+++ b/evals/debug-probe/README.md
@@ -359,10 +359,40 @@ outcome: hit
 Certified by `mutation-attach-with-resolvable-task-is-driven`, which exists so
 that mistake cannot be made again silently.
 
-**So the Functions stack is answerable here** — it needs
-`ms-azuretools.vscode-azurefunctions` installed in the probe environment and
-`func` on PATH, which the custom image (`msbench-1.1.0`) already carries. Until
-the extension is installed the gate declines rather than inventing a verdict.
+**So the Functions stack is answerable here.** It needs two things, and the
+custom image (`msbench-1.1.0`) already carries one:
+
+| Needed | Provides | Status |
+| --- | --- | --- |
+| `ms-azuretools.vscode-azurefunctions` | the `func` **task type**, so `preLaunchTask` resolves | added to [`msbench/config/base.yaml`](../msbench/config/base.yaml) |
+| `func` on PATH | the Functions host itself | already in the custom image |
+
+Measured on `stage-local-dev` with the extension installed into an isolated
+extensions dir — the preflight goes from declining to passing:
+
+```
+preLaunchTask "func: host start" resolves in this environment
+trigger port 127.0.0.1:7071 is free
+```
+
+**A breakpoint hit in a Functions project is not yet proven**, and the remaining
+distance is honest to state: the task chain is
+`func: host start` → `api: build` → `install`, so the project must install and
+compile inside the probe budget, and this fixture's breakpoint sits on
+`status = 'healthy'`, which only executes when PostgreSQL *and* Azurite answer.
+Locally neither runs, so the branch is unreachable; the custom image starts both
+in the phase preamble. That makes the remaining proof a container run rather than
+a local experiment.
+
+**The extension's dependency is on the extension under test, and the install
+order protects it.** `vscode-azurefunctions` depends on
+`vscode-azureresourcegroups` — us — and installing it pulls that from the
+marketplace. The wrong order would silently replace the VSIX being evaluated with
+a shipped release, and every run would grade the wrong build. Verified rather
+than assumed: with the dependency already installed, VS Code leaves it alone
+(installing `0.12.0` first, then the Functions extension, leaves `0.12.0` on
+disk). Our VSIX is the first `installExtensions` entry, so it is always in place
+first.
 
 **A launch configuration naming an adapter we do not install used to produce a
 fabricated red.** `debugpy`, `go` and `coreclr` are not in this container. With

--- a/evals/grader-certification/stage-local-dev/README.md
+++ b/evals/grader-certification/stage-local-dev/README.md
@@ -1,0 +1,56 @@
+# Why this fixture carries files no harvest could produce
+
+`stage-local-dev` is `stage-scaffold` plus the inputs a debugged workspace needs.
+Three of them are hand-written, and one of those is hand-written **necessarily**
+rather than for convenience.
+
+| File | Why it is not harvested |
+| --- | --- |
+| `.vscode/launch.json` | the local phase stops at the debug **plan**; `azure-debug-generate` never runs, so no run has produced one |
+| `.vscode/tasks.json` | same |
+| `debug-probe.json` | harness input; it is what the stimulus points the probe at |
+| `services/functions/local.settings.json` | **it is gitignored by design, so it can never appear in a `patch.diff`** |
+
+That last row is the interesting one, and it was found the expensive way.
+
+## `local.settings.json` cannot be harvested, ever
+
+`func start` will not run without it: it declares `FUNCTIONS_WORKER_RUNTIME`,
+`AzureWebJobsStorage`, and the app settings the generated code reads. It is also
+the file the scaffold agent is *instructed* to gitignore from the first commit,
+because it holds connection strings — see the `.gitignore` rule in
+`azure-project-scaffold/instructions.md`.
+
+Both are correct, and together they mean a harvested Functions fixture is
+**always** unrunnable. `harvest-stage.ts` reads the agent's `patch.diff`, and a
+gitignored file is not in it. No amount of re-harvesting fixes that.
+
+Measured, on run
+[`2026090178170878`](https://msbenchapp.azurewebsites.net/run-analysis/2026090178170878):
+
+```
+resolved services/functions/src/functions/health.ts:12
+debug adapter "node" is installed
+preLaunchTask "func: host start" resolves in this environment   <- the extension works
+trigger port 127.0.0.1:7071 is free
+                                                                <- then 240s of nothing
+outcome: appFailedToStart
+detail:  startDebugging(...) never resolved within the probe budget —
+         an unfinishable preLaunchTask is the usual cause
+```
+
+`func`, `azurite`, `psql` and a built `dist/` were all present. The background
+task never reported ready because `func host start` had no settings file to start
+from.
+
+The values here are the local-development ones the fixture's own emulators serve:
+Azurite via `UseDevelopmentStorage=true`, and the `taskuser`/`tasktracker`
+PostgreSQL role the phase preamble creates. `languageWorkers__node__arguments`
+opens the inspector on 9229, which is the port `launch.json` attaches to — that
+is the link that makes `request: attach` work at all, and it is normally written
+by the Azure Functions extension when it generates a debug configuration.
+
+**Nothing here is graded.** These are inputs that make the tree runnable, which is
+why the fixture deliberately does not certify `debug-config` or `debug-artifacts`
+— those grade `.vscode/**` against the plan, and grading our own inputs would be
+a verdict about us.

--- a/evals/grader-certification/stage-local-dev/services/functions/local.settings.json
+++ b/evals/grader-certification/stage-local-dev/services/functions/local.settings.json
@@ -1,0 +1,15 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "node",
+        "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
+        "DATABASE_URL": "postgresql://taskuser:taskpassword@127.0.0.1:5432/tasktracker",
+        "AZURE_STORAGE_CONNECTION_STRING": "UseDevelopmentStorage=true",
+        "NODE_ENV": "development",
+        "languageWorkers__node__arguments": "--inspect=9229"
+    },
+    "Host": {
+        "CORS": "*"
+    }
+}

--- a/evals/msbench/config/base.yaml
+++ b/evals/msbench/config/base.yaml
@@ -138,6 +138,44 @@ installExtensions:
   - id: ms-azuretools.cor-debug-probe
     mode: vsix
     path: /agent/assets/extensions/cor-debug-probe.vsix
+  # The Azure Functions extension, from the marketplace rather than a VSIX because
+  # we do not build it — this is the shipping one a developer would have.
+  #
+  # It is here for exactly one reason: it provides the `func` TASK TYPE. A generated
+  # Functions project's launch configuration declares
+  # `preLaunchTask: "func: host start"` with `"type": "func"`, and without the
+  # provider that task cannot run, nothing opens the inspector port, and
+  # `debug-breakpoint` reported `appFailedToStart` — exit 1, blaming the product for
+  # a project it generated correctly.
+  #
+  # Measured, on grader-certification/stage-local-dev, with the extension installed
+  # into an isolated extensions dir:
+  #
+  #     preLaunchTask "func: host start" resolves in this environment   <- was: cannot resolve
+  #
+  # The agent's own `.azure/vscode-debug-plan.md` lists this extension as a
+  # prerequisite, so installing it makes the eval environment match the environment
+  # the plan is written for rather than granting the product a favour.
+  #
+  # ── Ordering is load-bearing, and this entry MUST stay last ──────────────────
+  #
+  # `ms-azuretools.vscode-azurefunctions` DEPENDS ON
+  # `ms-azuretools.vscode-azureresourcegroups` — the extension under test — and
+  # installing it pulls that dependency from the marketplace. Installed the wrong way
+  # round, the marketplace build would replace the VSIX we are evaluating and every
+  # run would silently grade a shipped release instead of the change under test.
+  #
+  # Verified rather than assumed: with the dependency already present, VS Code leaves
+  # it alone. Installing 0.12.0 first and then this extension leaves 0.12.0 on disk,
+  # not the marketplace version. Our VSIX is the first entry above, so it is always
+  # in place before this runs. Do not reorder these.
+  #
+  # `func` itself is a separate dependency and is NOT provided by this: it is a CLI,
+  # installed by the phase preamble and present in the custom image (msbench-1.1.0).
+  # Both are needed, and on the stock image the gate still declines rather than
+  # inventing a verdict.
+  - id: ms-azuretools.vscode-azurefunctions
+    mode: marketplace
 
 # The Vally executor approves every permission request. Without this the
 # webview-opening tools block on a confirmation nothing can answer.

--- a/evals/msbench/config/phases/functions-breakpoint.yaml
+++ b/evals/msbench/config/phases/functions-breakpoint.yaml
@@ -1,0 +1,125 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/vscode-copilot-evaluation/main/doc/references/TestConfig.schema.json
+
+# Phase: `functions-breakpoint` — infrastructure only, like `debug-breakpoint`.
+#
+# Same question as `debug-breakpoint`, asked of the stack that matters: can a
+# debugger reach a breakpoint in an **Azure Functions** project inside this
+# container? The agent does nothing; the product is not under test.
+#
+# `debug-breakpoint` answers that for a plain Node app that launches its own
+# process. Every project the scaffold agent emits is a Functions app whose launch
+# configuration is `request: attach` behind `preLaunchTask: "func: host start"` —
+# a different code path end to end, and the one that produced a fabricated
+# `appFailedToStart` until the preflight was narrowed. So a green there says
+# nothing about here.
+#
+# The fixture is `evals/grader-certification/stage-local-dev`, staged by run.sh:
+# the harvested scaffold from run 2026083170541011 plus the `.vscode/**` its own
+# `.azure/vscode-debug-plan.md` specifies.
+#
+# ── Everything below is a prerequisite the TASK CHAIN would otherwise have to do ──
+#
+# The configuration's task chain is `func: host start` -> `api: build` -> `install`.
+# Left to itself that means an npm install and a TypeScript build inside the probe
+# budget, on a cold container, before anything can listen. Doing it here instead
+# is not cheating: it is the difference between measuring "can this project be
+# debugged" and measuring "does npm finish in 180 seconds". The tasks still run —
+# they just find their work already done.
+#
+# NOTE: `exitWhenDone` is deliberately absent from the spec below, for the same
+# reason as in debug-breakpoint.yaml: the probe quitting VS Code mid-run would
+# take the eval down with it.
+
+script: |
+  set -eux
+  cp -R /agent/assets/fixtures/stage-local-dev/. /workspace/
+
+  # ── Emulators ───────────────────────────────────────────────────────────────
+  #
+  # Lifted from config/phases/local.yaml, and fail-soft for the same reason: a
+  # preamble that dies takes the whole run with it, and a missing emulator should
+  # cost a stood-down gate rather than a lost run.
+  #
+  # They matter more here than elsewhere. The health handler this run breaks in
+  # calls `database.healthCheck()` and `storage.healthCheck()`, so with neither
+  # emulator up it takes its `unhealthy` branch — a different line from the one
+  # the breakpoint sits on. The breakpoint is therefore placed on a statement that
+  # runs on EVERY request (see the spec below) rather than on the healthy branch,
+  # so a stopped emulator degrades the result honestly instead of silently making
+  # the breakpoint unreachable.
+  [ -s /opt/nvm/nvm.sh ] && . /opt/nvm/nvm.sh >/dev/null 2>&1 || true
+  if command -v azurite >/dev/null 2>&1; then
+    mkdir -p /tmp/azurite
+    nohup azurite --silent --skipApiVersionCheck \
+      --location /tmp/azurite \
+      --blobHost 127.0.0.1 --queueHost 127.0.0.1 --tableHost 127.0.0.1 \
+      >/tmp/azurite.log 2>&1 &
+    for _ in $(seq 1 20); do
+      if (echo > /dev/tcp/127.0.0.1/10000) >/dev/null 2>&1; then break; fi
+      sleep 1
+    done
+    (echo > /dev/tcp/127.0.0.1/10000) >/dev/null 2>&1 \
+      && echo "azurite: listening on 127.0.0.1:10000" \
+      || echo "azurite: FAILED to listen"
+  else
+    echo "azurite: not installed (stock image)"
+  fi
+
+  if command -v pg_ctlcluster >/dev/null 2>&1 && [ -f /etc/cor-pg-version ]; then
+    PG_VERSION="$(cat /etc/cor-pg-version)"
+    pg_ctlcluster "$PG_VERSION" main start || echo "postgres: start reported a failure"
+    for _ in $(seq 1 20); do
+      if su postgres -c "pg_isready -q" >/dev/null 2>&1; then break; fi
+      sleep 1
+    done
+    if su postgres -c "pg_isready -q" >/dev/null 2>&1; then
+      su postgres -c "psql -tAc \"SELECT 1 FROM pg_roles WHERE rolname='taskuser'\"" | grep -q 1 \
+        || su postgres -c "psql -c \"CREATE ROLE taskuser LOGIN PASSWORD 'taskpassword' SUPERUSER\"" || true
+      su postgres -c "psql -tAc \"SELECT 1 FROM pg_database WHERE datname='tasktracker'\"" | grep -q 1 \
+        || su postgres -c "createdb -O taskuser tasktracker" || true
+      echo "postgres: ready on 127.0.0.1:5432"
+    else
+      echo "postgres: FAILED to become ready"
+    fi
+  else
+    echo "postgres: not installed (stock image)"
+  fi
+
+  # ── func, and the build the task chain expects ──────────────────────────────
+  if command -v func >/dev/null 2>&1; then
+    echo "func already present: $(func --version 2>&1 | tail -1)"
+  else
+    npm install -g azure-functions-core-tools@4 --unsafe-perm true \
+      || npm install -g azure-functions-core-tools@4 --unsafe-perm true --registry https://registry.npmjs.org/ \
+      || echo "func install FAILED; the probe will decline rather than invent a verdict"
+  fi
+  command -v func >/dev/null 2>&1 && func --version 2>&1 | tail -1 || echo "func: still unavailable"
+
+  cd /workspace
+  npm install --no-audit --no-fund || echo "npm install FAILED"
+  npm run build --workspace=services/shared || echo "shared build FAILED"
+  npm run build --workspace=services/functions || echo "functions build FAILED"
+  ls -la /workspace/services/functions/dist 2>&1 | head -20 || echo "no dist/ — func will have nothing to serve"
+
+  # Written AFTER the project is in place, for the ordering reason recorded in
+  # debug-breakpoint.yaml.
+  #
+  # The breakpoint is on `getServices()`, not on `status = 'healthy'`. Both are in
+  # the health handler, but the second only executes when BOTH emulators answer,
+  # so a stopped emulator would make the breakpoint unreachable and the verdict
+  # would read as "the debugger cannot stop here" rather than "the datastore is
+  # down". The first statement of the handler runs on every request and is the
+  # honest place to ask whether execution arrives at all.
+  cat > /workspace/debug-probe.json <<'JSON'
+  {
+    "launchConfig": "Task Tracker API (debug)",
+    "breakpoint": {
+      "glob": "services/functions/src/functions/*.ts",
+      "pattern": "const \\{ database, storage \\} = getServices\\(\\)"
+    },
+    "trigger": { "url": "http://127.0.0.1:7071/api/health" },
+    "timeoutMs": 240000
+  }
+  JSON
+  ls -la /workspace
+  cat /workspace/debug-probe.json

--- a/evals/msbench/config/stimuli/functions-breakpoint-control.yaml
+++ b/evals/msbench/config/stimuli/functions-breakpoint-control.yaml
@@ -1,0 +1,79 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/vscode-copilot-evaluation/main/doc/references/TestConfig.schema.json
+
+# phase: functions-breakpoint
+#
+# Stimulus `functions-breakpoint-control` — a NEGATIVE CONTROL, and the only
+# stimulus here whose expected result is RED.
+#
+# ── Why the assertion is inverted ────────────────────────────────────────────
+#
+# The obvious design is to assert the breakpoint IS hit and hope for green. That
+# design cannot distinguish success from silence, and this suite has now been
+# caught by that shape four separate times: a gate wired into a phase that never
+# writes its `debug-probe.json`, seven graders wired but never staged, a safety
+# gate whose file count was satisfied by the harness's own staged instructions,
+# and every gate in a `RATE_LIMIT` run. In all four, nothing happened and
+# everything passed.
+#
+# The asymmetry is the point. A green here could mean the breakpoint was hit, or
+# that the exec never ran, or that the grader was not staged, or that the probe
+# never activated. A RED can only mean the grader ran, exited 0, and therefore
+# that a debugger stopped on a line of an Azure Functions project inside this
+# container. Absence of action produces a pass; only the thing we are hoping for
+# produces a failure.
+#
+# So: **this stimulus is expected to FAIL, and a failure is the result we want.**
+# If it passes, nothing has been proven — read the fingerprint below to find out
+# which of the ways of doing nothing happened this time.
+#
+# ── Reading the outcome ──────────────────────────────────────────────────────
+#
+#   assertion FAILS, verdict outcome=hit          the gate works end to end for
+#                                                 the Functions stack. Promote the
+#                                                 assertion to its positive form.
+#   assertion passes, outcome=probeError          the harness declined; the detail
+#                                                 names what was missing (func, the
+#                                                 task provider, a port).
+#   assertion passes, outcome=appFailedToStart    the host never listened; read the
+#                                                 debuggee output in the verdict.
+#   assertion passes, outcome=breakpointNotHit    it started and execution never
+#                                                 arrived — the interesting case,
+#                                                 and the one worth a second run.
+#
+# The agent does nothing in this phase; the product is not under test. A red here
+# is a statement about the harness, never about generated code.
+
+promptSteps:
+  - text: |
+      Say "ready" and stop. This run is infrastructure only — the debug probe
+      writes the evidence before this turn is graded.
+    assertions:
+      # Liveness sentinel — must come first, and every stimulus needs one.
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
+        query: SELECT COUNT(*) > 0 FROM llm_responses
+
+      - comment: The probe extension installed and activated
+        exec: test -f .eval/probe.log
+
+      # THE inverted control. `!` flips the grader's exit code, so this assertion
+      # passes when the breakpoint was NOT hit and fails when it was.
+      #
+      # Deliberately paired with the outcome check below, because `!` alone cannot
+      # tell a miss from a decline: the grader exits 1 for a product-shaped failure
+      # and 3 for a harness fault, and this inverts both to a pass. The next
+      # assertion is what makes the pass legible.
+      - comment: INVERTED CONTROL; passes only if NO breakpoint was hit, so a failure here is the proof
+        exec: '! node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON /agent/assets/graders/evals/graders/validate-debug-breakpoint.ts'
+
+      # The same claim read from the artifact rather than from an exit code, so a
+      # pass above can be attributed. Fails if the verdict says `hit` — which is
+      # the same evidence as the inverted control, arrived at independently.
+      - comment: INVERTED CONTROL; the recorded verdict must not be a hit
+        exec: 'test -f .eval/debug-verdict.json && ! grep -q ''"outcome": *"hit"'' .eval/debug-verdict.json'
+
+      # Non-asserting, so it can never fail the run or change the assertion count.
+      # Read this FIRST either way: on a red it names what was hit, and on a green
+      # it names which way nothing happened.
+      - comment: Fingerprint; probe breadcrumb, full debug verdict, and the emulator/tool inventory
+        assertZeroExitCode: false
+        exec: 'echo "--- breadcrumb ---"; cat .eval/probe.log 2>&1 || echo "NO PROBE LOG"; echo "--- verdict ---"; cat .eval/debug-verdict.json 2>&1 || echo "NO VERDICT"; echo "--- tools ---"; for b in node npm func azurite psql; do printf "%s=%s\n" "$b" "$(command -v $b || echo MISSING)"; done; echo "--- listening ---"; (ss -lntp 2>/dev/null || netstat -lnt 2>/dev/null) | head -20; echo "--- dist ---"; ls -la services/functions/dist 2>&1 | head -10'

--- a/evals/msbench/run.sh
+++ b/evals/msbench/run.sh
@@ -86,6 +86,11 @@ PROBE_DEST="${ASSETS}/extensions/cor-debug-probe.vsix"
 # evals/debug-probe certifies with, so green here and green locally mean the same.
 FIXTURE_SRC="${REPO_ROOT}/evals/grader-certification/reference-node-fullstack"
 FIXTURE_DEST="${ASSETS}/fixtures/reference-node-fullstack"
+# The realistic Functions project, for the stimulus that asks whether the gate can
+# answer for the stack the agent actually generates rather than for a fixture built
+# to be answerable. See config/stimuli/functions-breakpoint-control.yaml.
+LOCALDEV_SRC="${REPO_ROOT}/evals/grader-certification/stage-local-dev"
+LOCALDEV_DEST="${ASSETS}/fixtures/stage-local-dev"
 
 # Borrowed purely for its container image; user-overrides.yaml replaces its
 # prompt and assertions wholesale. Swapping this for a heavier instance is how
@@ -259,6 +264,12 @@ cp -R "$FIXTURE_SRC" "$FIXTURE_DEST"
 # verdict nobody produced there, which is the most misleading artifact possible.
 rm -rf "${FIXTURE_DEST}/.eval" "${FIXTURE_DEST}/node_modules" "${FIXTURE_DEST}/debug-probe.json"
 [ -f "${FIXTURE_DEST}/.vscode/launch.json" ] || die "Debug fixture has no .vscode/launch.json at ${FIXTURE_DEST}"
+
+# The Functions fixture, staged the same way and for the same reason.
+rm -rf "$LOCALDEV_DEST"
+cp -R "$LOCALDEV_SRC" "$LOCALDEV_DEST"
+rm -rf "${LOCALDEV_DEST}/.eval" "${LOCALDEV_DEST}/node_modules"
+[ -f "${LOCALDEV_DEST}/.vscode/launch.json" ] || die "stage-local-dev has no .vscode/launch.json at ${LOCALDEV_DEST}"
 
 # --- stage the graders and build the config ----------------------------------
 #


### PR DESCRIPTION
Stacked on #1772. An **inverted** negative control for the Functions debug path, plus the two findings it produced.

## Why the assertion is inverted

Asserting the breakpoint *is* hit cannot distinguish success from silence. This suite has been caught by that shape four times: a gate wired into a phase that never writes its `debug-probe.json` (#1769), seven graders wired but never staged (#1755), a safety gate whose file count was satisfied by the harness's own staged instructions (#1767), and every gate in a `RATE_LIMIT` run. In all four, **nothing happened and everything passed**.

So this stimulus asserts the breakpoint is **NOT** hit:

```yaml
- comment: INVERTED CONTROL; passes only if NO breakpoint was hit, so a failure here is the proof
  exec: '! node .../validate-debug-breakpoint.ts'
```

A green could mean many kinds of nothing. A **red can only mean** the grader ran, exited 0, and a debugger stopped on a line of a Functions project in the container. Absence of action produces a pass; only the thing we want produces a failure.

Paired with a second assertion reading `outcome` from the verdict artifact, because `!` inverts exit 1 and exit 3 alike and cannot tell a miss from a decline.

## Finding 1 — the extension works in the container

Run [`2026090178170878`](https://msbenchapp.azurewebsites.net/run-analysis/2026090178170878) confirms #1772 end to end:

```
resolved services/functions/src/functions/health.ts:12
debug adapter "node" is installed
preLaunchTask "func: host start" resolves in this environment   <- previously declined every Functions project
trigger port 127.0.0.1:7071 is free
```

`func`, `azurite`, `psql` and a built `dist/` all present.

## Finding 2 — `local.settings.json` can never be harvested

The run then spent its full 240s budget:

```
outcome: appFailedToStart
detail:  startDebugging(...) never resolved within the probe budget —
         an unfinishable preLaunchTask is the usual cause
```

`func start` will not run without `services/functions/local.settings.json` — it declares `FUNCTIONS_WORKER_RUNTIME`, `AzureWebJobsStorage` and the app settings the generated code reads.

It is also the file the scaffold agent is **instructed to gitignore** from the first commit, because it holds connection strings.

Both are correct, and together they mean **a harvested Functions fixture is always unrunnable**: `harvest-stage.ts` reads the agent's `patch.diff`, and a gitignored file is not in it. No amount of re-harvesting fixes that.

Written by hand here, with a fixture README recording which files are inputs and why each cannot be harvested. `languageWorkers__node__arguments` opens the inspector on 9229 — the port `launch.json` attaches to, and the link that makes `request: attach` work at all.

## Also here

The `functions-breakpoint` phase seeds the fixture, starts Azurite and PostgreSQL, installs `func` if absent, and pre-runs `npm install` + the TypeScript build. The task chain still runs — it just finds its work done. That is the difference between measuring "can this be debugged" and "does npm finish in 240 seconds".

The breakpoint sits on `getServices()`, the first statement of the health handler, not on `status = 'healthy'` — the latter only executes when both emulators answer, so a stopped emulator would make it unreachable and the verdict would read as "the debugger cannot stop here" rather than "the datastore is down".

## Status

Whether a breakpoint is now reached is **unproven** — that is the next run. What is proven is that the previous blocker is gone and the next one is named. The control is designed so that run's result will be unambiguous either way.

`drift`, `typecheck`, `certify`, `gates`, `lint`, `stage:check` all pass.
