### PR TITLE
Use the canonical sentinel wording in integrate-seam, so it does not fork the gate

### DIFF
--- a/evals/msbench/config/stimuli/integrate-seam.yaml
+++ b/evals/msbench/config/stimuli/integrate-seam.yaml
@@ -49,7 +49,7 @@ promptSteps:
   - text: |
       Scaffold the project described by the approved `.azure/project-plan.md`.
     assertions:
-      - comment: Sentinel; scaffold turn must have produced a response or its checks are vacuous
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
         query: SELECT COUNT(*) > 0 FROM llm_responses
 
   # ─── Turn 1: integrate — the subject of this stimulus ──────────────────────────
@@ -91,7 +91,7 @@ promptSteps:
     text: |
       Looks good — go ahead and set up local development.
     assertions:
-      - comment: Sentinel; approval turn must have produced a response or its checks are vacuous
+      - comment: Sentinel; this turn must have produced a response or its checks are vacuous
         query: SELECT COUNT(*) > 0 FROM llm_responses
 
       # vally: tool-calls required [workflow-tools-start_local_development]


### PR DESCRIPTION
Fixes the failing **Agent Contracts / contracts** job on #1791.

## What was broken

`check-stimulus-comments.ts` reported **3 gate identity problems**, all from `integrate-seam.yaml`:

```
integrate-seam.yaml
  gate     liveness sentinel (pinned)
  expected Sentinel; this turn must have produced a response or its checks are vacuous
  found    Sentinel; scaffold turn must have produced a response or its checks are vacuous

integrate-seam.yaml
  gate     liveness sentinel (pinned)
  expected Sentinel; this turn must have produced a response or its checks are vacuous
  found    Sentinel; approval turn must have produced a response or its checks are vacuous

61 assertions share one query but describe it 3 different ways
```

I introduced this in the commit that added the stimulus. The three sentinels share one identical query — `SELECT COUNT(*) > 0 FROM llm_responses` — but I gave each a per-turn comment. A SQL assertion carries no grader filename, so its `comment` is the only stable identity it has in stored run results; rewording one forks that gate into a second identity with no history, while the original looks like it silently stopped being evaluated.

This is precisely the failure the check exists to catch. Its own note records the liveness sentinel reaching ten different wordings across eleven stimuli before anyone noticed.

## Why the per-turn wording is no loss

Attribution never came from the comment text. Verdicts are bound to their turn by the implied `stepIndex` filter and read positionally out of `eval.json` — which is exactly how I read the two `integrate-seam` runs yesterday, telling the three sentinels apart by position rather than by wording.

It also restores the corpus norm rather than departing from it: `debug-generate-artifacts.yaml` repeats one wording across four turns, `deploy-scaffold-iac.yaml` across two.

## Verification

Every step of the contracts job, run locally against this branch:

| step | result |
| --- | --- |
| `gates` | ✔ 141 distinct assertions across 49 stimuli, gate identity consistent |
| `drift` | ✔ 16 contracts intact, assets match baseline |
| `typecheck` | ✔ |
| `imports:self-test` | ✔ |
| `certify` | ✔ 152/152 grader certification cases |
| `stacks:check` | ✔ |
| `phases:check` | ✔ |
| `lint` | ✔ |
| `clean-machine:check` | ✔ 4 entrypoints, `node_modules` restored |

The last five never ran in CI, because the job stops at the first failing step — so this confirms nothing else was hiding behind the comments failure.

## One thing left deliberately untouched

`npm run certify` rewrites `evals/results/grader-certification/offline/report.json`, and regenerating it here produces a real content change beyond the timestamp: a `safety-owner-grant-in-a-plan-document-is-caught` case exists in the suite but is absent from the committed report. So that tracked artifact is stale on this branch — a certification case was added without regenerating it.

I reverted it rather than folding an unrelated generated-file update into a one-line fix. Nothing checks it (`certify` exits 0 regardless), so it is cosmetic, but it is worth someone regenerating deliberately.