### PR TITLE
fix(copilot-on-rails): require quoted mermaid labels in debug plan diagrams

### DIFF
--- a/.github/instructions/copilot-on-rails-docs.instructions.md
+++ b/.github/instructions/copilot-on-rails-docs.instructions.md
@@ -68,6 +68,9 @@ Use this map from source area to the screenshot(s) it backs:
   refresh them. If your change touched no UI, say so.
 - Re-read the affected sections and confirm every command id, MCP tool name, agent name, file path, and
   view→command mapping still matches the code you changed.
-- Keep the reference tables and the Mermaid pipeline diagram accurate.
+- Keep the reference tables and the Mermaid pipeline diagram accurate. When you edit that diagram, **wrap
+  every node label and edge label in double quotes** (`Plan["1 · azure-project-plan"]`,
+  `A -->|"@azure/storage-blob"| B`) — mermaid v11 reads a leading `@` in an unquoted label as edge-ID
+  syntax and fails to parse the whole diagram.
 - If nothing user-visible changed (a pure internal refactor), no doc update is needed — note that briefly
   instead of editing the doc.

--- a/evals/agent-assets.lock.json
+++ b/evals/agent-assets.lock.json
@@ -1,7 +1,7 @@
 {
-    "agentAssetsHash": "30b34c90384f5660601592aa41fefc9b97441aba8735fe1d6c83510e5b96eb96",
+    "agentAssetsHash": "3aef220627b42a3f692969eb062caa605ce7d1d38eeb1ab88c34e5607592030b",
     "scope": "azure-debug-generate.agent.md, azure-debug-generate/**, azure-debug-plan.agent.md, azure-debug-plan/**, azure-deploy.agent.md, azure-deploy/**, azure-project-integrate.agent.md, azure-project-integrate/**, azure-project-plan.agent.md, azure-project-plan/**, azure-project-scaffold.agent.md, azure-project-scaffold/**, shared-references/**",
-    "updatedAt": "2026-09-09T22:41:24.793Z",
+    "updatedAt": "2026-09-09T23:18:11.186Z",
     "files": {
         "azure-debug-generate.agent.md": "578913e2eda74726fcdcc8834a0d4ecf49e6e45930dd323d295d757db8bd620c",
         "azure-debug-generate/.metadata.json": "c0ccce18678415f23db0073d48cc646f2de446e7821c99c3130553548d958e0c",
@@ -32,7 +32,7 @@
         "azure-debug-plan/references/inventory.md": "0fdb477a32627b98dbae552aa4c92bcc72903f21d0997621f6d52b60870473d8",
         "azure-debug-plan/references/migrations.md": "4c63437fc61bf7ff0f39f1ae936e78290036940b5880a0af624db381d9feb9c7",
         "azure-debug-plan/references/multi-service.md": "9099ed9cf78b4a813539fb2b265a5b0eb80f99198ca87bd0a81c4bc7f3c0ac80",
-        "azure-debug-plan/references/plan-template.md": "e3a1d72d910409ebb7d2ae0a034c7fb69485b033c3b322d3b8431a272649b05d",
+        "azure-debug-plan/references/plan-template.md": "bc27784147a98ff241a1851482911df3be4af1bee05958b03be67b454d9b9c5d",
         "azure-debug-plan/references/project-types.md": "bfa27fbbe95be139f6390f2c8fa4719d36c1a577c512885e2eb2c8cf89b8cc58",
         "azure-debug-plan/references/runtimes.md": "f84769fe13f8464524f8ddeab6e325ea37b91ff2d7ec033d74748fe8a9924904",
         "azure-deploy.agent.md": "73ef0b16f508bec86da6c36109908f21cceecda8398f84e8db82badad6917b68",

--- a/resources/agents/azure-debug-plan/references/plan-template.md
+++ b/resources/agents/azure-debug-plan/references/plan-template.md
@@ -21,6 +21,26 @@ When editing markdown tables with `replace_string_in_file` or `multi_replace_str
 
 ---
 
+## ⚠️ Mermaid Label Quoting — ALWAYS Quote Every Label
+
+In the `## Architecture Diagram` mermaid block, **every node label and every edge label MUST be wrapped in double quotes.** This rule is unconditional — quote every label, every time, even when it looks harmless.
+
+```mermaid
+graph LR
+    %% ✅ CORRECT — every label quoted
+    API["Commerce API<br/>Azure Functions :7071"] -->|"@azure/storage-blob"| AZ["Azurite<br/>:10000"]
+    API -->|"pg"| PG[("PostgreSQL<br/>:5432")]
+
+    %% ❌ WRONG — unquoted labels; the leading @ is a parse error
+    %% API[Commerce API<br/>Azure Functions :7071] -->|@azure/storage-blob| AZ[Azurite]
+```
+
+**Why:** mermaid v11 uses `@` for edge-ID (`e1@-->`) and node-metadata (`id@{ shape: ... }`) syntax, so an `@` at the **start** of an unquoted label is lexed as a link ID and the whole diagram fails to parse with `Expecting 'AMP', 'COLON', ... got 'LINK_ID'`. Scoped npm package names (`@azure/storage-blob`, `@azure/identity`, `@prisma/client`) are the most common trigger, and they are exactly what shows up in Azure dependency edge labels. The debug-plan webview renders this block with mermaid — a parse error replaces the diagram with a raw `mermaid (error)` code block.
+
+Quoting is always valid in mermaid and also protects labels containing `(`, `)`, `:`, `-`, `/`, `#`, or `·`. Do **not** try to detect which labels are "risky" — just quote all of them.
+
+---
+
 ## Template
 
 ````markdown
@@ -143,6 +163,10 @@ graph LR
     %% Generated from Debug Configurations + Emulators tables above.
     %% Show each service as a node, each emulator as a node,
     %% and edges for the Azure Dependencies that connect them.
+    %% MANDATORY: wrap EVERY node label and EVERY edge label in double quotes —
+    %% e.g. API["Commerce API<br/>Azure Functions :7071"] -->|"@azure/storage-blob"| AZ["Azurite"]
+    %% An unquoted leading @ (scoped npm packages) is parsed as mermaid edge-ID
+    %% syntax and breaks the whole diagram. See "Mermaid Label Quoting" above.
 ```
 
 ---

--- a/src/webviews/copilotOnRails/views/LocalPlanView.tsx
+++ b/src/webviews/copilotOnRails/views/LocalPlanView.tsx
@@ -53,6 +53,7 @@ import {
     type LocalPlanSection,
 } from "./utils/parseLocalDebugPlanMarkdown";
 import { getPrerequisiteInstallLink } from "./utils/prerequisiteInstallLinks";
+import { quoteMermaidLabels } from "./utils/quoteMermaidLabels";
 
 mermaid.initialize({
     startOnLoad: false,
@@ -1041,7 +1042,7 @@ const MermaidBlock = ({ code }: { code: string }): JSX.Element => {
         let cancelled = false;
         const id = `mermaid-diagram-${++mermaidIdCounter}`;
         mermaid
-            .render(id, code)
+            .render(id, quoteMermaidLabels(code))
             .then(({ svg }) => {
                 if (!cancelled && ref.current) {
                     ref.current.innerHTML = svg;

--- a/src/webviews/copilotOnRails/views/utils/quoteMermaidLabels.ts
+++ b/src/webviews/copilotOnRails/views/utils/quoteMermaidLabels.ts
@@ -89,20 +89,7 @@ function quoteLabelsInLine(line: string): string {
                 // A label already rewritten by the cylinder rule starts with `(` or `"`, and
                 // `/` and `\` are the parallelogram/trapezoid shape delimiters rather than
                 // label text. Leave all of those to the rules that own them.
-                //
-                // Skipping `/` and `\` means a parallelogram or trapezoid label is never
-                // quoted, so `A[/@azure/identity/]` still fails to parse. That is a
-                // deliberate tradeoff: quoting it would flatten the shape into a plain
-                // rectangle, which silently changes a diagram that renders today. Losing a
-                // shape on every existing diagram is worse than not rescuing a rare one.
                 /^[("/\\]/.test(label) ? match : `[${quote(label)}]`,
-            )
-            // Round `(text)`: run after cylinder/circle/stadium so their delimiters are
-            // already consumed, and skip a body a previous rule produced. A stadium
-            // `A([x])` has by now become `A(["x"])`, so its paren body starts with `[`;
-            // without this guard it would be re-quoted into `A("[\"x\"]")` and break.
-            .replace(/\(([^()\n]+)\)/g, (match, label: string) =>
-                /^[["/\\]/.test(label) ? match : `(${quote(label)})`,
             );
 
         if (!hasMetadata) {

--- a/src/webviews/copilotOnRails/views/utils/quoteMermaidLabels.ts
+++ b/src/webviews/copilotOnRails/views/utils/quoteMermaidLabels.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Render-time normalization for the mermaid diagram in a debug plan.
+ *
+ * The `azure-debug-plan` agent's template asks for every flowchart label to be
+ * quoted, because mermaid v11 reserves characters that routinely show up in the
+ * package and service names these diagrams describe. The clearest example is
+ * `@`, which mermaid v11 lexes as the start of an edge id (`e1@-->`) or a node
+ * metadata block (`id@{ shape: rect }`) when it opens an *unquoted* label — so
+ * `API -->|@azure/storage-blob| AZ` fails to parse and the whole diagram is
+ * replaced by mermaid's syntax-error graphic.
+ *
+ * The template rule only helps plans generated from now on, and only when the
+ * model complies. Plans already written to a workspace still fail to render, so
+ * the webview quotes labels itself before handing the diagram to mermaid.
+ *
+ * The transform is deliberately conservative: it only quotes a label that is not
+ * quoted already, so it is a no-op on diagrams that already render.
+ */
+
+/** Diagram kinds this transform understands. Anything else is passed through untouched. */
+const flowchartHeader = /^(?:graph|flowchart)\b/;
+
+/**
+ * Quotes unquoted flowchart node and edge labels so reserved characters inside
+ * them are treated as text.
+ *
+ * Returns `code` unchanged when it isn't a flowchart — a sequence, class or ER
+ * diagram gives `[]`, `{}` and `|` completely different meanings, and rewriting
+ * one would turn a working diagram into a broken one.
+ */
+export function quoteMermaidLabels(code: string): string {
+    const lines = code.split('\n');
+    const bodyStart = endOfFrontmatter(lines);
+    if (!isFlowchart(lines, bodyStart)) {
+        return code;
+    }
+
+    return lines.map((line, i) => (i < bodyStart ? line : quoteLabelsInLine(line))).join('\n');
+}
+
+/**
+ * Index of the first line after a leading `---` YAML frontmatter block, or 0
+ * when there isn't one. Frontmatter is diagram config rather than diagram body,
+ * so it is copied through verbatim.
+ */
+function endOfFrontmatter(lines: string[]): number {
+    if (lines[0]?.trim() !== '---') {
+        return 0;
+    }
+    const close = lines.findIndex((line, i) => i > 0 && line.trim() === '---');
+    return close === -1 ? 0 : close + 1;
+}
+
+function isFlowchart(lines: string[], bodyStart: number): boolean {
+    for (let i = bodyStart; i < lines.length; i++) {
+        const line = lines[i].trim();
+        // `%%` covers both comments and `%%{init: ...}%%` directives.
+        if (line === '' || line.startsWith('%%')) {
+            continue;
+        }
+        return flowchartHeader.test(line);
+    }
+    return false;
+}
+
+function quoteLabelsInLine(line: string): string {
+    if (line.trim().startsWith('%%')) {
+        return line;
+    }
+
+    // Mermaid v11 node/edge metadata — `id@{ shape: rect }`, `e1@{ animate: true }` —
+    // is brace-delimited but is configuration, not a label. Quoting its body
+    // (`e1@{"animate: true"}`) would change what it means, so the rhombus rule is
+    // skipped entirely on any line that carries a metadata block.
+    const hasMetadata = line.includes('@{');
+
+    return mapUnquotedSegments(line, (segment) => {
+        let result = segment
+            // Cylinder `[(text)]` and circle `((text))` are matched before the plain
+            // `[text]` rule so their delimiters survive.
+            .replace(/\[\(([^)\]\n]+)\)\]/g, (_match, label: string) => `[(${quote(label)})]`)
+            .replace(/\(\(([^)\n]+)\)\)/g, (_match, label: string) => `((${quote(label)}))`)
+            .replace(/\[([^[\]\n]+)\]/g, (match, label: string) =>
+                // A label already rewritten by the cylinder rule starts with `(` or `"`, and
+                // `/` and `\` are the parallelogram/trapezoid shape delimiters rather than
+                // label text. Leave all of those to the rules that own them.
+                /^[("/\\]/.test(label) ? match : `[${quote(label)}]`,
+            );
+
+        if (!hasMetadata) {
+            result = result.replace(/\{([^{}\n]+)\}/g, (_match, label: string) => `{${quote(label)}}`);
+        }
+
+        // Edge labels: `-->|text|`.
+        return result.replace(/\|([^|\n]+)\|/g, (_match, label: string) => `|${quote(label)}|`);
+    });
+}
+
+const quote = (label: string): string => (label.includes('"') ? label : `"${label}"`);
+
+/**
+ * Applies `transform` to the parts of `line` that sit outside mermaid's `"…"`
+ * strings. Mermaid has no escape sequence inside a quoted label, so the double
+ * quotes alternate: even-indexed pieces are outside a string, odd-indexed ones
+ * are the label text itself. Rewriting only the outside pieces keeps an
+ * already-quoted label — including one that contains brackets, braces or pipes,
+ * such as `A["Blob (hot tier) [preview]"]` — exactly as the author wrote it.
+ */
+function mapUnquotedSegments(line: string, transform: (segment: string) => string): string {
+    return line
+        .split('"')
+        .map((segment, i) => (i % 2 === 0 ? transform(segment) : segment))
+        .join('"');
+}

--- a/src/webviews/copilotOnRails/views/utils/quoteMermaidLabels.ts
+++ b/src/webviews/copilotOnRails/views/utils/quoteMermaidLabels.ts
@@ -89,7 +89,20 @@ function quoteLabelsInLine(line: string): string {
                 // A label already rewritten by the cylinder rule starts with `(` or `"`, and
                 // `/` and `\` are the parallelogram/trapezoid shape delimiters rather than
                 // label text. Leave all of those to the rules that own them.
+                //
+                // Skipping `/` and `\` means a parallelogram or trapezoid label is never
+                // quoted, so `A[/@azure/identity/]` still fails to parse. That is a
+                // deliberate tradeoff: quoting it would flatten the shape into a plain
+                // rectangle, which silently changes a diagram that renders today. Losing a
+                // shape on every existing diagram is worse than not rescuing a rare one.
                 /^[("/\\]/.test(label) ? match : `[${quote(label)}]`,
+            )
+            // Round `(text)`: run after cylinder/circle/stadium so their delimiters are
+            // already consumed, and skip a body a previous rule produced. A stadium
+            // `A([x])` has by now become `A(["x"])`, so its paren body starts with `[`;
+            // without this guard it would be re-quoted into `A("[\"x\"]")` and break.
+            .replace(/\(([^()\n]+)\)/g, (match, label: string) =>
+                /^[["/\\]/.test(label) ? match : `(${quote(label)})`,
             );
 
         if (!hasMetadata) {

--- a/test/copilotOnRails/quoteMermaidLabels.test.ts
+++ b/test/copilotOnRails/quoteMermaidLabels.test.ts
@@ -1,0 +1,146 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { quoteMermaidLabels } from '../../src/webviews/copilotOnRails/views/utils/quoteMermaidLabels';
+
+suite('quoteMermaidLabels', () => {
+    suite('quotes unquoted labels', () => {
+        test('quotes an edge label that starts with @', () => {
+            // The real failure: mermaid v11 lexes a leading `@` as the start of an edge id
+            // (`e1@-->`), so the unquoted form fails to parse and the diagram is replaced
+            // by mermaid's syntax-error graphic.
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n    API -->|@azure/storage-blob| AZ[(Azurite)]'),
+                'graph LR\n    API -->|"@azure/storage-blob"| AZ[("Azurite")]',
+            );
+        });
+
+        test('quotes rectangle labels', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n    Web[Web UI<br/>Vite :5173] --> API[API<br/>:3000]'),
+                'graph LR\n    Web["Web UI<br/>Vite :5173"] --> API["API<br/>:3000"]',
+            );
+        });
+
+        test('quotes cylinder, circle and rhombus labels without losing the shape', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('graph TD\n    S((Start)) --> Q{Ready?}\n    Q --> DB[(Postgres :5432)]'),
+                'graph TD\n    S(("Start")) --> Q{"Ready?"}\n    Q --> DB[("Postgres :5432")]',
+            );
+        });
+
+        test('quotes stadium, subroutine and hexagon labels without losing the shape', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n    A([Stadium]) --> B[[Subroutine]] --> C{{Hexagon}}'),
+                'graph LR\n    A(["Stadium"]) --> B[["Subroutine"]] --> C{{"Hexagon"}}',
+            );
+        });
+
+        test('quotes a subgraph title', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('graph TB\n    subgraph core [Core Services]\n        A[API] --> B[DB]\n    end'),
+                'graph TB\n    subgraph core ["Core Services"]\n        A["API"] --> B["DB"]\n    end',
+            );
+        });
+
+        test('accepts flowchart as well as graph', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('flowchart LR\n    A[API] --> B[DB]'),
+                'flowchart LR\n    A["API"] --> B["DB"]',
+            );
+        });
+
+        test('normalizes a diagram behind a directive or frontmatter, leaving the preamble alone', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('%%{init: {"theme":"dark"}}%%\ngraph LR\n    A[API] --> B[DB]'),
+                '%%{init: {"theme":"dark"}}%%\ngraph LR\n    A["API"] --> B["DB"]',
+            );
+            assert.strictEqual(
+                quoteMermaidLabels('---\nconfig:\n  theme: dark\n---\ngraph LR\n    A[API] --> B[DB]'),
+                '---\nconfig:\n  theme: dark\n---\ngraph LR\n    A["API"] --> B["DB"]',
+            );
+        });
+    });
+
+    suite('leaves valid syntax alone', () => {
+        test('is a no-op on an already-quoted diagram', () => {
+            const code = 'graph LR\n    A["Web App"] -->|"HTTP"| B["API"]';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+
+        test('is idempotent', () => {
+            const once = quoteMermaidLabels('graph LR\n    A[API] -->|calls| B[(DB)]');
+            assert.strictEqual(quoteMermaidLabels(once), once);
+        });
+
+        test('does not touch brackets, braces or pipes inside an already-quoted label', () => {
+            const code = 'graph LR\n    A["Blob (hot tier) [preview]"] --> B["Queue {std}"]';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+
+        test('does not touch markdown string labels', () => {
+            const code = 'graph LR\n    A["`**bold** label`"] --> B["`_italic_`"]';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+
+        test('does not rewrite v11 node or edge metadata blocks', () => {
+            // `id@{ shape: rect }` and `e1@{ animate: true }` are brace-delimited
+            // configuration, not labels — quoting their bodies would change what they mean.
+            const code = 'flowchart LR\n    A@{ shape: rect, label: "Hi" }\n    A e1@--> B\n    e1@{ animate: true }';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+
+        test('does not touch comment lines', () => {
+            const code = 'graph LR\n    %% A[Not a node] and |not an edge|\n    A[API] --> B[DB]';
+            assert.strictEqual(
+                quoteMermaidLabels(code),
+                'graph LR\n    %% A[Not a node] and |not an edge|\n    A["API"] --> B["DB"]',
+            );
+        });
+
+        test('does not touch styling or interaction directives', () => {
+            const code =
+                'graph LR\n' +
+                '    classDef svc fill:#f9f,stroke:#333\n' +
+                '    style A fill:#bbf\n' +
+                '    linkStyle 0 stroke:#f00\n' +
+                '    click A "https://example.com" "Open docs"';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+
+        test('does not flatten parallelogram or trapezoid shapes into rectangles', () => {
+            const code = 'graph LR\n    A[/Input/] --> B[\\Output\\] --> C[/Trapezoid\\]';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+
+        test('leaves a diagram with no labels untouched', () => {
+            const code = 'graph LR\n    A --> B --> C';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+    });
+
+    suite('non-flowchart diagrams', () => {
+        // `[]`, `{}` and `|` mean something else entirely outside a flowchart, so these
+        // must come back byte-for-byte identical.
+        const diagrams: Record<string, string> = {
+            sequence: 'sequenceDiagram\n    Alice->>John: Hello John\n    John-->>Alice: Great!',
+            class: 'classDiagram\n    class Animal { +int age }\n    Animal <|-- Dog',
+            er: 'erDiagram\n    CUSTOMER ||--o{ ORDER : places',
+            state: 'stateDiagram-v2\n    [*] --> Still\n    Still --> [*]',
+            pie: 'pie title Pets\n    "Dogs" : 386\n    "Cats" : 85',
+        };
+
+        for (const [name, code] of Object.entries(diagrams)) {
+            test(`leaves the ${name} diagram untouched`, () => {
+                assert.strictEqual(quoteMermaidLabels(code), code);
+            });
+        }
+
+        test('leaves an empty diagram untouched', () => {
+            assert.strictEqual(quoteMermaidLabels(''), '');
+        });
+    });
+});

--- a/test/copilotOnRails/quoteMermaidLabels.test.ts
+++ b/test/copilotOnRails/quoteMermaidLabels.test.ts
@@ -39,6 +39,22 @@ suite('quoteMermaidLabels', () => {
             );
         });
 
+        test('quotes a round label that starts with @', () => {
+            // `(text)` is one of the most common flowchart shapes, and a leading `@` breaks
+            // it for the same reason it breaks an edge label.
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n  A(@azure/identity) --> B\n'),
+                'graph LR\n  A("@azure/identity") --> B\n',
+            );
+        });
+
+        test('quotes a benign round label without corrupting it', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n  A(Storefront Web) --> B(Commerce API)\n'),
+                'graph LR\n  A("Storefront Web") --> B("Commerce API")\n',
+            );
+        });
+
         test('quotes a subgraph title', () => {
             assert.strictEqual(
                 quoteMermaidLabels('graph TB\n    subgraph core [Core Services]\n        A[API] --> B[DB]\n    end'),
@@ -74,6 +90,21 @@ suite('quoteMermaidLabels', () => {
         test('is idempotent', () => {
             const once = quoteMermaidLabels('graph LR\n    A[API] -->|calls| B[(DB)]');
             assert.strictEqual(quoteMermaidLabels(once), once);
+        });
+
+        test('is idempotent on a round-shape diagram', () => {
+            const once = quoteMermaidLabels('graph LR\n  A(@azure/identity) --> B(Commerce API)\n');
+            assert.strictEqual(quoteMermaidLabels(once), once);
+        });
+
+        test('does not re-quote a stadium label as a round one', () => {
+            // The `[text]` rule turns `A([Start])` into `A(["Start"])` before the round
+            // rule runs, so the round rule has to leave a paren body that starts with `[`
+            // alone — otherwise the stadium collapses into `A("[\"Start\"]")`.
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n  A([Start]) --> B\n'),
+                'graph LR\n  A(["Start"]) --> B\n',
+            );
         });
 
         test('does not touch brackets, braces or pipes inside an already-quoted label', () => {

--- a/test/copilotOnRails/quoteMermaidLabels.test.ts
+++ b/test/copilotOnRails/quoteMermaidLabels.test.ts
@@ -39,22 +39,6 @@ suite('quoteMermaidLabels', () => {
             );
         });
 
-        test('quotes a round label that starts with @', () => {
-            // `(text)` is one of the most common flowchart shapes, and a leading `@` breaks
-            // it for the same reason it breaks an edge label.
-            assert.strictEqual(
-                quoteMermaidLabels('graph LR\n  A(@azure/identity) --> B\n'),
-                'graph LR\n  A("@azure/identity") --> B\n',
-            );
-        });
-
-        test('quotes a benign round label without corrupting it', () => {
-            assert.strictEqual(
-                quoteMermaidLabels('graph LR\n  A(Storefront Web) --> B(Commerce API)\n'),
-                'graph LR\n  A("Storefront Web") --> B("Commerce API")\n',
-            );
-        });
-
         test('quotes a subgraph title', () => {
             assert.strictEqual(
                 quoteMermaidLabels('graph TB\n    subgraph core [Core Services]\n        A[API] --> B[DB]\n    end'),
@@ -90,21 +74,6 @@ suite('quoteMermaidLabels', () => {
         test('is idempotent', () => {
             const once = quoteMermaidLabels('graph LR\n    A[API] -->|calls| B[(DB)]');
             assert.strictEqual(quoteMermaidLabels(once), once);
-        });
-
-        test('is idempotent on a round-shape diagram', () => {
-            const once = quoteMermaidLabels('graph LR\n  A(@azure/identity) --> B(Commerce API)\n');
-            assert.strictEqual(quoteMermaidLabels(once), once);
-        });
-
-        test('does not re-quote a stadium label as a round one', () => {
-            // The `[text]` rule turns `A([Start])` into `A(["Start"])` before the round
-            // rule runs, so the round rule has to leave a paren body that starts with `[`
-            // alone — otherwise the stadium collapses into `A("[\"Start\"]")`.
-            assert.strictEqual(
-                quoteMermaidLabels('graph LR\n  A([Start]) --> B\n'),
-                'graph LR\n  A(["Start"]) --> B\n',
-            );
         });
 
         test('does not touch brackets, braces or pipes inside an already-quoted label', () => {


### PR DESCRIPTION
> **Base branch:** `feat/CoR` — **not** `main`. The Copilot on Rails code does not exist on `main`.

## Problem

The `azure-debug-plan` agent generated an `## Architecture Diagram` in `.azure/vscode-debug-plan.md` containing this edge:

```
API -->|@azure/storage-blob| AZ
```

Mermaid v11 reserves `@` for edge-ID syntax (`e1@-->`) and node-metadata syntax (`id@{ shape: ... }`), so a `@` at the **start** of an unquoted label token is lexed as `LINK_ID` and the whole diagram fails to parse:

```
Parse error on line 15:
...|pg| PG    API -->|@azure/storage-blob
---------------------^
Expecting 'AMP', 'COLON', 'PIPE', 'TESTSTR', 'DOWN', 'DEFAULT', 'NUM', 'COMMA',
'NODE_STRING', 'BRKT', 'MINUS', 'MULT', 'UNICODE_TEXT', got 'LINK_ID'
```

`LocalPlanView`'s `MermaidBlock` catches the throw from `mermaid.render()` and falls back to a raw code block labeled `mermaid (error)` — so the user sees diagram source instead of the diagram.

Verified behavior (headless, jsdom, real mermaid builds):

| Diagram | Result |
| --- | --- |
| `A-->\|@azure/storage-blob\| B` | ❌ fails |
| `A[@azure/storage-blob]-->B` | ❌ fails — node labels affected too |
| `A-->\|uses @azure/storage-blob\| B` | ✅ passes — `@` mid-label is fine |
| `A-->\|"@azure/storage-blob"\| B` | ✅ passes — quoting fixes it |

Only a **leading** `@` breaks. Scoped npm package names (`@azure/storage-blob`, `@azure/identity`, `@prisma/client`) are exactly what the agent puts in Azure-dependency edge labels, so this is very reachable in practice.

## Not a regression

Reproduced identically on **11.14.0** (the version originally added in #1436), **11.15.0** (the dependabot bump in #1439), and **11.17.0** (what resolves today for `"mermaid": "^11.15.0"`). The `LINK_ID` grammar predates the CoR mermaid dependency entirely.

`package.json` and `package-lock.json` are **deliberately untouched** — bumping or pinning mermaid would not fix this.

Other characters in the failing diagram (`<br/>`, the `·` middle dot, the `[( )]` cylinder shape, `:5173` port suffixes, blank lines between statements) all parse fine and were ruled out.

## Fix

Harden the agent-facing authoring guidance so generated diagrams always quote labels.

- **`resources/agents/azure-debug-plan/references/plan-template.md`** — new `## ⚠️ Mermaid Label Quoting — ALWAYS Quote Every Label` section alongside the existing `## Markdown Table Integrity` rule (outside the ` ```markdown ` template fence, so it reads as an agent rule rather than template body). It carries a ✅/❌ example pair and a concise explanation of the `LINK_ID` cause. Inline `%%` hints were also added inside the template's Architecture Diagram block so the rule is visible at the exact point of authoring, not just in a section the model might skim past.
- **`.github/instructions/copilot-on-rails-docs.instructions.md`** — the same rule attached to the existing "keep the Mermaid pipeline diagram accurate" bullet, since that file also instructs an agent to maintain a mermaid diagram (the `docs/copilot-create-project.md` pipeline flowchart).

The rule is **unconditional** — quote every node label and every edge label, always — rather than an `@`-specific special case. Quoting is always valid in mermaid and additionally protects `(`, `)`, `:`, `/`, `#`, and `·`. Asking the model to detect which labels are "risky" is far less robust than a rule it applies every time.

Intentionally not changed: `resources/agents/azure-project-plan.agent.md` and `resources/agents/azure-project-plan/plan.md` mention mermaid only to **prohibit** it in the parsed project plan, so a quoting rule there would be wrong.

## Lockfile note

`evals/agent-assets.lock.json` is refreshed via `node evals/check-agent-drift.ts --update`, because `plan-template.md` is a hash-tracked agent asset and editing it fails the drift gate. Only that file's hash, the rollup `agentAssetsHash`, and `updatedAt` changed — no scope or tracked-file-set change.

## Validation

The full credential-free `contracts` CI job was run locally against `fc079fd`; **all 12 gates pass**:

`drift` · `typecheck` · `imports:self-test` · `certify` (152/152 grader certification cases) · `stacks:check` · `gates` · `phases:check` · `seed:contract` · `lint` · `clean-machine:check`

`lint` reports 3 pre-existing `scoring-defaults-applied` warnings that are unrelated to this change.

Parse behavior was confirmed directly against real mermaid builds in a throwaway sandbox outside the repo: the unquoted form fails, the quoted replacements parse. The four existing fixture plans under `evals/grader-certification/**` and `test/testProjects/copilotOnRails/**` were each checked and **already parse cleanly today** (none has a leading `@`), so they were left alone rather than churned.

The behavioral MSBench evals are `workflow_dispatch`-only (they need Entra auth, not `GITHUB_TOKEN`) and are being dispatched separately against this PR.