### PR TITLE
Fix mermaid rendering for debug plans already on disk

### DIFF
--- a/src/webviews/copilotOnRails/views/LocalPlanView.tsx
+++ b/src/webviews/copilotOnRails/views/LocalPlanView.tsx
@@ -53,6 +53,7 @@ import {
     type LocalPlanSection,
 } from "./utils/parseLocalDebugPlanMarkdown";
 import { getPrerequisiteInstallLink } from "./utils/prerequisiteInstallLinks";
+import { quoteMermaidLabels } from "./utils/quoteMermaidLabels";
 
 mermaid.initialize({
     startOnLoad: false,
@@ -1041,7 +1042,7 @@ const MermaidBlock = ({ code }: { code: string }): JSX.Element => {
         let cancelled = false;
         const id = `mermaid-diagram-${++mermaidIdCounter}`;
         mermaid
-            .render(id, code)
+            .render(id, quoteMermaidLabels(code))
             .then(({ svg }) => {
                 if (!cancelled && ref.current) {
                     ref.current.innerHTML = svg;

--- a/src/webviews/copilotOnRails/views/utils/quoteMermaidLabels.ts
+++ b/src/webviews/copilotOnRails/views/utils/quoteMermaidLabels.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Render-time normalization for the mermaid diagram in a debug plan.
+ *
+ * The `azure-debug-plan` agent's template asks for every flowchart label to be
+ * quoted, because mermaid v11 reserves characters that routinely show up in the
+ * package and service names these diagrams describe. The clearest example is
+ * `@`, which mermaid v11 lexes as the start of an edge id (`e1@-->`) or a node
+ * metadata block (`id@{ shape: rect }`) when it opens an *unquoted* label — so
+ * `API -->|@azure/storage-blob| AZ` fails to parse and the whole diagram is
+ * replaced by mermaid's syntax-error graphic.
+ *
+ * The template rule only helps plans generated from now on, and only when the
+ * model complies. Plans already written to a workspace still fail to render, so
+ * the webview quotes labels itself before handing the diagram to mermaid.
+ *
+ * The transform is deliberately conservative: it only quotes a label that is not
+ * quoted already, so it is a no-op on diagrams that already render.
+ */
+
+/** Diagram kinds this transform understands. Anything else is passed through untouched. */
+const flowchartHeader = /^(?:graph|flowchart)\b/;
+
+/**
+ * Quotes unquoted flowchart node and edge labels so reserved characters inside
+ * them are treated as text.
+ *
+ * Returns `code` unchanged when it isn't a flowchart — a sequence, class or ER
+ * diagram gives `[]`, `{}` and `|` completely different meanings, and rewriting
+ * one would turn a working diagram into a broken one.
+ */
+export function quoteMermaidLabels(code: string): string {
+    const lines = code.split('\n');
+    const bodyStart = endOfFrontmatter(lines);
+    if (!isFlowchart(lines, bodyStart)) {
+        return code;
+    }
+
+    return lines.map((line, i) => (i < bodyStart ? line : quoteLabelsInLine(line))).join('\n');
+}
+
+/**
+ * Index of the first line after a leading `---` YAML frontmatter block, or 0
+ * when there isn't one. Frontmatter is diagram config rather than diagram body,
+ * so it is copied through verbatim.
+ */
+function endOfFrontmatter(lines: string[]): number {
+    if (lines[0]?.trim() !== '---') {
+        return 0;
+    }
+    const close = lines.findIndex((line, i) => i > 0 && line.trim() === '---');
+    return close === -1 ? 0 : close + 1;
+}
+
+function isFlowchart(lines: string[], bodyStart: number): boolean {
+    for (let i = bodyStart; i < lines.length; i++) {
+        const line = lines[i].trim();
+        // `%%` covers both comments and `%%{init: ...}%%` directives.
+        if (line === '' || line.startsWith('%%')) {
+            continue;
+        }
+        return flowchartHeader.test(line);
+    }
+    return false;
+}
+
+function quoteLabelsInLine(line: string): string {
+    if (line.trim().startsWith('%%')) {
+        return line;
+    }
+
+    // Mermaid v11 node/edge metadata — `id@{ shape: rect }`, `e1@{ animate: true }` —
+    // is brace-delimited but is configuration, not a label. Quoting its body
+    // (`e1@{"animate: true"}`) would change what it means, so the rhombus rule is
+    // skipped entirely on any line that carries a metadata block.
+    const hasMetadata = line.includes('@{');
+
+    return mapUnquotedSegments(line, (segment) => {
+        let result = segment
+            // Cylinder `[(text)]` and circle `((text))` are matched before the plain
+            // `[text]` rule so their delimiters survive.
+            .replace(/\[\(([^)\]\n]+)\)\]/g, (_match, label: string) => `[(${quote(label)})]`)
+            .replace(/\(\(([^)\n]+)\)\)/g, (_match, label: string) => `((${quote(label)}))`)
+            .replace(/\[([^[\]\n]+)\]/g, (match, label: string) =>
+                // A label already rewritten by the cylinder rule starts with `(` or `"`, and
+                // `/` and `\` are the parallelogram/trapezoid shape delimiters rather than
+                // label text. Leave all of those to the rules that own them.
+                /^[("/\\]/.test(label) ? match : `[${quote(label)}]`,
+            );
+
+        if (!hasMetadata) {
+            result = result.replace(/\{([^{}\n]+)\}/g, (_match, label: string) => `{${quote(label)}}`);
+        }
+
+        // Edge labels: `-->|text|`.
+        return result.replace(/\|([^|\n]+)\|/g, (_match, label: string) => `|${quote(label)}|`);
+    });
+}
+
+const quote = (label: string): string => (label.includes('"') ? label : `"${label}"`);
+
+/**
+ * Applies `transform` to the parts of `line` that sit outside mermaid's `"…"`
+ * strings. Mermaid has no escape sequence inside a quoted label, so the double
+ * quotes alternate: even-indexed pieces are outside a string, odd-indexed ones
+ * are the label text itself. Rewriting only the outside pieces keeps an
+ * already-quoted label — including one that contains brackets, braces or pipes,
+ * such as `A["Blob (hot tier) [preview]"]` — exactly as the author wrote it.
+ */
+function mapUnquotedSegments(line: string, transform: (segment: string) => string): string {
+    return line
+        .split('"')
+        .map((segment, i) => (i % 2 === 0 ? transform(segment) : segment))
+        .join('"');
+}

--- a/test/copilotOnRails/quoteMermaidLabels.test.ts
+++ b/test/copilotOnRails/quoteMermaidLabels.test.ts
@@ -1,0 +1,146 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { quoteMermaidLabels } from '../../src/webviews/copilotOnRails/views/utils/quoteMermaidLabels';
+
+suite('quoteMermaidLabels', () => {
+    suite('quotes unquoted labels', () => {
+        test('quotes an edge label that starts with @', () => {
+            // The real failure: mermaid v11 lexes a leading `@` as the start of an edge id
+            // (`e1@-->`), so the unquoted form fails to parse and the diagram is replaced
+            // by mermaid's syntax-error graphic.
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n    API -->|@azure/storage-blob| AZ[(Azurite)]'),
+                'graph LR\n    API -->|"@azure/storage-blob"| AZ[("Azurite")]',
+            );
+        });
+
+        test('quotes rectangle labels', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n    Web[Web UI<br/>Vite :5173] --> API[API<br/>:3000]'),
+                'graph LR\n    Web["Web UI<br/>Vite :5173"] --> API["API<br/>:3000"]',
+            );
+        });
+
+        test('quotes cylinder, circle and rhombus labels without losing the shape', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('graph TD\n    S((Start)) --> Q{Ready?}\n    Q --> DB[(Postgres :5432)]'),
+                'graph TD\n    S(("Start")) --> Q{"Ready?"}\n    Q --> DB[("Postgres :5432")]',
+            );
+        });
+
+        test('quotes stadium, subroutine and hexagon labels without losing the shape', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n    A([Stadium]) --> B[[Subroutine]] --> C{{Hexagon}}'),
+                'graph LR\n    A(["Stadium"]) --> B[["Subroutine"]] --> C{{"Hexagon"}}',
+            );
+        });
+
+        test('quotes a subgraph title', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('graph TB\n    subgraph core [Core Services]\n        A[API] --> B[DB]\n    end'),
+                'graph TB\n    subgraph core ["Core Services"]\n        A["API"] --> B["DB"]\n    end',
+            );
+        });
+
+        test('accepts flowchart as well as graph', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('flowchart LR\n    A[API] --> B[DB]'),
+                'flowchart LR\n    A["API"] --> B["DB"]',
+            );
+        });
+
+        test('normalizes a diagram behind a directive or frontmatter, leaving the preamble alone', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('%%{init: {"theme":"dark"}}%%\ngraph LR\n    A[API] --> B[DB]'),
+                '%%{init: {"theme":"dark"}}%%\ngraph LR\n    A["API"] --> B["DB"]',
+            );
+            assert.strictEqual(
+                quoteMermaidLabels('---\nconfig:\n  theme: dark\n---\ngraph LR\n    A[API] --> B[DB]'),
+                '---\nconfig:\n  theme: dark\n---\ngraph LR\n    A["API"] --> B["DB"]',
+            );
+        });
+    });
+
+    suite('leaves valid syntax alone', () => {
+        test('is a no-op on an already-quoted diagram', () => {
+            const code = 'graph LR\n    A["Web App"] -->|"HTTP"| B["API"]';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+
+        test('is idempotent', () => {
+            const once = quoteMermaidLabels('graph LR\n    A[API] -->|calls| B[(DB)]');
+            assert.strictEqual(quoteMermaidLabels(once), once);
+        });
+
+        test('does not touch brackets, braces or pipes inside an already-quoted label', () => {
+            const code = 'graph LR\n    A["Blob (hot tier) [preview]"] --> B["Queue {std}"]';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+
+        test('does not touch markdown string labels', () => {
+            const code = 'graph LR\n    A["`**bold** label`"] --> B["`_italic_`"]';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+
+        test('does not rewrite v11 node or edge metadata blocks', () => {
+            // `id@{ shape: rect }` and `e1@{ animate: true }` are brace-delimited
+            // configuration, not labels — quoting their bodies would change what they mean.
+            const code = 'flowchart LR\n    A@{ shape: rect, label: "Hi" }\n    A e1@--> B\n    e1@{ animate: true }';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+
+        test('does not touch comment lines', () => {
+            const code = 'graph LR\n    %% A[Not a node] and |not an edge|\n    A[API] --> B[DB]';
+            assert.strictEqual(
+                quoteMermaidLabels(code),
+                'graph LR\n    %% A[Not a node] and |not an edge|\n    A["API"] --> B["DB"]',
+            );
+        });
+
+        test('does not touch styling or interaction directives', () => {
+            const code =
+                'graph LR\n' +
+                '    classDef svc fill:#f9f,stroke:#333\n' +
+                '    style A fill:#bbf\n' +
+                '    linkStyle 0 stroke:#f00\n' +
+                '    click A "https://example.com" "Open docs"';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+
+        test('does not flatten parallelogram or trapezoid shapes into rectangles', () => {
+            const code = 'graph LR\n    A[/Input/] --> B[\\Output\\] --> C[/Trapezoid\\]';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+
+        test('leaves a diagram with no labels untouched', () => {
+            const code = 'graph LR\n    A --> B --> C';
+            assert.strictEqual(quoteMermaidLabels(code), code);
+        });
+    });
+
+    suite('non-flowchart diagrams', () => {
+        // `[]`, `{}` and `|` mean something else entirely outside a flowchart, so these
+        // must come back byte-for-byte identical.
+        const diagrams: Record<string, string> = {
+            sequence: 'sequenceDiagram\n    Alice->>John: Hello John\n    John-->>Alice: Great!',
+            class: 'classDiagram\n    class Animal { +int age }\n    Animal <|-- Dog',
+            er: 'erDiagram\n    CUSTOMER ||--o{ ORDER : places',
+            state: 'stateDiagram-v2\n    [*] --> Still\n    Still --> [*]',
+            pie: 'pie title Pets\n    "Dogs" : 386\n    "Cats" : 85',
+        };
+
+        for (const [name, code] of Object.entries(diagrams)) {
+            test(`leaves the ${name} diagram untouched`, () => {
+                assert.strictEqual(quoteMermaidLabels(code), code);
+            });
+        }
+
+        test('leaves an empty diagram untouched', () => {
+            assert.strictEqual(quoteMermaidLabels(''), '');
+        });
+    });
+});


### PR DESCRIPTION
Stacked on #1813 — please review/merge that one first. Base branch is `nturinski-mermaid-label-quoting-490`.

## Why a second PR

#1813 fixes the **generation** side: it adds an unconditional "quote every node and edge label" rule to `resources/agents/azure-debug-plan/references/plan-template.md` and to the CoR docs instructions. That is prevention at the source, and it has two gaps:

1. It does nothing for a `.azure/vscode-debug-plan.md` that is **already on disk** in a user's workspace. Those diagrams still fail to render today.
2. A template rule is a *request* the model can decline. Normalization is *enforced*.

This PR closes both gaps by normalizing at **render** time.

## The failure

The generated diagram contains:

```
API -->|@azure/storage-blob| AZ
```

Mermaid v11 reserves `@` for edge-ID (`e1@-->`) and node-metadata (`id@{ shape: ... }`) syntax, so an `@` at the *start* of an unquoted label lexes as `LINK_ID` and the whole diagram fails to parse — the webview shows mermaid's "Syntax error in text" bomb graphic instead of the architecture diagram. An `@` mid-label is fine; quoting the label fixes it.

This is **not** a mermaid version regression — it reproduces identically on 11.14.0, 11.15.0 and 11.17.0, so the `mermaid` dependency is untouched.

`parseLocalDebugPlanMarkdown` is innocent: it extracts the fenced block faithfully. The gap was that `MermaidBlock` handed that string straight to `mermaid.render()` with no normalization.

## What changed

- **New** `src/webviews/copilotOnRails/views/utils/quoteMermaidLabels.ts` — quotes any flowchart node or edge label that is not quoted already.
- `LocalPlanView.tsx`'s `MermaidBlock` now calls `mermaid.render(id, quoteMermaidLabels(code))`. The error fallback still shows the code the author actually wrote.
- **New** `test/copilotOnRails/quoteMermaidLabels.test.ts` — 22 unit tests in the existing suite's style, no new test framework.

The transform is deliberately narrow, because the failure mode of a bad rewrite is a diagram that *used* to work and no longer does:

| Guard | Why |
| --- | --- |
| Only `graph` / `flowchart` diagrams are rewritten | `[]`, `{}` and `\|` mean something else entirely in sequence, class, ER, state and pie diagrams — those come back byte-identical |
| Lines containing `@{` are exempt from the rhombus rule | v11 node/edge metadata (`A@{ shape: rect }`, `e1@{ animate: true }`) is brace-delimited *configuration*, not a label. Rewriting `e1@{ animate: true }` to `e1@{"animate: true"}` would change what it means. This is explicit rather than accidental |
| Rewrites skip the inside of existing `"…"` strings | Keeps an already-quoted label intact even when it contains brackets or braces (`A["Blob (hot tier) [preview]"]`), and makes the transform idempotent |
| Cylinder/circle/stadium/subroutine/hexagon delimiters matched before the plain `[…]` rule; `/` and `\` (parallelogram/trapezoid) left alone | Shapes are preserved rather than flattened to a rectangle |
| Comment lines and leading YAML frontmatter pass through | They are not diagram body |

Net effect: it is a no-op on any diagram that already renders.

## Validation

**Real mermaid 11.17.0 under jsdom, driving the actual `parseLocalDebugPlanMarkdown` over plan markdown — 107/107 checks pass:**

- The reported failing diagram: **fails as-authored, parses after normalization.**
- All four checked-in plan fixtures parse **before and after**, and normalization is idempotent on each:
  - `test/testProjects/copilotOnRails/attendance/vscode-debug-plan.md`
  - `test/testProjects/copilotOnRails/scrapbook/vscode-debug-plan.md`
  - `evals/grader-certification/reference-node-fullstack/.azure/vscode-debug-plan.md`
  - `evals/grader-certification/stage-local-dev/.azure/vscode-debug-plan.md`
- Valid before **and** after, uncorrupted: already-quoted labels, `subgraph`, `classDef` + `class`, bare `A --> B --> C`, rhombus, circle, cylinder, hexagon, stadium, subroutine, parallelogram, trapezoid, `style`, `linkStyle`, `click` callbacks, markdown-string labels (``["`**bold**`"]``), `%%` comments, `%%{init: …}%%` directives, YAML frontmatter, and v11 `id@{ shape }` / `e1@-->` metadata.
- Non-flowchart diagrams and v11 metadata lines verified **byte-identical**.
- `@`-leading labels broken before / fixed after in every shape: edge label, rect, cylinder, circle, rhombus.

**Repo gates — all green:**

| Gate | Result |
| --- | --- |
| `npm run build:check` (tsc --noEmit) | ✅ |
| `npm run lint` | ✅ |
| `evals`: `drift` | ✅ 17 agent contracts intact — no agent asset changed, so `agent-assets.lock.json` is untouched |
| `evals`: `typecheck`, `lint`, `certify` (152/152), `imports:self-test`, `stacks:check`, `gates`, `phases:check`, `seed:contract`, `clean-machine:check` | ✅ |

`evals/results/grader-certification/offline/report.json` was restored after `certify` so its `generatedAt` churn does not leak into this PR, and `package-lock.json` was restored after the local `npm i`. The diff is three files.

## Docs

No update needed in `docs/copilot-create-project.md`: no command, MCP tool, agent, `.azure/*` artifact or `workspaceState` key changed, and no UI surface was added, removed or restyled. The debug plan view's *intended* appearance is unchanged — this only makes diagrams that were showing the error graphic render as designed. `08-debug-plan-view.png` is therefore only stale if it happens to have been captured while a diagram was failing to parse; worth a glance, but no placeholder was added or removed.