### PR TITLE
Give the sequenced compound task the runOptions its siblings get

### DIFF
--- a/evals/agent-assets.lock.json
+++ b/evals/agent-assets.lock.json
@@ -1,7 +1,7 @@
 {
-    "agentAssetsHash": "0185898b38122ae24c2fd215a02fd55ed3ccfdbfe1524e4953d3b2e326fd68b0",
+    "agentAssetsHash": "3609a526c5581390a2ef1ffd02c99942a6d2d9ad563a0741017853e965d827e0",
     "scope": "azure-debug-generate.agent.md, azure-debug-generate/**, azure-debug-plan.agent.md, azure-debug-plan/**, azure-deploy.agent.md, azure-deploy/**, azure-project-integrate.agent.md, azure-project-integrate/**, azure-project-plan.agent.md, azure-project-plan/**, azure-project-scaffold.agent.md, azure-project-scaffold/**, shared-references/**",
-    "updatedAt": "2026-09-03T16:43:05.908Z",
+    "updatedAt": "2026-09-03T20:36:26.571Z",
     "files": {
         "azure-debug-generate.agent.md": "c9849fb6271193d104ef30161071bebe95fd29c6abea3a5c6d081416a5ebe8a6",
         "azure-debug-generate/.metadata.json": "c0ccce18678415f23db0073d48cc646f2de446e7821c99c3130553548d958e0c",
@@ -10,10 +10,10 @@
         "azure-debug-generate/references/emulators/_template.md": "76950ec0d9552fe55cf9e9d8f1685f79c1fef74206babef817499fb38303fe09",
         "azure-debug-generate/references/emulators/azurite.md": "f17b3cda9716d39fede3078774000aad545c9b4b7bda11913f6f63905e15da1b",
         "azure-debug-generate/references/emulators/postgres.md": "874ad86df90c0fda48adb5434d4cbb1f720762b1434a90f4494b5c16c72cf4ec",
-        "azure-debug-generate/references/generate.md": "e09b615fb44a46aafce8610abc314d2759376c4045a6040d394f62e4cdb54656",
+        "azure-debug-generate/references/generate.md": "a8948d12d6737f5bb282d607354321193c306163141155647fbbff40b8aa45d2",
         "azure-debug-generate/references/limited-support.md": "427285f71f2eb4102c86d19dd079363b20900f722a5cf67158764dd973473b3a",
         "azure-debug-generate/references/migrations.md": "e1b2723a9bd6b8554a1f9133b1b7483f86af217d06642ae7520e5e7816f05dd2",
-        "azure-debug-generate/references/multi-service.md": "09e4bf742d3b07236bee21787895dd010bdca7d08e4272034f21f4a32a15be34",
+        "azure-debug-generate/references/multi-service.md": "d1b0014a27023a17052a19fb3f1f983a15b7119f7460ebb9fc23dabdd20cec05",
         "azure-debug-generate/references/preflight.md": "6df0fec6568fb4f92a21a87230d8bd9ca5b92dc0e69dacf11122a8827e6941a5",
         "azure-debug-generate/references/project-types/_template.md": "b4e03b4c572cb49ad529eacc1ece920045a53979f8b47e454f6e22c0695e6da7",
         "azure-debug-generate/references/project-types/frontend-spa/debug-adapters/_template.md": "5f4793706ae3cd74b10f2d7601cdaa01a6ffd4431aa3d569be32cabef5c8291b",

--- a/evals/check-agent-drift.ts
+++ b/evals/check-agent-drift.ts
@@ -150,6 +150,19 @@ const contracts: Contract[] = [
         pattern: /`?\/api\/health`?/,
         grader: "plan-structure-valid (Route Definitions)",
     },
+    {
+        // The sequenced compound task is reachable both directly and as a compound's
+        // `preLaunchTask`, so it is the task likeliest to be invoked twice — and it was
+        // the one task whose literal template omitted `runOptions`. A real run copied the
+        // template faithfully and produced 6 conforming tasks out of 7, failing
+        // `debug-config` with `invalidTaskRunOptions` on exactly the task the template
+        // shipped without it. Pinning the template, not the prose, because the template is
+        // what the agent copied.
+        file: "azure-debug-generate/references/multi-service.md",
+        name: "compound-task-run-options",
+        pattern: /"dependsOrder":\s*"sequence",\s*\n\s*"runOptions":\s*\{\s*"instanceLimit":\s*1,\s*"instancePolicy":\s*"silent"\s*\}/,
+        grader: "debug-config-structurally-sound (invalidTaskRunOptions)",
+    },
 ];
 
 /**

--- a/resources/agents/azure-debug-generate/references/generate.md
+++ b/resources/agents/azure-debug-generate/references/generate.md
@@ -162,7 +162,9 @@ Use the **Service Root** column from the plan's Services table to determine the 
 
 ### Task `runOptions` Rules
 
-Every task generated for the debug chain (install, clean, watch, build, top-level, and emulator tasks) **must** include `runOptions` with `instanceLimit: 1` and `instancePolicy: "silent"`. This prevents duplicate task instances and silently skips re-invocations when a task is already running (e.g., from compound + individual `preLaunchTask` chains).
+**Every** task in `tasks.json` must include `runOptions` with `instanceLimit: 1` and `instancePolicy: "silent"` — install, clean, watch, build, top-level, emulator, **and the sequenced compound task** from [multi-service.md](multi-service.md) § Compound Debug Configuration. There is no task type this is optional for; if you are writing a `"label"`, you are writing `runOptions` beside it.
+
+This prevents duplicate task instances and silently skips re-invocations when a task is already running (e.g., from compound + individual `preLaunchTask` chains). The compound task is the one that needs it most, not least: it is reachable both directly and as a `preLaunchTask`, so it is the likeliest to be invoked twice.
 
 ### Start Emulators Task
 

--- a/resources/agents/azure-debug-generate/references/multi-service.md
+++ b/resources/agents/azure-debug-generate/references/multi-service.md
@@ -53,7 +53,8 @@ When a frontend service proxies to a local backend (e.g., a dev server proxy for
     "{backend-service-id}: {backend-top-level-task}",
     "{frontend-service-id}: {frontend-top-level-task}"
   ],
-  "dependsOrder": "sequence"
+  "dependsOrder": "sequence",
+  "runOptions": { "instanceLimit": 1, "instancePolicy": "silent" }
 }
 ```
 


### PR DESCRIPTION
A real `azure-debug-generate` run produced seven tasks. Six carried `runOptions`; one did not, and `validate-debug-config` failed the run:

```
• [invalidTaskRunOptions] $.tasks: Task "Debug All Services (sequenced)" must set
  runOptions.instanceLimit to 1 and runOptions.instancePolicy to "silent" so a
  repeated invocation is a no-op.
```

That looks like agent carelessness until you line the tasks up against the instructions — and then it is the instructions being wrong in two reinforcing places.

## Cause 1: the enumeration excludes the failing task

`generate.md` said *"Every task generated for the debug chain (install, clean, watch, build, top-level, and emulator tasks) must include..."*. The parenthetical reads as exhaustive, and the sequenced compound task is not in it.

Measured against the real output, the correlation is exact:

| task | `runOptions` | category |
|---|---|---|
| Start Emulators | yes | emulator *(enumerated)* |
| tasks-api: npm install | yes | install *(enumerated)* |
| tasks-api: npm clean | yes | clean *(enumerated)* |
| tasks-api: npm watch | yes | watch *(enumerated)* |
| tasks-api: func host start | yes | top-level *(enumerated)* |
| task-tracker-web: vite dev | yes | top-level *(enumerated)* |
| **Debug All Services (sequenced)** | **NO** | **compound — not enumerated** |

Six for six on the enumerated categories, and the single miss is the single category the enumeration omits.

## Cause 2: the template it copied

`multi-service.md` ships a literal JSON template for this exact task, and that template had **no `runOptions`** — while the `Start Emulators` template a few lines away in `generate.md` does. The agent copied what it was given.

## The fix

Both causes. The template now carries `runOptions`, and the prose says *"every task in `tasks.json`"* with the compound named explicitly — plus why it matters **most** there rather than least: it is reachable both directly and as a compound''s `preLaunchTask`, so it is the likeliest of all of them to be invoked twice.

## Verified against the captured run

Not by inspection. Adding exactly the line the fixed template emits, and nothing else, to that run''s `tasks.json`:

```
BEFORE  FAIL  • [invalidTaskRunOptions] Task "Debug All Services (sequenced)" …
AFTER   PASS  gate=debug-config — launch.json and tasks.json are structurally sound
```

Pinned with a `check-agent-drift.ts` contract on the **template**, since the template is what gets copied. Falsification-tested — reverting the template reports `compound-task-run-options: ... no longer states this contract`, rather than only moving the asset hash.

Contracts 17/17. All nine suites pass.