### PR TITLE
Tell azure-deploy how to load its MCP tools, and name record_deploy_prerequisites at the gate that calls it

### DIFF
--- a/evals/agent-assets.lock.json
+++ b/evals/agent-assets.lock.json
@@ -1,7 +1,7 @@
 {
-    "agentAssetsHash": "0185898b38122ae24c2fd215a02fd55ed3ccfdbfe1524e4953d3b2e326fd68b0",
+    "agentAssetsHash": "48a0fb263cdbdfe702d760849affc9f537b14edb188e46f8a536a07a70ab07a2",
     "scope": "azure-debug-generate.agent.md, azure-debug-generate/**, azure-debug-plan.agent.md, azure-debug-plan/**, azure-deploy.agent.md, azure-deploy/**, azure-project-integrate.agent.md, azure-project-integrate/**, azure-project-plan.agent.md, azure-project-plan/**, azure-project-scaffold.agent.md, azure-project-scaffold/**, shared-references/**",
-    "updatedAt": "2026-09-03T16:43:05.908Z",
+    "updatedAt": "2026-09-09T16:21:14.738Z",
     "files": {
         "azure-debug-generate.agent.md": "c9849fb6271193d104ef30161071bebe95fd29c6abea3a5c6d081416a5ebe8a6",
         "azure-debug-generate/.metadata.json": "c0ccce18678415f23db0073d48cc646f2de446e7821c99c3130553548d958e0c",
@@ -35,7 +35,7 @@
         "azure-debug-plan/references/plan-template.md": "e3a1d72d910409ebb7d2ae0a034c7fb69485b033c3b322d3b8431a272649b05d",
         "azure-debug-plan/references/project-types.md": "bfa27fbbe95be139f6390f2c8fa4719d36c1a577c512885e2eb2c8cf89b8cc58",
         "azure-debug-plan/references/runtimes.md": "f84769fe13f8464524f8ddeab6e325ea37b91ff2d7ec033d74748fe8a9924904",
-        "azure-deploy.agent.md": "9de0fb4acdea81c527b0abedd034c584dc2aa2d8cf9056769124f71835c1403d",
+        "azure-deploy.agent.md": "12b1214797d7ae857e07c53436ba60facd27c77670640bfbf1e6bfe7ed6ad904",
         "azure-deploy/.metadata.json": "be0709e660b5da6f558d73e464bed2cd39a3382619bc9076796078843d43cb56",
         "azure-deploy/deploy/instructions.md": "fce3feb85e97b977d1f191ce1f2ee4ef23bf1c467309f4a291b40f9311c5aa99",
         "azure-deploy/deploy/references/approval-gate-template.md": "ca0b2b5b86c0463f8bbb5972438013fe9a5237dd225953fb89e627769898e049",
@@ -83,7 +83,7 @@
         "azure-deploy/prereq/references/subagent-starter-scaffold.md": "786e41d77c20df47d8fd6f40b71c2e03fba3bd7504a93fe6db3b272d1a0cd628",
         "azure-deploy/prereq/references/subscription-resolution.md": "82cf51b5e861fcbef15eb10aa7f3a7d0c9049600ac566778d8046b03cba0e0c7",
         "azure-deploy/prereq/references/zero-code-path.md": "5979cfd1a7a76d36b290621cebfb13cb6815a8cc5996edbe72f22c5edffbf443",
-        "azure-deploy/references/approval-gates.md": "229bfe97d3d50ee2532bcec3504effb68098a39f27e07827601f82ddfd9f223c",
+        "azure-deploy/references/approval-gates.md": "c4eaf58118e7d5a67392afb2dd0c59d79ad9bfc83e380a969fc0a6856114a33c",
         "azure-deploy/references/azd-template-routing.md": "67bee4fdbfdb42f70faf72871c8ff767051433f9505a271b41c8db665b127797",
         "azure-deploy/references/handoff-protocol.md": "f492a70fdd3e5a3ebe8b10c90e789946b7a3661c7838a3c2f11c039011316fd2",
         "azure-deploy/references/iac-resources.md": "49d8cb5820da4ecd2db81b6dc0b0b86fdc099ab7ffc1eaf23021a40ac3cc2379",

--- a/resources/agents/azure-deploy.agent.md
+++ b/resources/agents/azure-deploy.agent.md
@@ -10,6 +10,20 @@ model: ['Claude Opus 4.7 (copilot)', 'Claude Sonnet 4.6 (copilot)']
 
 # Azure Deployment Agent
 
+## Azure Resources MCP Tools
+
+Every `copilot-azure-resources-extension-tools/*` tool this agent uses is provided by an MCP server declared in this agent's `tools:` frontmatter, so **these tools ARE available in this session.** VS Code does not always surface them directly in your active tool list; that absence does **not** mean the tool is missing or that "the extension does not expose this MCP endpoint."
+
+When a step tells you to call one of these tools and you do not see it directly available, do **not** give up — load it and call it:
+
+1. Call `tool_search` with the **exact tool name only** as the query (e.g. `record_deploy_prerequisites`) — a single tool name, never a phrase like "azure mcp deploy prerequisites".
+2. If the tool is not already active, enable it with `activate_tools`, then invoke the tool (e.g. `record_deploy_prerequisites`).
+3. If the search misses or a call errors, **retry** the search → activate → invoke loop with the exact tool name. Persist until the call succeeds.
+
+Never claim one of these tools is "not available" or "not exposed", never fall back to a manual work-around (narrating a CLI check in chat, or hand-editing an artifact the tool owns), and never stop, summarize, or announce completion until the required tool call has actually **succeeded**. Treating a required view/state tool as unavailable is a **failure of this agent**, not an acceptable outcome.
+
+This applies to every tool this agent is contracted to call: `record_deploy_prerequisites`, `open_deploy_plan_view`, `capture_deployment_inventory`, and `open_deploy_result_view`.
+
 You are the deployment phase of the guided Azure project workflow:
 
 **Plan → Scaffold → Integrate → Local Dev → Deploy**

--- a/resources/agents/azure-deploy/references/approval-gates.md
+++ b/resources/agents/azure-deploy/references/approval-gates.md
@@ -8,6 +8,16 @@ Display the architecture plan for user approval BEFORE generating any files:
 
 > ⛔ **Open the plan view FIRST.** Call `open_deploy_plan_view` before displaying the gate text — it renders the `prepare-plan.json` you just wrote (services, SKUs, region, cost) in a side-by-side view. Call it once per gate; it is a display action only and never replaces the chat approval prompt below.
 
+> ⛔ **Record the CLI prerequisites through the MCP tool — not in chat.** The plan view has a prerequisites section for the two CLIs this stage depends on, and it is populated **only** by `record_deploy_prerequisites`. Before (or right alongside) `open_deploy_plan_view`:
+>
+> 1. Probe each CLI with its version command in the user's own default shell — **azd** → `azd version`, **az** → `az version`.
+> 2. Call `record_deploy_prerequisites` with one entry per tool: `installed: true` when the command returned a version, otherwise `installed: false`. Include the detected `version` when you have it.
+> 3. Do **not** pass install links or display names — the view resolves those from its own catalog.
+>
+> Example: `record_deploy_prerequisites({ tools: [{ id: "azd", installed: true, version: "1.9.2" }, { id: "az", installed: false }] })`
+>
+> Checking the CLIs by hand and describing the result in chat does **not** satisfy this — the user's plan view stays empty. Never write these into `prepare-plan.json`; that is the vendored pipeline's artifact. If the tool is not directly listed, load it first per "Azure Resources MCP Tools" in [`azure-deploy.agent.md`](../../azure-deploy.agent.md) — do **not** conclude it is unavailable.
+
 > ⛔ **Resource group edit is MANDATORY in the gate display.** Show this exact block:
 > ```
 > 🏢 **Subscription:** {subscriptionName} (`{subscriptionId}`)


### PR DESCRIPTION
Stacked on #1791 — its `record_deploy_prerequisites` assertion is what validates this change, so this must merge after it.

## What was wrong

`record_deploy_prerequisites` was never invoked. The user's Deployment plan view showed no prerequisite status, because the agent checked `az`/`azd` by hand and narrated the result in chat instead of calling the tool.

**Root cause: the tool was named only in the parent agent file.** `azure-deploy.agent.md` L45/L48 describe the call, but no file the agent reads *at the point of work* mentioned it. It belongs at the **scaffold approval gate** — `agent.md` ties it to "as soon as `prepare-plan.json` is written and before (or right alongside) `open_deploy_plan_view`" — and that gate is authored in `references/approval-gates.md`, which already contracted `open_deploy_plan_view` and never named this one.

The gap is **not** in `prereq/instructions.md`. That phase is read-only static evaluation under an absolute prohibition on running commands, and it probes CLIs through the vendored `mcp_azure_mcp_extension_cli_install`. `azd version` / `az version` appear in no sub-instruction file at all.

## Verification: a controlled before/after

Same stimulus (`deploy-scaffold-iac`), same assertion text, same model.

| | pre-fix `2026090870361562` | post-fix `2026090916668652` |
|---|---|---|
| `record_deploy_prerequisites` | **FAIL** | **PASS** |
| `open_deploy_plan_view` | PASS | PASS |
| total | 11/13 | 12/13 |

```
step0 [51] mcp_copilot_azure_record_deploy_prerequisites
      args={"tools":[{"id":"azd","installed":false},{"id":"az","installed":true,"version":"2.90.0"}]}
      -> {"message":"Recorded deployment prerequisites. They will appear in the Deployment Plan view."}
```

## The pre-fix run isolates the cause

The failure was **not** that the agent could not find the tool. Pre-fix it ran this search, and the tool came back second of five:

```
[34] tool_search {"query":"azure mcp capture deployment inventory prerequisites pricing"}
     -> ["mcp_copilot_azure_capture_deployment_inventory",
         "mcp_copilot_azure_record_deploy_prerequisites",   <-- surfaced, then not called
         "mcp_copilot_azure_start_deployment", ...]
```

The tool was surfaced and skipped. Meanwhile, in the same run at the same gate, the agent *did* call `open_deploy_plan_view` — the one tool that gate's own instruction file already named.

That is the parent/sub-instruction split demonstrated inside a single run, holding everything else constant:

| tool | named in `approval-gates.md` pre-fix? | pre-fix outcome |
| --- | --- | --- |
| `open_deploy_plan_view` | yes | called |
| `record_deploy_prerequisites` | no — parent file only | surfaced by search, not called |

Naming it at the point of work is what changed the outcome.

## The second commit is consistency, not the fix

`azure-deploy` is the only one of the six agents without the "Azure Resources MCP Tools" preamble; the other five all carry it. I added it, and it is worth keeping — but **it is not what fixed this**, and an earlier draft of this description wrongly implied it was.

What it demonstrably changed is the *form* of the search. Pre-fix the agent searched phrases (`"azure mcp capture deployment inventory prerequisites pricing"`); post-fix it searched exact tool names (`"mcp_copilot_azure_open_deploy_plan_view mcp_copilot_azure_record_deploy_prerequisites"`), which is what the preamble's rule 1 asks for and never a phrase. Since `open_deploy_plan_view` was reached by a phrase search pre-fix, the preamble makes the search *reliable* rather than *possible*.

One observation that does hold across every run examined: **`tool_search` always immediately precedes an MCP call — 9 of 9, no exceptions.** These tools are not in the model's default active list. That makes search necessary but, as this run shows, not sufficient.

## The 13th assertion

Fails for an unrelated, already-filed reason — #1787, now reproduced a third time. The IaC compiled; the agent then wrote `validationResult.status: null` and recorded no bicep-build check. Nothing here touches manifest writing, and it fails identically pre- and post-fix. The stimulus's falsifiability probe (assertion 12) passed, so the grader demonstrably still fails in this container and that red is trustworthy.

## Notes

- **No doc update needed.** `docs/copilot-create-project.md` L274 already documents the intended behaviour and even names the symptom — "until it does, the view shows their status as **Unknown**". This restores documented behaviour rather than changing it. No UI changed, so no screenshots are stale.
- The third file re-records `evals/agent-assets.lock.json`. `check-agent-drift.ts` fails on any tracked agent-asset change until the evals are re-run against the new instructions; `deploy-scaffold-iac` is the only stimulus driving `azure-deploy`, and it ran post-change as the verification above.
