### PR TITLE
CoR: Add a deployment results view opener to the Azure Project tree

### DIFF
--- a/src/tree/project/AzureProjectProgressTreeDataProvider.ts
+++ b/src/tree/project/AzureProjectProgressTreeDataProvider.ts
@@ -83,7 +83,7 @@ export class AzureProjectProgressTreeDataProvider implements vscode.TreeDataProv
         return [
             new ProjectCreationStageItem(effectiveStage, files.hasProjectPlan),
             new LocalDevelopmentStageItem(effectiveStage, files.hasLocalDevelopmentPlan),
-            new DeploymentStageItem(effectiveStage, files.hasDeploymentPlan, files.hasAppOnboardSession),
+            new DeploymentStageItem(effectiveStage, files.hasDeploymentPlan, files.hasAppOnboardSession, files.hasDeployResult),
         ];
     }
 }

--- a/src/tree/project/DeploymentStageItem.ts
+++ b/src/tree/project/DeploymentStageItem.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import { copilotOnRailsCommandIds } from '../../commands/copilotOnRails/registerCopilotOnRailsCommands';
+import { OpenDeployResultNode } from './OpenDeployResultNode';
 import { OpenPlanNode } from './OpenPlanNode';
 import { ProgressNode } from './ProgressNode';
 import { StageNode } from './StageNode';
@@ -17,13 +18,28 @@ export class DeploymentStageItem extends StageNode {
     protected readonly stepIndex = 2;
     protected readonly iconName = 'rocket';
 
-    constructor(currentStage: number, hasPlanFile: boolean, private readonly hasAppOnboardSession: boolean) {
+    constructor(
+        currentStage: number,
+        hasPlanFile: boolean,
+        private readonly hasAppOnboardSession: boolean,
+        private readonly hasDeployResult: boolean,
+    ) {
         super(currentStage, hasPlanFile);
     }
 
     getChildren(): ProgressNode[] {
+        const nodes: ProgressNode[] = [];
+
         if (this.hasPlanFile) {
-            return [new OpenPlanNode(this.stageId, copilotOnRailsCommandIds.openDeploymentPlanView)];
+            nodes.push(new OpenPlanNode(this.stageId, copilotOnRailsCommandIds.openDeploymentPlanView));
+        }
+
+        if (this.hasDeployResult) {
+            nodes.push(new OpenDeployResultNode(this.stageId, copilotOnRailsCommandIds.openDeployResultView));
+        }
+
+        if (nodes.length > 0) {
+            return nodes;
         }
 
         return [new StateStageNode(

--- a/src/tree/project/OpenDeployResultNode.ts
+++ b/src/tree/project/OpenDeployResultNode.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { ProgressNode } from './ProgressNode';
+
+/**
+ * Reopens the Deployment results view for the workspace's latest `deploy-result.json`.
+ * Only shown once that artifact exists, so the deploy report stays reachable after
+ * the user closes its tab.
+ */
+export class OpenDeployResultNode implements ProgressNode {
+    constructor(
+        private readonly stageId: string,
+        private readonly openDeployResultCommandId: string,
+    ) { }
+
+    getChildren(): ProgressNode[] {
+        return [];
+    }
+
+    getTreeItem(): vscode.TreeItem {
+        const label = vscode.l10n.t('Open deployment results');
+        const item = new vscode.TreeItem(label, vscode.TreeItemCollapsibleState.None);
+        item.id = `${this.stageId}.openDeployResult`;
+        item.iconPath = new vscode.ThemeIcon('cloud-upload');
+        item.tooltip = label;
+        item.command = {
+            command: this.openDeployResultCommandId,
+            title: '',
+        };
+        return item;
+    }
+}

--- a/src/tree/project/projectPlanFiles.ts
+++ b/src/tree/project/projectPlanFiles.ts
@@ -14,6 +14,8 @@ export interface ProjectPlanFiles {
     hasLocalDevelopmentPlan: boolean;
     hasDeploymentPlan: boolean;
     hasAppOnboardSession: boolean;
+    /** True once the deploy agent has written a `deploy-result.json`, i.e. there are results to show. */
+    hasDeployResult: boolean;
     /** True when any project artifact exists (requirements, a plan file, or an App Onboard session). */
     hasAny: boolean;
     /** The furthest stage reached. */
@@ -53,7 +55,12 @@ const PLAN_FILE_GLOBS = [
 ] as const;
 
 /** All artifacts that indicate an in-progress project, for watching. */
-const ALL_PROJECT_FILE_GLOBS = [REQUIREMENTS_FILE_GLOB, ...PLAN_FILE_GLOBS, APP_ONBOARD_ACTIVE_SESSION_FILE_GLOB] as const;
+const ALL_PROJECT_FILE_GLOBS = [
+    REQUIREMENTS_FILE_GLOB,
+    ...PLAN_FILE_GLOBS,
+    APP_ONBOARD_ACTIVE_SESSION_FILE_GLOB,
+    ...DEPLOY_RESULT_FILE_GLOBS,
+] as const;
 
 export function createProjectPlanFileWatcher(glob: string): vscode.FileSystemWatcher {
     const folder = vscode.workspace.workspaceFolders?.[0];
@@ -130,9 +137,10 @@ export async function getProjectPlanFiles(): Promise<ProjectPlanFiles> {
     const hasLocalDevelopmentPlan = exists(DEBUG_PLAN_FILE_GLOB);
     const hasDeploymentPlan = PREPARE_PLAN_FILE_GLOBS.some(exists);
     const hasAppOnboardSession = exists(APP_ONBOARD_ACTIVE_SESSION_FILE_GLOB);
+    const hasDeployResult = DEPLOY_RESULT_FILE_GLOBS.some(exists);
 
     let currentStage: ProjectStage = 0;
-    if (hasDeploymentPlan || hasAppOnboardSession) {
+    if (hasDeploymentPlan || hasAppOnboardSession || hasDeployResult) {
         currentStage = 2;
     } else if (hasLocalDevelopmentPlan) {
         currentStage = 1;
@@ -144,7 +152,8 @@ export async function getProjectPlanFiles(): Promise<ProjectPlanFiles> {
         hasLocalDevelopmentPlan,
         hasDeploymentPlan,
         hasAppOnboardSession,
-        hasAny: hasRequirements || hasProjectPlan || hasLocalDevelopmentPlan || hasDeploymentPlan || hasAppOnboardSession,
+        hasDeployResult,
+        hasAny: hasRequirements || hasProjectPlan || hasLocalDevelopmentPlan || hasDeploymentPlan || hasAppOnboardSession || hasDeployResult,
         currentStage,
     };
 }


### PR DESCRIPTION
Here is how the button looks:
<img width="435" height="248" alt="image" src="https://github.com/user-attachments/assets/fbc118e3-7f3c-4115-94fd-feb870f59ea4" />

This just opens the deployment results view so users can access it easier. 