### PR TITLE
CoR: Harden preview manifest parsing

### DIFF
--- a/src/webviews/copilotOnRails/extension/utils/previewPagesReader.ts
+++ b/src/webviews/copilotOnRails/extension/utils/previewPagesReader.ts
@@ -5,22 +5,11 @@
 
 import * as path from "path";
 import * as vscode from "vscode";
+import { parsePreviewManifest, type PreviewManifest } from '../../shared/previewManifest';
 import { type PreviewPage, type PreviewStatus } from "../../views/utils/parseScaffoldPlanMarkdown";
 
 /** Workspace-relative path of the per-page HTML preview folder written by the planner agent. */
 export const PREVIEW_FOLDER_RELATIVE_PATH = path.join('.azure', '.preview-temp');
-
-interface ManifestPage {
-    slug: string;
-    title?: string;
-    route?: string;
-    status?: 'pending' | 'ready';
-}
-
-interface Manifest {
-    previewStatus?: PreviewStatus;
-    pages?: ManifestPage[];
-}
 
 export interface PreviewPagesResult {
     pages: PreviewPage[];
@@ -45,7 +34,7 @@ export interface PreviewPagesResult {
  */
 export async function readPreviewPages(previewFolderUri: vscode.Uri): Promise<PreviewPagesResult> {
     const manifest = await readManifest(previewFolderUri);
-    if (!manifest?.pages?.length) {
+    if (!manifest?.pages.length) {
         return { pages: [], previewStatus: manifest?.previewStatus };
     }
 
@@ -53,12 +42,6 @@ export async function readPreviewPages(previewFolderUri: vscode.Uri): Promise<Pr
 
     const pages: PreviewPage[] = [];
     for (const entry of manifest.pages) {
-        if (!entry.slug) {
-            continue;
-        }
-        const title = entry.title ?? entry.slug;
-        const route = entry.route ?? `/${entry.slug}`;
-
         // File presence is the source of truth — always attempt the read, never
         // gate it on the manifest's `status`. A non-empty HTML file means the
         // page is ready even if the agent never flipped `status` to `"ready"`.
@@ -68,29 +51,25 @@ export async function readPreviewPages(previewFolderUri: vscode.Uri): Promise<Pr
         if (rawHtml && rawHtml.trim().length > 0) {
             pages.push({
                 slug: entry.slug,
-                title,
-                route,
+                title: entry.title,
+                route: entry.route,
                 status: 'ready',
                 html: preparePreviewHtml(rawHtml, themeCss),
             });
         } else {
-            pages.push({ slug: entry.slug, title, route, status: 'pending' });
+            pages.push({ slug: entry.slug, title: entry.title, route: entry.route, status: 'pending' });
         }
     }
     return { pages, previewStatus: manifest.previewStatus };
 }
 
-async function readManifest(previewFolderUri: vscode.Uri): Promise<Manifest | undefined> {
+async function readManifest(previewFolderUri: vscode.Uri): Promise<PreviewManifest | undefined> {
     const manifestUri = vscode.Uri.joinPath(previewFolderUri, 'manifest.json');
     const text = await readOptionalText(manifestUri);
     if (!text) {
         return undefined;
     }
-    try {
-        return JSON.parse(text) as Manifest;
-    } catch {
-        return undefined;
-    }
+    return parsePreviewManifest(text);
 }
 
 async function readOptionalText(uri: vscode.Uri): Promise<string | undefined> {

--- a/src/webviews/copilotOnRails/shared/previewManifest.ts
+++ b/src/webviews/copilotOnRails/shared/previewManifest.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isJsonObject } from './jsonUtils';
+
+export interface PreviewManifestPage {
+    slug: string;
+    title: string;
+    route: string;
+    status: 'pending' | 'ready';
+}
+
+export interface PreviewManifest {
+    previewStatus?: 'generating' | 'ready';
+    pages: PreviewManifestPage[];
+}
+
+const previewPageSlugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export function parsePreviewManifest(text: string): PreviewManifest | undefined {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(text);
+    } catch {
+        return undefined;
+    }
+
+    if (!isJsonObject(parsed)) {
+        return undefined;
+    }
+
+    return {
+        previewStatus: parsed.previewStatus === 'generating' || parsed.previewStatus === 'ready'
+            ? parsed.previewStatus
+            : undefined,
+        pages: Array.isArray(parsed.pages)
+            ? parsed.pages.filter(isPreviewManifestPage)
+            : [],
+    };
+}
+
+function isPreviewManifestPage(value: unknown): value is PreviewManifestPage {
+    return isJsonObject(value)
+        && typeof value.slug === 'string'
+        && previewPageSlugPattern.test(value.slug)
+        && typeof value.title === 'string'
+        && value.title.trim().length > 0
+        && typeof value.route === 'string'
+        && value.route.trim().length > 0
+        && (value.status === 'pending' || value.status === 'ready');
+}

--- a/test/copilotOnRails/previewPagesReader.test.ts
+++ b/test/copilotOnRails/previewPagesReader.test.ts
@@ -1,0 +1,144 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as vscode from 'vscode';
+import { readPreviewPages } from '../../src/webviews/copilotOnRails/extension/utils/previewPagesReader';
+
+suite('readPreviewPages', () => {
+    let testDirectory: string;
+
+    setup(async () => {
+        testDirectory = await mkdtemp(join(tmpdir(), 'preview-pages-reader-'));
+    });
+
+    teardown(async () => {
+        await rm(testDirectory, { recursive: true, force: true });
+    });
+
+    test('reads valid pages while preserving partial generation', async () => {
+        const previewFolder = await writePreviewManifest({
+            previewStatus: 'generating',
+            pages: [
+                { slug: 'dashboard', title: 'Dashboard', route: '/', status: 'pending' },
+                { slug: 'account-settings', title: 'Account settings', route: '/settings', status: 'pending' },
+            ],
+        });
+        await writeFile(join(previewFolder.fsPath, 'theme.css'), 'body { color: blue; }');
+        await writeFile(join(previewFolder.fsPath, 'dashboard.html'), '<head><link rel="stylesheet" href="theme.css"></head>');
+
+        const result = await readPreviewPages(previewFolder);
+
+        assert.strictEqual(result.previewStatus, 'generating');
+        assert.deepStrictEqual(result.pages, [
+            {
+                slug: 'dashboard',
+                title: 'Dashboard',
+                route: '/',
+                status: 'ready',
+                html: '<head><style data-inlined="theme.css">body { color: blue; }</style></head>',
+            },
+            {
+                slug: 'account-settings',
+                title: 'Account settings',
+                route: '/settings',
+                status: 'pending',
+            },
+        ]);
+    });
+
+    test('ignores entries with invalid field types or values', async () => {
+        const previewFolder = await writePreviewManifest({
+            previewStatus: 'complete',
+            pages: [
+                null,
+                [],
+                'dashboard',
+                { slug: 42, title: 'Dashboard', route: '/', status: 'pending' },
+                { slug: 'missing-title', title: '', route: '/', status: 'pending' },
+                { slug: 'invalid-title', title: 42, route: '/', status: 'pending' },
+                { slug: 'invalid-route', title: 'Invalid route', route: 42, status: 'pending' },
+                { slug: 'empty-route', title: 'Empty route', route: ' ', status: 'pending' },
+                { slug: 'invalid-status', title: 'Invalid status', route: '/', status: 'complete' },
+                { slug: 'non-string-status', title: 'Invalid status', route: '/', status: false },
+                { slug: 'valid-page', title: 'Valid page', route: '/valid', status: 'ready' },
+            ],
+        });
+
+        const result = await readPreviewPages(previewFolder);
+
+        assert.strictEqual(result.previewStatus, undefined);
+        assert.deepStrictEqual(result.pages, [{
+            slug: 'valid-page',
+            title: 'Valid page',
+            route: '/valid',
+            status: 'pending',
+        }]);
+    });
+
+    test('ignores invalid top-level field types', async () => {
+        const previewFolder = await writePreviewManifest({
+            previewStatus: 42,
+            pages: {},
+        });
+
+        assert.deepStrictEqual(await readPreviewPages(previewFolder), {
+            pages: [],
+            previewStatus: undefined,
+        });
+    });
+
+    test('ignores malformed JSON', async () => {
+        const previewFolder = await writeManifestText('{"pages":');
+
+        assert.deepStrictEqual(await readPreviewPages(previewFolder), {
+            pages: [],
+            previewStatus: undefined,
+        });
+    });
+
+    test('ignores non-object JSON roots', async () => {
+        for (const text of ['null', '[]', '"manifest"', '42', 'true']) {
+            const previewFolder = await writeManifestText(text);
+
+            assert.deepStrictEqual(await readPreviewPages(previewFolder), {
+                pages: [],
+                previewStatus: undefined,
+            });
+        }
+    });
+
+    test('rejects traversal slugs without reading outside the preview folder', async () => {
+        const previewFolder = await writePreviewManifest({
+            previewStatus: 'ready',
+            pages: [{
+                slug: '../outside',
+                title: 'Outside',
+                route: '/outside',
+                status: 'ready',
+            }],
+        });
+        await writeFile(join(previewFolder.fsPath, '..', 'outside.html'), '<h1>Workspace content</h1>');
+
+        assert.deepStrictEqual(await readPreviewPages(previewFolder), {
+            pages: [],
+            previewStatus: 'ready',
+        });
+    });
+
+    async function writePreviewManifest(manifest: unknown): Promise<vscode.Uri> {
+        return writeManifestText(JSON.stringify(manifest));
+    }
+
+    async function writeManifestText(text: string): Promise<vscode.Uri> {
+        const previewFolderPath = join(testDirectory, '.azure', '.preview-temp');
+        await mkdir(previewFolderPath, { recursive: true });
+        await writeFile(join(previewFolderPath, 'manifest.json'), text);
+        return vscode.Uri.file(previewFolderPath);
+    }
+});


### PR DESCRIPTION
## Summary
- parse planner preview manifests through a runtime validator
- reject malformed page fields and path-unsafe slugs before constructing preview file URIs
- preserve valid and partially generated preview behavior