### PR TITLE
CoR: Harden requirements parsing

### DIFF
--- a/src/webviews/copilotOnRails/extension/resumePendingCreateWithCopilot.ts
+++ b/src/webviews/copilotOnRails/extension/resumePendingCreateWithCopilot.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import { copilotOnRailsCommandIds } from '../../../commands/copilotOnRails/registerCopilotOnRailsCommands';
 import { azureProjectFocusCommandId } from '../../../constants';
+import { isJsonObject } from '../shared/jsonUtils';
 
 /**
  * Creating a project requires an empty folder. When the user starts the flow in a
@@ -74,8 +75,12 @@ async function consumePendingCreateMarker(): Promise<boolean> {
 
 function parseCreatedAt(raw: Uint8Array): number | undefined {
     try {
-        const parsed = JSON.parse(Buffer.from(raw).toString('utf-8')) as Partial<PendingCreateMarker>;
-        return typeof parsed.createdAt === 'number' ? parsed.createdAt : undefined;
+        const parsed: unknown = JSON.parse(Buffer.from(raw).toString('utf-8'));
+        if (!isJsonObject(parsed)) {
+            return undefined;
+        }
+
+        return typeof parsed.createdAt === 'number' && Number.isFinite(parsed.createdAt) ? parsed.createdAt : undefined;
     } catch {
         return undefined;
     }

--- a/src/webviews/copilotOnRails/shared/jsonUtils.ts
+++ b/src/webviews/copilotOnRails/shared/jsonUtils.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export function isJsonObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function readStringRecord(value: unknown): Record<string, string> | undefined {
+    if (!isJsonObject(value) || !Object.values(value).every(entry => typeof entry === 'string')) {
+        return undefined;
+    }
+
+    return value as Record<string, string>;
+}

--- a/src/webviews/copilotOnRails/views/utils/parseRequirements.ts
+++ b/src/webviews/copilotOnRails/views/utils/parseRequirements.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { isJsonObject } from '../../shared/jsonUtils';
+
 export type RequirementsAnswer = string | number | boolean | string[] | null;
 
 export type RequirementsStatus = 'inferred' | 'needs_input' | 'confirmed' | string;
@@ -107,64 +109,82 @@ export function inferInputType(
 }
 
 function parseOption(raw: unknown): RequirementsOption | undefined {
-    if (typeof raw === 'string' && raw.trim().length > 0) {
-        return { label: raw };
+    if (!isJsonObject(raw)) {
+        return undefined;
     }
-    if (raw && typeof raw === 'object') {
-        const obj = raw as Record<string, unknown>;
-        const label = typeof obj.label === 'string' ? obj.label : undefined;
-        if (!label) {
-            return undefined;
-        }
-        const description = typeof obj.description === 'string' ? obj.description : undefined;
-        const exclusive = typeof obj.exclusive === 'boolean' ? obj.exclusive : undefined;
-        return { label, description, exclusive };
+
+    const label = typeof raw.label === 'string' ? raw.label : undefined;
+    if (!label) {
+        return undefined;
     }
-    return undefined;
+
+    const description = typeof raw.description === 'string' ? raw.description : undefined;
+    const exclusive = typeof raw.exclusive === 'boolean' ? raw.exclusive : undefined;
+    return { label, description, exclusive };
+}
+
+function parseWorkspaceSignals(raw: unknown): RequirementsWorkspaceSignals | undefined {
+    if (!isJsonObject(raw)) {
+        return undefined;
+    }
+
+    return {
+        rootPath: typeof raw.rootPath === 'string' ? raw.rootPath : undefined,
+        detectedFiles: Array.isArray(raw.detectedFiles)
+            ? raw.detectedFiles.filter((file): file is string => typeof file === 'string')
+            : undefined,
+        hasSourceCode: typeof raw.hasSourceCode === 'boolean' ? raw.hasSourceCode : undefined,
+        hasPackageJson: typeof raw.hasPackageJson === 'boolean' ? raw.hasPackageJson : undefined,
+        decision: typeof raw.decision === 'string' ? raw.decision : undefined,
+        decisionReason: typeof raw.decisionReason === 'string' ? raw.decisionReason : undefined,
+    };
 }
 
 export function parseRequirementsJson(content: string): RequirementsData {
-    const raw = JSON.parse(content) as Record<string, unknown>;
-    const questionsRaw = Array.isArray(raw.questions) ? raw.questions as unknown[] : [];
+    const parsed: unknown = JSON.parse(content);
+    if (!isJsonObject(parsed)) {
+        throw new TypeError('Requirements JSON must contain an object.');
+    }
+
+    const questionsRaw = Array.isArray(parsed.questions) ? parsed.questions : [];
 
     const questions: RequirementsQuestion[] = questionsRaw
         .map((q, idx): RequirementsQuestion | undefined => {
-            if (!q || typeof q !== 'object') {
+            if (!isJsonObject(q)) {
                 return undefined;
             }
-            const obj = q as Record<string, unknown>;
-            const id = typeof obj.id === 'string' && obj.id.trim() ? obj.id : `question-${idx}`;
-            const category = typeof obj.category === 'string' && obj.category.trim() ? obj.category : 'general';
-            const question = typeof obj.question === 'string' ? obj.question : '';
-            const header = typeof obj.header === 'string' ? obj.header : undefined;
-            const status = typeof obj.status === 'string' ? obj.status : 'needs_input';
-            const rationale = typeof obj.rationale === 'string'
-                ? obj.rationale
-                : (typeof obj.reason === 'string' ? obj.reason : undefined);
-            const multiSelect = typeof obj.multiSelect === 'boolean' ? obj.multiSelect : undefined;
-            const allowFreeformInput = typeof obj.allowFreeformInput === 'boolean' ? obj.allowFreeformInput : undefined;
-            const serviceId = typeof obj.serviceId === 'string' && obj.serviceId.trim() ? obj.serviceId : undefined;
+            const id = typeof q.id === 'string' && q.id.trim() ? q.id : `question-${idx}`;
+            const category = typeof q.category === 'string' && q.category.trim() ? q.category : 'general';
+            const question = typeof q.question === 'string' ? q.question : '';
+            const header = typeof q.header === 'string' ? q.header : undefined;
+            const status = typeof q.status === 'string' ? q.status : 'needs_input';
+            const rationale = typeof q.rationale === 'string'
+                ? q.rationale
+                : (typeof q.reason === 'string' ? q.reason : undefined);
+            const multiSelect = typeof q.multiSelect === 'boolean' ? q.multiSelect : undefined;
+            const allowFreeformInput = typeof q.allowFreeformInput === 'boolean' ? q.allowFreeformInput : undefined;
+            const serviceId = typeof q.serviceId === 'string' && q.serviceId.trim() ? q.serviceId : undefined;
 
             let answer: RequirementsAnswer;
-            if (obj.answer === null || obj.answer === undefined) {
+            if (q.answer === null || q.answer === undefined) {
                 answer = null;
-            } else if (Array.isArray(obj.answer)) {
-                answer = obj.answer.filter((x): x is string => typeof x === 'string');
-            } else if (typeof obj.answer === 'string' || typeof obj.answer === 'number' || typeof obj.answer === 'boolean') {
-                answer = obj.answer;
+            } else if (Array.isArray(q.answer)) {
+                answer = q.answer.filter((x): x is string => typeof x === 'string');
+            } else if (typeof q.answer === 'string' || typeof q.answer === 'number' || typeof q.answer === 'boolean') {
+                answer = q.answer;
             } else {
-                answer = String(obj.answer);
+                answer = null;
             }
 
-            const options = Array.isArray(obj.options)
-                ? obj.options.map(parseOption).filter((o): o is RequirementsOption => o !== undefined)
+            const options = Array.isArray(q.options)
+                ? q.options.map(parseOption).filter((o): o is RequirementsOption => o !== undefined)
                 : undefined;
 
             let recommendedChoice: RequirementsRecommendedChoice | undefined;
-            if (Array.isArray(obj.recommendedChoice)) {
-                recommendedChoice = obj.recommendedChoice.filter((x): x is string => typeof x === 'string');
-            } else if (typeof obj.recommendedChoice === 'string') {
-                recommendedChoice = obj.recommendedChoice;
+            if (Array.isArray(q.recommendedChoice)) {
+                recommendedChoice = q.recommendedChoice.filter((x): x is string => typeof x === 'string');
+            } else if (typeof q.recommendedChoice === 'string') {
+                recommendedChoice = q.recommendedChoice;
             }
 
             return {
@@ -184,34 +204,31 @@ export function parseRequirementsJson(content: string): RequirementsData {
         })
         .filter((q): q is RequirementsQuestion => q !== undefined);
 
-    const workspaceSignals = raw.workspaceSignals && typeof raw.workspaceSignals === 'object'
-        ? raw.workspaceSignals as RequirementsWorkspaceSignals
-        : undefined;
+    const workspaceSignals = parseWorkspaceSignals(parsed.workspaceSignals);
 
-    const servicesRaw = Array.isArray(raw.services) ? raw.services as unknown[] : [];
+    const servicesRaw = Array.isArray(parsed.services) ? parsed.services : [];
     const services: RequirementsService[] = servicesRaw
         .map((s): RequirementsService | undefined => {
-            if (!s || typeof s !== 'object') { return undefined; }
-            const obj = s as Record<string, unknown>;
-            const id = typeof obj.id === 'string' && obj.id.trim() ? obj.id : undefined;
-            const label = typeof obj.label === 'string' && obj.label.trim() ? obj.label : undefined;
-            const role = typeof obj.role === 'string' && ['frontend', 'backend', 'worker'].includes(obj.role) ? obj.role as RequirementsServiceRole : undefined;
+            if (!isJsonObject(s)) { return undefined; }
+            const id = typeof s.id === 'string' && s.id.trim() ? s.id : undefined;
+            const label = typeof s.label === 'string' && s.label.trim() ? s.label : undefined;
+            const role = typeof s.role === 'string' && ['frontend', 'backend', 'worker'].includes(s.role) ? s.role as RequirementsServiceRole : undefined;
             if (!id || !label || !role) { return undefined; }
-            const root = typeof obj.root === 'string' ? obj.root : undefined;
+            const root = typeof s.root === 'string' ? s.root : undefined;
             return { id, label, role, root };
         })
         .filter((s): s is RequirementsService => s !== undefined);
 
     const executionMode: RequirementsExecutionMode | undefined =
-        raw.executionMode === 'auto' || raw.executionMode === 'guided'
-            ? raw.executionMode
+        parsed.executionMode === 'auto' || parsed.executionMode === 'guided'
+            ? parsed.executionMode
             : undefined;
 
     return {
-        schemaVersion: typeof raw.schemaVersion === 'string' ? raw.schemaVersion : undefined,
-        generatedAt: typeof raw.generatedAt === 'string' ? raw.generatedAt : undefined,
-        mode: typeof raw.mode === 'string' ? raw.mode : undefined,
-        summary: typeof raw.summary === 'string' ? raw.summary : undefined,
+        schemaVersion: typeof parsed.schemaVersion === 'string' ? parsed.schemaVersion : undefined,
+        generatedAt: typeof parsed.generatedAt === 'string' ? parsed.generatedAt : undefined,
+        mode: typeof parsed.mode === 'string' ? parsed.mode : undefined,
+        summary: typeof parsed.summary === 'string' ? parsed.summary : undefined,
         executionMode,
         workspaceSignals,
         services: services.length > 0 ? services : undefined,

--- a/test/copilotOnRails/jsonUtils.test.ts
+++ b/test/copilotOnRails/jsonUtils.test.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { isJsonObject, readStringRecord } from '../../src/webviews/copilotOnRails/shared/jsonUtils';
+
+suite('jsonUtils', () => {
+    suite('isJsonObject', () => {
+        test('accepts plain objects', () => {
+            assert.strictEqual(isJsonObject({ value: 'test' }), true);
+            assert.strictEqual(isJsonObject({}), true);
+        });
+
+        test('rejects non-object JSON values', () => {
+            for (const value of [null, [], 'value', 42, true]) {
+                assert.strictEqual(isJsonObject(value), false);
+            }
+        });
+    });
+
+    suite('readStringRecord', () => {
+        test('returns records whose values are all strings', () => {
+            assert.deepStrictEqual(readStringRecord({ first: 'one', second: 'two' }), {
+                first: 'one',
+                second: 'two',
+            });
+            assert.deepStrictEqual(readStringRecord({}), {});
+        });
+
+        test('rejects non-objects and records with non-string values', () => {
+            assert.strictEqual(readStringRecord(null), undefined);
+            assert.strictEqual(readStringRecord(['one']), undefined);
+            assert.strictEqual(readStringRecord({ first: 'one', second: 2 }), undefined);
+        });
+    });
+});

--- a/test/copilotOnRails/parseRequirements.test.ts
+++ b/test/copilotOnRails/parseRequirements.test.ts
@@ -1,0 +1,111 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { parseRequirementsJson } from '../../src/webviews/copilotOnRails/views/utils/parseRequirements';
+
+suite('parseRequirementsJson', () => {
+    test('rejects valid JSON roots that are not objects', () => {
+        for (const content of ['null', '[]', '"requirements"', '42', 'true']) {
+            assert.throws(
+                () => parseRequirementsJson(content),
+                /Requirements JSON must contain an object/,
+            );
+        }
+    });
+
+    test('filters malformed nested values while preserving valid data', () => {
+        const result = parseRequirementsJson(JSON.stringify({
+            summary: 'Keep this summary',
+            questions: [
+                null,
+                'not a question',
+                {
+                    id: 'framework',
+                    category: 'service',
+                    question: 'Which framework?',
+                    answer: 'React',
+                    status: 'confirmed',
+                    options: [
+                        { label: 'React', description: 'React with Vite', exclusive: true },
+                        { label: 42 },
+                        'Vue',
+                        null,
+                    ],
+                },
+            ],
+            services: [
+                { id: 'web', label: 'Web app', role: 'frontend', root: './web' },
+                { id: 'api', label: 7, role: 'backend' },
+                { id: 'worker', label: 'Worker', role: 'invalid' },
+                [],
+            ],
+            workspaceSignals: {
+                rootPath: './app',
+                detectedFiles: ['package.json', 42, 'src/index.ts'],
+                hasSourceCode: true,
+                hasPackageJson: 'yes',
+                decision: 'extend',
+                decisionReason: false,
+            },
+        }));
+
+        assert.strictEqual(result.summary, 'Keep this summary');
+        assert.deepStrictEqual(result.questions, [{
+            id: 'framework',
+            category: 'service',
+            question: 'Which framework?',
+            header: undefined,
+            answer: 'React',
+            status: 'confirmed',
+            rationale: undefined,
+            options: [{ label: 'React', description: 'React with Vite', exclusive: true }],
+            recommendedChoice: undefined,
+            multiSelect: undefined,
+            allowFreeformInput: undefined,
+            serviceId: undefined,
+        }]);
+        assert.deepStrictEqual(result.services, [{
+            id: 'web',
+            label: 'Web app',
+            role: 'frontend',
+            root: './web',
+        }]);
+        assert.deepStrictEqual(result.workspaceSignals, {
+            rootPath: './app',
+            detectedFiles: ['package.json', 'src/index.ts'],
+            hasSourceCode: true,
+            hasPackageJson: undefined,
+            decision: 'extend',
+            decisionReason: undefined,
+        });
+    });
+
+    test('maps unsupported answer objects to null', () => {
+        const result = parseRequirementsJson(JSON.stringify({
+            questions: [{
+                id: 'framework',
+                category: 'service',
+                question: 'Which framework?',
+                answer: { name: 'React' },
+                status: 'confirmed',
+            }],
+        }));
+
+        assert.strictEqual(result.questions[0].answer, null);
+    });
+
+    test('omits nested collections whose containers have the wrong type', () => {
+        const result = parseRequirementsJson(JSON.stringify({
+            questions: 'invalid',
+            services: {},
+            workspaceSignals: [],
+        }));
+
+        assert.deepStrictEqual(result.questions, []);
+        assert.strictEqual(result.services, undefined);
+        assert.strictEqual(result.workspaceSignals, undefined);
+    });
+});


### PR DESCRIPTION
Malformed requirements artifacts can currently leak unchecked values into the webview, including non-object roots, invalid workspace signals, and object answers coerced to strings.

This change adds shared runtime JSON guards and applies them to requirements parsing and pending-create marker parsing. It preserves valid siblings in partially malformed requirements while rejecting unsupported nested shapes, maps object answers to `null`, and accepts pending-create timestamps only when they are finite numbers.

Tests cover the shared guards, non-object roots, malformed nested fields, partial valid data, unsupported answer objects, and existing requirements telemetry behavior.