### PR TITLE
Cover the round mermaid shape and fix double-circle corruption

### DIFF
--- a/src/webviews/copilotOnRails/views/utils/quoteMermaidLabels.ts
+++ b/src/webviews/copilotOnRails/views/utils/quoteMermaidLabels.ts
@@ -20,6 +20,11 @@
  *
  * The transform is deliberately conservative: it only quotes a label that is not
  * quoted already, so it is a no-op on diagrams that already render.
+ *
+ * Covered shapes: rectangle, round, stadium, subroutine, cylinder, circle,
+ * double circle, rhombus and hexagon nodes, plus subgraph titles and edge
+ * labels. The asymmetric shape (`A>text]`) and the parallelogram/trapezoid
+ * family (`A[/text/]`) are knowingly left alone — see `quoteLabelsInLine`.
  */
 
 /** Diagram kinds this transform understands. Anything else is passed through untouched. */
@@ -79,16 +84,27 @@ function quoteLabelsInLine(line: string): string {
     // skipped entirely on any line that carries a metadata block.
     const hasMetadata = line.includes('@{');
 
-    return mapUnquotedSegments(line, (segment) => {
+    // Pass 1 — every shape whose label is delimited by brackets or braces, plus edge
+    // labels. Nested delimiters are matched longest-first, so an outer delimiter is
+    // consumed before an inner rule can claim its body. The asymmetric shape (`A>text]`)
+    // has no rule: its opening delimiter is a bare `>`, which is indistinguishable from
+    // an arrowhead, so a rule for it could not be made safe.
+    const afterBrackets = mapUnquotedSegments(line, (segment) => {
         let result = segment
-            // Cylinder `[(text)]` and circle `((text))` are matched before the plain
-            // `[text]` rule so their delimiters survive.
-            .replace(/\[\(([^)\]\n]+)\)\]/g, (_match, label: string) => `[(${quote(label)})]`)
-            .replace(/\(\(([^)\n]+)\)\)/g, (_match, label: string) => `((${quote(label)}))`)
+            .replace(/\(\(\(([^()\n]+)\)\)\)/g, (_match, label: string) => `(((${quote(label)})))`)
+            // The cylinder body is lazy up to the first `)]` so a label that itself
+            // contains parentheses — `[(Postgres (primary))]` — is quoted whole.
+            .replace(/\[\(([^[\]\n]+?)\)\]/g, (_match, label: string) => `[(${quote(label)})]`)
+            .replace(/\(\(([^)\n]+)\)\)/g, (match, label: string) =>
+                // A double circle already rewritten above leaves a body starting with `(`.
+                label.startsWith('(') ? match : `((${quote(label)}))`,
+            )
             .replace(/\[([^[\]\n]+)\]/g, (match, label: string) =>
                 // A label already rewritten by the cylinder rule starts with `(` or `"`, and
                 // `/` and `\` are the parallelogram/trapezoid shape delimiters rather than
-                // label text. Leave all of those to the rules that own them.
+                // label text. Leave all of those to the rules that own them. A parallelogram
+                // or trapezoid label therefore stays unquoted — a deliberate trade, since
+                // flattening the shape into a rectangle would be the worse outcome.
                 /^[("/\\]/.test(label) ? match : `[${quote(label)}]`,
             );
 
@@ -99,6 +115,23 @@ function quoteLabelsInLine(line: string): string {
         // Edge labels: `-->|text|`.
         return result.replace(/\|([^|\n]+)\|/g, (_match, label: string) => `|${quote(label)}|`);
     });
+
+    // `click nodeId call handler(a, b)` is the one flowchart statement that puts an
+    // unquoted, comma-separated argument list in parentheses. Quoting it would collapse
+    // the arguments into a single string, so interaction statements skip the round rule.
+    if (/^\s*click\b/.test(line)) {
+        return afterBrackets;
+    }
+
+    // Pass 2 — the round shape `(text)`. It runs over a *freshly* re-split line rather
+    // than inside pass 1, because pass 1 introduces quotes of its own: the parentheses
+    // in `Web[Attendance Web (Vite)]` become part of a quoted label, and re-splitting is
+    // what stops them from being quoted a second time. Re-splitting also means the outer
+    // parentheses of a stadium, cylinder, circle or double circle are already separated
+    // from their now-quoted body, so this rule cannot touch them.
+    return mapUnquotedSegments(afterBrackets, (segment) =>
+        segment.replace(/\(([^()\n]+)\)/g, (_match, label: string) => `(${quote(label)})`),
+    );
 }
 
 const quote = (label: string): string => (label.includes('"') ? label : `"${label}"`);

--- a/test/copilotOnRails/quoteMermaidLabels.test.ts
+++ b/test/copilotOnRails/quoteMermaidLabels.test.ts
@@ -39,6 +39,38 @@ suite('quoteMermaidLabels', () => {
             );
         });
 
