### PR TITLE
CoR: Hide mermaid diagram if and error occurs rendering it 

### DIFF
--- a/src/webviews/copilotOnRails/views/LocalPlanView.tsx
+++ b/src/webviews/copilotOnRails/views/LocalPlanView.tsx
@@ -654,8 +654,51 @@ const SectionCard = ({
     defaultOpen: boolean;
     onRefreshPrerequisites?: () => void;
     isRefreshing?: boolean;
-}): JSX.Element => {
+}): JSX.Element | null => {
     const [open, setOpen] = useState(defaultOpen);
+    const [failedDiagrams, setFailedDiagrams] = useState<ReadonlySet<number>>(
+        () => new Set(),
+    );
+    const handleDiagramStatus = useCallback(
+        (index: number, failed: boolean) =>
+            setFailedDiagrams((previous) => {
+                if (previous.has(index) === failed) {
+                    return previous;
+                }
+                const next = new Set(previous);
+                if (failed) {
+                    next.add(index);
+                } else {
+                    next.delete(index);
+                }
+                return next;
+            }),
+        [],
+    );
+
+    const diagramCount = useMemo(
+        () => section.content.filter(isMermaidCodeBlock).length,
+        [section.content],
+    );
+
+    const isDiagramOnlySection = useMemo(
+        () =>
+            section.content.every(
+                (item) =>
+                    isMermaidCodeBlock(item) ||
+                    item.type === "paragraph" ||
+                    item.type === "blockquote",
+            ),
+        [section.content],
+    );
+
+    if (
+        diagramCount > 0 &&
+        failedDiagrams.size >= diagramCount &&
+        isDiagramOnlySection
+    ) {
+        return null;
+    }
 
     return (
         <div className="sectionCard">
@@ -690,6 +733,9 @@ const SectionCard = ({
                             key={i}
                             item={item}
                             sectionTitle={section.title}
+                            onDiagramStatus={(failed) =>
+                                handleDiagramStatus(i, failed)
+                            }
                         />
                     ))}
                 </div>
@@ -698,12 +744,20 @@ const SectionCard = ({
     );
 };
 
+function isMermaidCodeBlock(item: LocalPlanContent): boolean {
+    return (
+        item.type === "codeBlock" && item.language?.toLowerCase() === "mermaid"
+    );
+}
+
 const ContentBlock = ({
     item,
     sectionTitle,
+    onDiagramStatus,
 }: {
     item: LocalPlanContent;
     sectionTitle: string;
+    onDiagramStatus?: (failed: boolean) => void;
 }): JSX.Element | null => {
     switch (item.type) {
         case "table":
@@ -723,8 +777,13 @@ const ContentBlock = ({
                 />
             );
         case "codeBlock":
-            if (item.language?.toLowerCase() === "mermaid") {
-                return <MermaidBlock code={item.code} />;
+            if (isMermaidCodeBlock(item)) {
+                return (
+                    <MermaidBlock
+                        code={item.code}
+                        onRenderStatus={onDiagramStatus}
+                    />
+                );
             }
             return <CodeBlock language={item.language} code={item.code} />;
         case "bulletList":
@@ -1033,24 +1092,43 @@ const CodeBlock = ({
     </div>
 );
 
-const MermaidBlock = ({ code }: { code: string }): JSX.Element => {
+const MermaidBlock = ({
+    code,
+    onRenderStatus,
+}: {
+    code: string;
+    onRenderStatus?: (failed: boolean) => void;
+}): JSX.Element | null => {
     const ref = useRef<HTMLDivElement>(null);
-    const [error, setError] = useState<string | null>(null);
+    const [failedCode, setFailedCode] = useState<string | null>(null);
+    const onRenderStatusRef = useRef(onRenderStatus);
 
     useEffect(() => {
+        onRenderStatusRef.current = onRenderStatus;
+    });
+
+    useEffect(() => {
+        const container = ref.current;
+        if (!container) {
+            return;
+        }
         let cancelled = false;
         const id = `mermaid-diagram-${++mermaidIdCounter}`;
         mermaid
-            .render(id, code)
+            .render(id, code, container)
             .then(({ svg }) => {
                 if (!cancelled && ref.current) {
                     ref.current.innerHTML = svg;
-                    setError(null);
+                    setFailedCode(null);
+                    onRenderStatusRef.current?.(false);
                 }
             })
-            .catch((err: Error) => {
+            .catch(() => {
+                // A malformed diagram isn't actionable for the user, so drop the
+                // block entirely rather than surfacing a parse error.
                 if (!cancelled) {
-                    setError(err.message);
+                    setFailedCode(code);
+                    onRenderStatusRef.current?.(true);
                 }
             });
         return () => {
@@ -1058,15 +1136,8 @@ const MermaidBlock = ({ code }: { code: string }): JSX.Element => {
         };
     }, [code]);
 
-    if (error) {
-        return (
-            <div className="codeBlock">
-                <span className="codeBlockLang">mermaid (error)</span>
-                <pre>
-                    <code>{code}</code>
-                </pre>
-            </div>
-        );
+    if (failedCode === code) {
+        return null;
     }
 
     return <div className="mermaidDiagram" ref={ref} />;


### PR DESCRIPTION

This pull request improves the handling and display of Mermaid diagrams within the `LocalPlanView` by suppressing sections that contain only diagrams if all of them fail to render. It also refactors how diagram rendering errors are managed and reported between components.

### Improved error handling and user experience for Mermaid diagrams

* The `SectionCard` component now tracks the render status of Mermaid diagrams and omits the entire section from the UI if it contains only diagrams (plus paragraphs/quotes) and all diagrams fail to render.
* The `MermaidBlock` component no longer displays a parse error for malformed diagrams; instead, it simply omits the failed diagram from the UI and notifies the parent component of the failure.
* The `ContentBlock` and `MermaidBlock` components now communicate diagram render status via a callback, allowing the parent section to respond appropriately to diagram failures. [[1]](diffhunk://#diff-73bf65ca17bf2300c0fa647a242530d9288a9cac71510b64835a753a4c35b189L726-R786) [[2]](diffhunk://#diff-73bf65ca17bf2300c0fa647a242530d9288a9cac71510b64835a753a4c35b189R736-R738) [[3]](diffhunk://#diff-73bf65ca17bf2300c0fa647a242530d9288a9cac71510b64835a753a4c35b189R747-R760)

### Code organization and utility

* Added a utility function `isMermaidCodeBlock` to consistently identify Mermaid code blocks throughout the codebase.