### PR TITLE
CoR: Improve package metadata validation

### DIFF
--- a/src/webviews/copilotOnRails/extension/openFrontendPreviewView.ts
+++ b/src/webviews/copilotOnRails/extension/openFrontendPreviewView.ts
@@ -8,6 +8,7 @@ import * as vscode from "vscode";
 import { ext } from "../../../extensionVariables";
 import { INTEGRATION_PLAN_FILE_GLOB } from "../../../tree/project/projectPlanFiles";
 import { CopilotOnRailsContext } from "../../../utils/copilotOnRails/CopilotOnRailsContext";
+import { isJsonObject, readStringRecord } from "../shared/jsonUtils";
 import { FrontendPreviewViewController } from "./controllers/FrontendPreviewViewController";
 import { closeLoadingView } from "./openLoadingView";
 
@@ -135,12 +136,16 @@ function isFrontendProject(dir: vscode.Uri): boolean {
         return true;
     }
     try {
-        const pkg = JSON.parse(fs.readFileSync(vscode.Uri.joinPath(dir, 'package.json').fsPath, 'utf-8')) as {
-            dependencies?: Record<string, string>;
-            devDependencies?: Record<string, string>;
-        };
-        const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-        return FRONTEND_FRAMEWORKS.some((framework) => framework in deps);
+        const parsed: unknown = JSON.parse(fs.readFileSync(vscode.Uri.joinPath(dir, 'package.json').fsPath, 'utf-8'));
+        if (!isJsonObject(parsed)) {
+            return false;
+        }
+
+        const dependencies = readStringRecord(parsed.dependencies) ?? {};
+        const devDependencies = readStringRecord(parsed.devDependencies) ?? {};
+        return FRONTEND_FRAMEWORKS.some((framework) =>
+            Object.hasOwn(dependencies, framework) || Object.hasOwn(devDependencies, framework)
+        );
     } catch {
         return false;
     }

--- a/src/webviews/copilotOnRails/extension/utils/devServerManager.ts
+++ b/src/webviews/copilotOnRails/extension/utils/devServerManager.ts
@@ -8,6 +8,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
 import { ext } from "../../../../extensionVariables";
+import { isJsonObject, readStringRecord } from "../../shared/jsonUtils";
 
 /**
  * A running frontend dev server. `url` is the localhost URL the server bound to
@@ -79,7 +80,12 @@ function detectPackageManager(folder: string): 'npm' | 'pnpm' | 'yarn' {
 function detectDevScript(folder: string): string | undefined {
     try {
         const pkgRaw = fs.readFileSync(path.join(folder, 'package.json'), 'utf-8');
-        const scripts = (JSON.parse(pkgRaw) as { scripts?: Record<string, string> }).scripts ?? {};
+        const parsed: unknown = JSON.parse(pkgRaw);
+        if (!isJsonObject(parsed)) {
+            return undefined;
+        }
+
+        const scripts = readStringRecord(parsed.scripts) ?? {};
         if (scripts.dev) {
             return 'dev';
         }


### PR DESCRIPTION
Workspace-owned package.json files can contain valid JSON with unexpected runtime types, so TypeScript casts alone could classify invalid frontend dependencies or select non-string dev scripts.

This change validates parsed package metadata as a JSON object, accepts only string-valued dependency and script records, and uses own-property checks for frontend framework keys. Missing and malformed files retain the existing fallback behavior.