+        test('quotes round labels', () => {
+            // The round shape is one of the most common in a generated architecture
+            // diagram, and nothing else in the transform covers a single-paren body.
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n    A(@azure/identity) --> B(Storefront Web)'),
+                'graph LR\n    A("@azure/identity") --> B("Storefront Web")',
+            );
+        });
+
+        test('quotes a double circle without collapsing it to a circle', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n    A(((Core))) --> B(Next)'),
+                'graph LR\n    A((("Core"))) --> B("Next")',
+            );
+        });
+
+        test('quotes a label that itself contains parentheses exactly once', () => {
+            // The round rule runs as a second pass over a re-split line, so parentheses
+            // that the first pass has just enclosed in a quoted label are not quoted again.
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n    Web[Attendance Web<br/>(Vite dev server)] -->|calls (async)| DB[(Postgres (primary))]'),
+                'graph LR\n    Web["Attendance Web<br/>(Vite dev server)"] -->|"calls (async)"| DB[("Postgres (primary)")]',
+            );
+        });
+
+        test('does not re-quote the outer parentheses of a stadium, cylinder or circle', () => {
+            assert.strictEqual(
+                quoteMermaidLabels('graph LR\n    A([Stadium]) --> B[(Cylinder)] --> C((Circle))'),
+                'graph LR\n    A(["Stadium"]) --> B[("Cylinder")] --> C(("Circle"))',
+            );
+        });
+
         test('quotes a subgraph title', () => {
             assert.strictEqual(
                 quoteMermaidLabels('graph TB\n    subgraph core [Core Services]\n        A[API] --> B[DB]\n    end'),
@@ -67,13 +99,24 @@ suite('quoteMermaidLabels', () => {
 
     suite('leaves valid syntax alone', () => {
         test('is a no-op on an already-quoted diagram', () => {
-            const code = 'graph LR\n    A["Web App"] -->|"HTTP"| B["API"]';
+            const code = 'graph LR\n    A["Web App"] -->|"HTTP"| B["API"]\n    B --> C("Round")';
             assert.strictEqual(quoteMermaidLabels(code), code);
         });
 
         test('is idempotent', () => {
-            const once = quoteMermaidLabels('graph LR\n    A[API] -->|calls| B[(DB)]');
+            const once = quoteMermaidLabels('graph LR\n    A[API] -->|calls| B[(DB)] --> C(Cache)');
             assert.strictEqual(quoteMermaidLabels(once), once);
+        });
+
+        test('does not quote the arguments of a click call handler', () => {
+            // `click nodeId call handler(a, b)` is the one flowchart statement with an
+            // unquoted, comma-separated argument list in parens. Quoting it would collapse
+            // the two arguments into a single string.
+            const code = 'graph LR\n    A(Node) --> B[Done]\n    click A call handleClick(alpha, beta)';
+            assert.strictEqual(
+                quoteMermaidLabels(code),
+                'graph LR\n    A("Node") --> B["Done"]\n    click A call handleClick(alpha, beta)',
+            );
         });
 
         test('does not touch brackets, braces or pipes inside an already-quoted label', () => {
@@ -94,10 +137,10 @@ suite('quoteMermaidLabels', () => {
         });
 
         test('does not touch comment lines', () => {
-            const code = 'graph LR\n    %% A[Not a node] and |not an edge|\n    A[API] --> B[DB]';
+            const code = 'graph LR\n    %% A[Not a node] and |not an edge| and (not round)\n    A[API] --> B[DB]';
             assert.strictEqual(
                 quoteMermaidLabels(code),
-                'graph LR\n    %% A[Not a node] and |not an edge|\n    A["API"] --> B["DB"]',
+                'graph LR\n    %% A[Not a node] and |not an edge| and (not round)\n    A["API"] --> B["DB"]',
             );
         });
 
@@ -112,6 +155,9 @@ suite('quoteMermaidLabels', () => {
         });
 
         test('does not flatten parallelogram or trapezoid shapes into rectangles', () => {
+            // Deliberate trade: their labels stay unquoted, because rewriting `[/x/]` to
+            // `["/x/"]` would silently turn a parallelogram into a rectangle with literal
+            // slashes in it. Leaving one rare label unquoted is the lesser harm.
             const code = 'graph LR\n    A[/Input/] --> B[\\Output\\] --> C[/Trapezoid\\]';
             assert.strictEqual(quoteMermaidLabels(code), code);
         });


### PR DESCRIPTION
Follow-up to #1817, which is already merged into `nturinski-mermaid-label-quoting-490` — so this is a second stacked PR on the same base rather than a push to that PR. Stacks under #1813.

## Two holes in #1817

**1. The round shape `A(text)` was not covered at all.** Nothing in the transform matched a single-paren body, so `A(@azure/identity)` showed the syntax-error graphic *both before and after* normalization. Round is one of the most common node shapes in a generated architecture diagram, not an exotic case.

**2. The double circle `A(((text)))` was corrupted.** The circle rule matched the inner two parens, so a diagram that rendered fine *before* #1817 came out as `A(("(Core")))` and stopped rendering. That is a regression #1817 shipped, and it is fixed here.

Verified against real mermaid 11.17.0, all 12 documented flowchart shapes with an `@`-leading label:

| shape | before | after #1817 | after this PR |
| --- | --- | --- | --- |
| rect `A[x]` | fail | pass | pass |
| **round `A(x)`** | fail | **fail** | **pass** |
| stadium `A([x])` | fail | pass | pass |
| subroutine `A[[x]]` | fail | pass | pass |
| cylinder `A[(x)]` | fail | pass | pass |
| circle `A((x))` | fail | pass | pass |
| **double circle `A(((x)))`** | fail | **fail** | **pass** |
| rhombus `A{x}` | fail | pass | pass |
| hexagon `A{{x}}` | fail | pass | pass |
| edge label `-->\|x\|` | fail | pass | pass |
| asymmetric `A>x]` | fail | fail | fail — deliberate |
| parallelogram `A[/x/]` | fail | fail | fail — deliberate |

## Why the round rule is a second pass, not another `.replace()`

The obvious patch is to chain a round rule onto the existing pass, guarded against bodies a previous rule already rewrote. That does fix round, but it **regresses three cases #1817 currently fixes**, because pass 1 inserts quotes of its own and the chained rule then re-quotes parentheses it has just enclosed:

| input | after #1817 | naive chained rule |
| --- | --- | --- |
| `Web[Attendance Web<br/>(Vite dev server)]` | ✅ `Web["Attendance Web<br/>(Vite dev server)"]` | ❌ `Web["Attendance Web<br/>("Vite dev server")"]` |
| `Web[Vite(5173)]` | ✅ `Web["Vite(5173)"]` | ❌ `Web["Vite("5173")"]` |
| `A -->\|calls (async)\| B` | ✅ `\|"calls (async)"\|` | ❌ `\|calls ("async")\|` |

All three are invalid mermaid as-authored and are *fixed* by #1817 — a chained rule would turn them back into parse errors. The first one is the attendance fixture's own label, unquoted, which is exactly what a pre-#1813 plan on disk looks like.

Running the round rule as a **second pass over a freshly re-split line** avoids this: by then those parentheses live inside a quoted label, so the quote-aware segmentation already introduced in #1817 makes them untouchable. It also removes the need for any guard on the round rule — the outer parens of a stadium, cylinder, circle or double circle are already separated from their now-quoted body by the time pass 2 runs.

## Also in this PR

- **Cylinder body is now lazy up to the first `)]`**, so `[(Postgres (primary))]` is quoted whole rather than having its inner parens rewritten.
- **`click nodeId call handler(a, b)` skips the round rule.** It is the one flowchart statement with an unquoted, comma-separated argument list in parentheses; quoting it parses fine but silently collapses two arguments into one string. Parse-level checks cannot catch that, so it is guarded explicitly.
- **The two remaining gaps are documented as deliberate.** Asymmetric `A>x]` opens with a bare `>` that is indistinguishable from an arrowhead, and quoting `A[/x/]` would flatten a parallelogram into a rectangle with literal slashes. Leaving one rare label unquoted beats silently changing a shape — noted in code so a later reader doesn't "fix" it.

## Validation

**Real mermaid 11.17.0 under jsdom, driving `parseLocalDebugPlanMarkdown` — 149/149:**

- All 9 quotable shapes fixed for an `@`-leading label (round and double circle newly among them).
- 31 valid diagrams still valid *and* idempotent after normalization, including benign round/double-circle/stadium/cylinder/circle, `subgraph`, `classDef`+`class`, `style`, `linkStyle`, both `click` forms, markdown-string labels, v11 node and edge metadata, `%%` comments, `%%{init}%%`, and YAML frontmatter.
- Non-flowchart diagrams (sequence, class, ER, state, pie), v11 metadata lines, and `click … call handler(a, b)` verified **byte-identical**.
- The four checked-in plan fixtures parse before *and* after and are idempotent.
- The reported failing diagram still fails as-authored and parses after.
- Documented gaps asserted as *unchanged* rather than silently broken.

**Unit tests:** `test/copilotOnRails/quoteMermaidLabels.test.ts` grows from 22 to 27, covering the round-shape fix, the benign `A(Storefront Web)` no-corruption case, the stadium/cylinder/circle-after-round interaction, double circle, parens-inside-a-bracketed-label, and the `click call` guard.

**Gates — all green:** root `build:check` (tsc --noEmit) and `lint`; evals `drift` (agent lock untouched), `typecheck`, `lint`, `certify`, `imports:self-test`, `stacks:check`, `gates`, `phases:check`, `seed:contract`, `clean-machine:check`. `evals/results/` restored after `certify`. Diff is two files.

> Note for anyone running `npm run lint` locally after the eval gates: `certify` / `clean-machine:check` generate `evals/msbench/assets/graders/**`, which is gitignored but **not** ignored by the flat ESLint config, so root lint then reports 49 parsing errors from files that aren't yours. Delete that directory and re-run. Unrelated to this change, but it cost me a cycle.

## Docs

No `docs/copilot-create-project.md` update needed, same reasoning as #1817: no command, MCP tool, agent, `.azure/*` artifact or `workspaceState` key changed, and no UI surface added, removed or restyled. No screenshots made stale.