### PR TITLE
CoR: Fix scaffold plan framework options

### DIFF
--- a/docs/copilot-create-project.md
+++ b/docs/copilot-create-project.md
@@ -183,10 +183,9 @@ For apps with a UI, the preview also renders one **UI Preview** card per screen 
 mock‑up) so you can see the proposed layout before any code is written. Read the plan, then **approve** it (or
 type feedback to revise it).
 
-Technology dropdowns follow each service's role and language across both supported plan layouts: per-service
-`Framework` rows and the earlier combined `Backend` / `Frontend` rows. API and worker cards offer backend
-frameworks such as Azure Functions, while web app cards offer frontend frameworks. The view shows a warning
-below a selected technology when the scaffold agent has limited support for it.
+When a service card includes an editable framework row, its choices follow that service's role and language.
+API and worker cards offer backend frameworks such as Azure Functions, while web app cards offer frontend
+frameworks. The view warns when the scaffold agent has limited support for the selected technology.
 
 The plan's **Prerequisites** section lists the tools the agent detected (with an **Installed** status) and an
 **Install** link for each. Those links are not written by the agent — the extension resolves each link

--- a/docs/copilot-create-project.md
+++ b/docs/copilot-create-project.md
@@ -183,6 +183,8 @@ For apps with a UI, the preview also renders one **UI Preview** card per screen 
 mock‑up) so you can see the proposed layout before any code is written. Read the plan, then **approve** it (or
 type feedback to revise it).
 
+Technology dropdowns in each service card follow that service's role and language. API and worker cards offer backend frameworks such as Azure Functions, while web app cards offer frontend frameworks.
+
 The plan's **Prerequisites** section lists the tools the agent detected (with an **Installed** status) and an
 **Install** link for each. Those links are not written by the agent — the extension resolves each link
 deterministically from a built‑in catalog by matching the tool name, so the plan markdown can never inject an

--- a/docs/copilot-create-project.md
+++ b/docs/copilot-create-project.md
@@ -183,7 +183,10 @@ For apps with a UI, the preview also renders one **UI Preview** card per screen 
 mock‑up) so you can see the proposed layout before any code is written. Read the plan, then **approve** it (or
 type feedback to revise it).
 
-Technology dropdowns in each service card follow that service's role and language. API and worker cards offer backend frameworks such as Azure Functions, while web app cards offer frontend frameworks.
+Technology dropdowns follow each service's role and language across both supported plan layouts: per-service
+`Framework` rows and the earlier combined `Backend` / `Frontend` rows. API and worker cards offer backend
+frameworks such as Azure Functions, while web app cards offer frontend frameworks. The view shows a warning
+below a selected technology when the scaffold agent has limited support for it.
 
 The plan's **Prerequisites** section lists the tools the agent detected (with an **Installed** status) and an
 **Install** link for each. Those links are not written by the agent — the extension resolves each link

--- a/src/webviews/copilotOnRails/views/ScaffoldPlanView.tsx
+++ b/src/webviews/copilotOnRails/views/ScaffoldPlanView.tsx
@@ -14,93 +14,7 @@ import './styles/scaffoldPlanView.scss';
 import { type ScaffoldPlanContent, type ScaffoldPlanData, type ScaffoldPlanSection, type PreviewPage, type PreviewStatus, type TreeNode } from './utils/parseScaffoldPlanMarkdown';
 import { getPrerequisiteInstallLink } from './utils/prerequisiteInstallLinks';
 import { isApprovedOrLater } from './utils/projectPlanStatus';
-
-const editableOptions: Record<string, string[]> = {
-    'Language': ['JavaScript', 'TypeScript', 'Python', 'C# (.NET)'],
-    'Runtime': ['Node', 'Deno', 'Bun', 'CPython', 'PyPy', '.NET'],
-    'Backend': ['Azure Functions v4 (Node.js v4 model)', 'Express.js', 'Fastify', 'Flask', 'FastAPI', 'Spring Boot', 'ASP.NET Core'],
-    'Frontend': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor', 'None'],
-    'Framework': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor'],
-    'Package Manager': ['npm', 'yarn', 'pnpm', 'pip', 'poetry', 'uv', 'dotnet (NuGet)'],
-    'Test Runner': ['vitest', 'jest', 'mocha', 'pytest', 'unittest', 'xUnit', 'NUnit', 'MSTest'],
-};
-
-// Fields whose dropdown choices depend on the selected Language. When the user
-// changes the Language dropdown, each of these cells is reset to the language's
-// default (the first entry) if its current value isn't valid for the new
-// language (see cascade in handleTableCellChange). The first entry per language
-// is the recommended/default choice.
-const languageDependentOptions: Record<string, Record<string, string[]>> = {
-    'Runtime': {
-        'TypeScript': ['Node', 'Deno', 'Bun'],
-        'JavaScript': ['Node', 'Deno', 'Bun'],
-        'Python': ['CPython', 'PyPy'],
-        'C# (.NET)': ['.NET'],
-    },
-    'Frontend': {
-        'TypeScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
-        'JavaScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
-        'Python': ['React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
-        'C# (.NET)': ['Blazor', 'React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
-    },
-    'Framework': {
-        'TypeScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte'],
-        'JavaScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte'],
-        'Python': ['React + Vite', 'Vue + Vite', 'Svelte'],
-        'C# (.NET)': ['Blazor', 'React + Vite', 'Vue + Vite'],
-    },
-    'Package Manager': {
-        'TypeScript': ['npm', 'pnpm', 'yarn'],
-        'JavaScript': ['npm', 'pnpm', 'yarn'],
-        'Python': ['pip', 'poetry', 'uv'],
-        'C# (.NET)': ['dotnet (NuGet)'],
-    },
-    'Test Runner': {
-        'TypeScript': ['vitest', 'jest', 'mocha'],
-        'JavaScript': ['vitest', 'jest', 'mocha'],
-        'Python': ['pytest', 'unittest'],
-        'C# (.NET)': ['xUnit', 'NUnit', 'MSTest'],
-    },
-};
-
-// Options that are officially supported. Anything else is offered as a
-// convenience but flagged with a soft "not officially supported" warning.
-const fullySupportedOptions: Record<string, Set<string>> = {
-    'Runtime': new Set(['Node', 'CPython', '.NET']),
-    'Frontend': new Set(['React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor', 'None']),
-    'Framework': new Set(['React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor']),
-    'Package Manager': new Set(['npm', 'pnpm', 'pip', 'poetry', 'dotnet (NuGet)']),
-    'Test Runner': new Set(['vitest', 'jest', 'mocha', 'pytest', 'xUnit', 'NUnit', 'MSTest']),
-};
-
-// Language choices allowed in frontend service sections. Frontends are always
-// JavaScript or TypeScript — Python and C# backends can pair with a JS/TS
-// frontend, but the frontend section itself must not offer those languages.
-const frontendLanguageOptions = ['JavaScript', 'TypeScript'];
-
-// Returns the dropdown options for a given field, narrowing to the language's
-// choices when the field is language-dependent.
-function optionsForField(field: string, language: string | undefined, isFrontend?: boolean): string[] | undefined {
-    if (field === 'Language' && isFrontend) {
-        return frontendLanguageOptions;
-    }
-    const byLanguage = languageDependentOptions[field];
-    if (byLanguage) {
-        const key = language?.trim();
-        return (key && byLanguage[key]) || editableOptions[field];
-    }
-    return editableOptions[field];
-}
-
-// True when a section is an editable "service stack" section — i.e. it contains
-// a table with a Language row. Each service (backend, frontend, worker, …) gets
-// its own stack section, and the count is dynamic, so we detect them by shape
-// rather than by a fixed section number.
-function isServiceStackSection(section: ScaffoldPlanSection): boolean {
-    return (section.content ?? []).some(
-        c => c.type === 'table' && c.rows.some(r => r[0]?.trim() === 'Language'),
-    );
-}
+import { getServiceStackKind, isFullySupportedOption, isServiceStackSection, languageDependentFields, optionsForField, type ServiceStackKind } from './utils/scaffoldPlanTechnologyOptions';
 
 
 const previewBackendLanguages = new Set<string>(['Python', 'C# (.NET)']);
@@ -391,6 +305,7 @@ export const ScaffoldPlanView = (): JSX.Element => {
             return;
         }
 
+        const serviceKind = getServiceStackKind(plan.sections[sectionIdx]);
         const field = content.rows[rowIdx][0];
         applyCellChange(content, sectionIdx, contentIdx, rowIdx, colIdx, value);
 
@@ -401,14 +316,12 @@ export const ScaffoldPlanView = (): JSX.Element => {
         // (NuGet) and vitest → xUnit. Each service stack table is self-contained
         // so the lookup stays within this table.
         if (field?.trim() === 'Language') {
-            for (const dependentField of Object.keys(languageDependentOptions)) {
+            for (const dependentField of languageDependentFields) {
                 const depRowIdx = content.rows.findIndex(r => r[0]?.trim() === dependentField);
                 if (depRowIdx < 0) {
                     continue;
                 }
-                // Only non-`Language` fields cascade here, so `isFrontend` never
-                // narrows the result — pass undefined deliberately.
-                const validOptions = optionsForField(dependentField, value) ?? [];
+                const validOptions = optionsForField(dependentField, value, serviceKind) ?? [];
                 const currentValue = content.rows[depRowIdx][colIdx];
                 if (validOptions.length > 0 && !validOptions.includes(currentValue)) {
                     applyCellChange(content, sectionIdx, contentIdx, depRowIdx, colIdx, validOptions[0]);
@@ -866,15 +779,10 @@ interface SectionCardProps {
     onTableCellChange: (sectionIdx: number, contentIdx: number, rowIdx: number, colIdx: number, value: string) => void;
 }
 
-// True when a section title indicates a frontend service (e.g. "Frontend — Web App").
-function isFrontendSection(section: ScaffoldPlanSection): boolean {
-    return /\bfrontend\b/i.test(section.title);
-}
-
 const SectionCard = ({ section, sectionIdx, disabled, editedCells, onTableCellChange }: SectionCardProps): JSX.Element => {
     const [expanded, setExpanded] = useState(false);
     const isStack = isServiceStackSection(section);
-    const isFrontend = isFrontendSection(section);
+    const serviceKind = getServiceStackKind(section);
     const previewLanguage = previewBackendLanguageForSection(section);
 
     return (
@@ -903,7 +811,7 @@ const SectionCard = ({ section, sectionIdx, disabled, editedCells, onTableCellCh
                         editedCells={editedCells}
                         onTableCellChange={onTableCellChange}
                         collapsedRows={isStack && !expanded ? collapsiblePlanRowLabels : undefined}
-                        isFrontend={isFrontend}
+                        serviceKind={serviceKind}
                     />
                 ))}
             </div>
@@ -1167,12 +1075,11 @@ interface ContentBlockProps {
     editedCells?: Set<CellKey>;
     /** Row labels to hide (collapsed state). When undefined, all rows are shown. */
     collapsedRows?: Set<string>;
-    /** When true, restricts Language choices to JavaScript/TypeScript. */
-    isFrontend?: boolean;
+    serviceKind: ServiceStackKind;
     onTableCellChange: (sectionIdx: number, contentIdx: number, rowIdx: number, colIdx: number, value: string) => void;
 }
 
-const ContentBlock = ({ item, sectionIdx, contentIdx, disabled, editedCells, collapsedRows, isFrontend, onTableCellChange }: ContentBlockProps): JSX.Element => {
+const ContentBlock = ({ item, sectionIdx, contentIdx, disabled, editedCells, collapsedRows, serviceKind, onTableCellChange }: ContentBlockProps): JSX.Element => {
     switch (item.type) {
         case 'keyValue':
             return (
@@ -1198,22 +1105,16 @@ const ContentBlock = ({ item, sectionIdx, contentIdx, disabled, editedCells, col
                                     <tr key={ri}>
                                         {row.map((cell, ci) => {
                                             const componentName = row[0];
-                                            // Language-dependent fields (Runtime, Framework,
-                                            // Package Manager, Test Runner) derive their choices
-                                            // from the Language row in this same service table so
-                                            // each service narrows independently.
-                                            const language = item.rows.find(r => r[0]?.trim() === 'Language')?.[ci];
+                                            const usesLanguageRow = item.rows.some(tableRow => tableRow[0]?.trim() === 'Language');
+                                            const language = item.rows.find(tableRow => tableRow[0]?.trim() === 'Language')?.[ci];
                                             const options = ci > 0
-                                                ? optionsForField(componentName?.trim(), language, isFrontend)
+                                                ? optionsForField(componentName?.trim(), language, serviceKind, usesLanguageRow)
                                                 : undefined;
                                             const isEdited = options ? editedCells?.has(cellKey(sectionIdx, contentIdx, ri, ci)) : false;
-                                            // Soft warning when an option outside the officially
-                                            // supported set is picked (e.g. Bun runtime, yarn,
-                                            // Next.js). Informational only — doesn't block.
-                                            const supportedSet = ci > 0 ? fullySupportedOptions[componentName?.trim()] : undefined;
-                                            const showSupportWarning = supportedSet !== undefined
-                                                && cell
-                                                && !supportedSet.has(cell.trim());
+                                            const isFullySupported = ci > 0 && cell
+                                                ? isFullySupportedOption(componentName, cell, serviceKind, usesLanguageRow)
+                                                : undefined;
+                                            const showSupportWarning = isFullySupported === false;
                                             return (
                                                 <td key={ci} className={isEdited ? 'editedCell' : undefined}>
                                                     {options ? (

--- a/src/webviews/copilotOnRails/views/ScaffoldPlanView.tsx
+++ b/src/webviews/copilotOnRails/views/ScaffoldPlanView.tsx
@@ -14,7 +14,103 @@ import './styles/scaffoldPlanView.scss';
 import { type ScaffoldPlanContent, type ScaffoldPlanData, type ScaffoldPlanSection, type PreviewPage, type PreviewStatus, type TreeNode } from './utils/parseScaffoldPlanMarkdown';
 import { getPrerequisiteInstallLink } from './utils/prerequisiteInstallLinks';
 import { isApprovedOrLater } from './utils/projectPlanStatus';
-import { getServiceStackKind, isFullySupportedOption, isServiceStackSection, languageDependentFields, optionsForField, type ServiceStackKind } from './utils/scaffoldPlanTechnologyOptions';
+import { isAzureFunctionsFramework, isBackendServiceSection } from './utils/scaffoldPlanTechnologyOptions';
+
+const editableOptions: Record<string, string[]> = {
+    'Language': ['JavaScript', 'TypeScript', 'Python', 'C# (.NET)'],
+    'Runtime': ['Node', 'Deno', 'Bun', 'CPython', 'PyPy', '.NET'],
+    'Backend': ['Azure Functions v4 (Node.js v4 model)', 'Express.js', 'Fastify', 'Flask', 'FastAPI', 'Spring Boot', 'ASP.NET Core'],
+    'Frontend': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor', 'None'],
+    'Framework': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor'],
+    'Package Manager': ['npm', 'yarn', 'pnpm', 'pip', 'poetry', 'uv', 'dotnet (NuGet)'],
+    'Test Runner': ['vitest', 'jest', 'mocha', 'pytest', 'unittest', 'xUnit', 'NUnit', 'MSTest'],
+};
+
+// Fields whose dropdown choices depend on the selected Language. When the user
+// changes the Language dropdown, each of these cells is reset to the language's
+// default (the first entry) if its current value isn't valid for the new
+// language (see cascade in handleTableCellChange). The first entry per language
+// is the recommended/default choice.
+const languageDependentOptions: Record<string, Record<string, string[]>> = {
+    'Runtime': {
+        'TypeScript': ['Node', 'Deno', 'Bun'],
+        'JavaScript': ['Node', 'Deno', 'Bun'],
+        'Python': ['CPython', 'PyPy'],
+        'C# (.NET)': ['.NET'],
+    },
+    'Frontend': {
+        'TypeScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
+        'JavaScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
+        'Python': ['React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
+        'C# (.NET)': ['Blazor', 'React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
+    },
+    'Framework': {
+        'TypeScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte'],
+        'JavaScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte'],
+        'Python': ['React + Vite', 'Vue + Vite', 'Svelte'],
+        'C# (.NET)': ['Blazor', 'React + Vite', 'Vue + Vite'],
+    },
+    'Package Manager': {
+        'TypeScript': ['npm', 'pnpm', 'yarn'],
+        'JavaScript': ['npm', 'pnpm', 'yarn'],
+        'Python': ['pip', 'poetry', 'uv'],
+        'C# (.NET)': ['dotnet (NuGet)'],
+    },
+    'Test Runner': {
+        'TypeScript': ['vitest', 'jest', 'mocha'],
+        'JavaScript': ['vitest', 'jest', 'mocha'],
+        'Python': ['pytest', 'unittest'],
+        'C# (.NET)': ['xUnit', 'NUnit', 'MSTest'],
+    },
+};
+
+const backendFrameworkOptions: Record<string, string[]> = {
+    'TypeScript': ['Azure Functions', 'Fastify', 'Express'],
+    'JavaScript': ['Azure Functions', 'Fastify', 'Express'],
+    'Python': ['Azure Functions', 'FastAPI', 'Flask'],
+    'C# (.NET)': ['Azure Functions', 'ASP.NET Core'],
+};
+
+// Options that are officially supported. Anything else is offered as a
+// convenience but flagged with a soft "not officially supported" warning.
+const fullySupportedOptions: Record<string, Set<string>> = {
+    'Runtime': new Set(['Node', 'CPython', '.NET']),
+    'Frontend': new Set(['React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor', 'None']),
+    'Framework': new Set(['React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor']),
+    'Package Manager': new Set(['npm', 'pnpm', 'pip', 'poetry', 'dotnet (NuGet)']),
+    'Test Runner': new Set(['vitest', 'jest', 'mocha', 'pytest', 'xUnit', 'NUnit', 'MSTest']),
+};
+
+// Language choices allowed in frontend service sections. Frontends are always
+// JavaScript or TypeScript — Python and C# backends can pair with a JS/TS
+// frontend, but the frontend section itself must not offer those languages.
+const frontendLanguageOptions = ['JavaScript', 'TypeScript'];
+
+// Returns the dropdown options for a given field, narrowing to the language's
+// choices when the field is language-dependent.
+function optionsForField(field: string, language: string | undefined, isFrontend?: boolean, isBackend?: boolean): string[] | undefined {
+    if (field === 'Language' && isFrontend) {
+        return frontendLanguageOptions;
+    }
+    const byLanguage = field === 'Framework' && isBackend
+        ? backendFrameworkOptions
+        : languageDependentOptions[field];
+    if (byLanguage) {
+        const key = language?.trim();
+        return (key && byLanguage[key]) || editableOptions[field];
+    }
+    return editableOptions[field];
+}
+
+// True when a section is an editable "service stack" section — i.e. it contains
+// a table with a Language row. Each service (backend, frontend, worker, …) gets
+// its own stack section, and the count is dynamic, so we detect them by shape
+// rather than by a fixed section number.
+function isServiceStackSection(section: ScaffoldPlanSection): boolean {
+    return (section.content ?? []).some(
+        c => c.type === 'table' && c.rows.some(r => r[0]?.trim() === 'Language'),
+    );
+}
 
 
 const previewBackendLanguages = new Set<string>(['Python', 'C# (.NET)']);
@@ -305,7 +401,7 @@ export const ScaffoldPlanView = (): JSX.Element => {
             return;
         }
 
-        const serviceKind = getServiceStackKind(plan.sections[sectionIdx]);
+        const isBackend = isBackendServiceSection(plan.sections[sectionIdx]);
         const field = content.rows[rowIdx][0];
         applyCellChange(content, sectionIdx, contentIdx, rowIdx, colIdx, value);
 
@@ -316,12 +412,13 @@ export const ScaffoldPlanView = (): JSX.Element => {
         // (NuGet) and vitest → xUnit. Each service stack table is self-contained
         // so the lookup stays within this table.
         if (field?.trim() === 'Language') {
-            for (const dependentField of languageDependentFields) {
+            for (const dependentField of Object.keys(languageDependentOptions)) {
                 const depRowIdx = content.rows.findIndex(r => r[0]?.trim() === dependentField);
                 if (depRowIdx < 0) {
                     continue;
                 }
-                const validOptions = optionsForField(dependentField, value, serviceKind) ?? [];
+                // Framework choices also depend on whether this service is a backend.
+                const validOptions = optionsForField(dependentField, value, undefined, isBackend) ?? [];
                 const currentValue = content.rows[depRowIdx][colIdx];
                 if (validOptions.length > 0 && !validOptions.includes(currentValue)) {
                     applyCellChange(content, sectionIdx, contentIdx, depRowIdx, colIdx, validOptions[0]);
@@ -779,10 +876,16 @@ interface SectionCardProps {
     onTableCellChange: (sectionIdx: number, contentIdx: number, rowIdx: number, colIdx: number, value: string) => void;
 }
 
+// True when a section title indicates a frontend service (e.g. "Frontend — Web App").
+function isFrontendSection(section: ScaffoldPlanSection): boolean {
+    return /\bfrontend\b/i.test(section.title);
+}
+
 const SectionCard = ({ section, sectionIdx, disabled, editedCells, onTableCellChange }: SectionCardProps): JSX.Element => {
     const [expanded, setExpanded] = useState(false);
     const isStack = isServiceStackSection(section);
-    const serviceKind = getServiceStackKind(section);
+    const isFrontend = isFrontendSection(section);
+    const isBackend = isBackendServiceSection(section);
     const previewLanguage = previewBackendLanguageForSection(section);
 
     return (
@@ -811,7 +914,8 @@ const SectionCard = ({ section, sectionIdx, disabled, editedCells, onTableCellCh
                         editedCells={editedCells}
                         onTableCellChange={onTableCellChange}
                         collapsedRows={isStack && !expanded ? collapsiblePlanRowLabels : undefined}
-                        serviceKind={serviceKind}
+                        isFrontend={isFrontend}
+                        isBackend={isBackend}
                     />
                 ))}
             </div>
@@ -1075,11 +1179,13 @@ interface ContentBlockProps {
     editedCells?: Set<CellKey>;
     /** Row labels to hide (collapsed state). When undefined, all rows are shown. */
     collapsedRows?: Set<string>;
-    serviceKind: ServiceStackKind;
+    /** When true, restricts Language choices to JavaScript/TypeScript. */
+    isFrontend?: boolean;
+    isBackend?: boolean;
     onTableCellChange: (sectionIdx: number, contentIdx: number, rowIdx: number, colIdx: number, value: string) => void;
 }
 
-const ContentBlock = ({ item, sectionIdx, contentIdx, disabled, editedCells, collapsedRows, serviceKind, onTableCellChange }: ContentBlockProps): JSX.Element => {
+const ContentBlock = ({ item, sectionIdx, contentIdx, disabled, editedCells, collapsedRows, isFrontend, isBackend, onTableCellChange }: ContentBlockProps): JSX.Element => {
     switch (item.type) {
         case 'keyValue':
             return (
@@ -1105,16 +1211,25 @@ const ContentBlock = ({ item, sectionIdx, contentIdx, disabled, editedCells, col
                                     <tr key={ri}>
                                         {row.map((cell, ci) => {
                                             const componentName = row[0];
-                                            const usesLanguageRow = item.rows.some(tableRow => tableRow[0]?.trim() === 'Language');
-                                            const language = item.rows.find(tableRow => tableRow[0]?.trim() === 'Language')?.[ci];
+                                            // Language-dependent fields (Runtime, Framework,
+                                            // Package Manager, Test Runner) derive their choices
+                                            // from the Language row in this same service table so
+                                            // each service narrows independently.
+                                            const language = item.rows.find(r => r[0]?.trim() === 'Language')?.[ci];
                                             const options = ci > 0
-                                                ? optionsForField(componentName?.trim(), language, serviceKind, usesLanguageRow)
+                                                ? optionsForField(componentName?.trim(), language, isFrontend, isBackend)
                                                 : undefined;
                                             const isEdited = options ? editedCells?.has(cellKey(sectionIdx, contentIdx, ri, ci)) : false;
-                                            const isFullySupported = ci > 0 && cell
-                                                ? isFullySupportedOption(componentName, cell, serviceKind, usesLanguageRow)
-                                                : undefined;
-                                            const showSupportWarning = isFullySupported === false;
+                                            const field = componentName?.trim();
+                                            const supportedSet = ci > 0 ? fullySupportedOptions[field] : undefined;
+                                            // Soft warning when an option outside the officially
+                                            // supported set is picked (e.g. Express, Bun, yarn,
+                                            // Next.js). Informational only — doesn't block.
+                                            const showSupportWarning = !!cell && (
+                                                field === 'Framework' && isBackend
+                                                    ? !isAzureFunctionsFramework(cell)
+                                                    : supportedSet !== undefined && !supportedSet.has(cell.trim())
+                                            );
                                             return (
                                                 <td key={ci} className={isEdited ? 'editedCell' : undefined}>
                                                     {options ? (

--- a/src/webviews/copilotOnRails/views/utils/scaffoldPlanTechnologyOptions.ts
+++ b/src/webviews/copilotOnRails/views/utils/scaffoldPlanTechnologyOptions.ts
@@ -163,7 +163,7 @@ export function isFullySupportedOption(
     }
     if (normalizedField === 'Framework') {
         if (serviceKind === 'backend') {
-            return isBackendFramework(value);
+            return isAzureFunctionsFramework(value);
         }
         if (serviceKind === 'frontend') {
             return fullySupportedOptions.Frontend.has(value.trim());
@@ -185,7 +185,12 @@ function classifyRoleText(value: string): Exclude<ServiceStackKind, 'unknown'> |
 }
 
 function isBackendFramework(value: string): boolean {
-    return /^(azure functions?(?:\b.*)?|express(?:\.js)?|fastify|flask|fastapi|spring boot|asp\.net core)$/i.test(value.trim());
+    return isAzureFunctionsFramework(value)
+        || /^(express(?:\.js)?|fastify|flask|fastapi|spring boot|asp\.net core)$/i.test(value.trim());
+}
+
+function isAzureFunctionsFramework(value: string): boolean {
+    return /^azure functions?(?:\b.*)?$/i.test(value.trim());
 }
 
 function isFrontendFramework(value: string): boolean {

--- a/src/webviews/copilotOnRails/views/utils/scaffoldPlanTechnologyOptions.ts
+++ b/src/webviews/copilotOnRails/views/utils/scaffoldPlanTechnologyOptions.ts
@@ -1,0 +1,193 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { ScaffoldPlanSection } from './parseScaffoldPlanMarkdown';
+
+export type ServiceStackKind = 'backend' | 'frontend' | 'unknown';
+
+const editableOptions: Record<string, string[]> = {
+    'Language': ['JavaScript', 'TypeScript', 'Python', 'C# (.NET)'],
+    'Runtime': ['Node', 'Deno', 'Bun', 'CPython', 'PyPy', '.NET'],
+    'Backend': ['Azure Functions v4 (Node.js v4 model)', 'Express.js', 'Fastify', 'Flask', 'FastAPI', 'Spring Boot', 'ASP.NET Core'],
+    'Frontend': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor', 'None'],
+    'Package Manager': ['npm', 'yarn', 'pnpm', 'pip', 'poetry', 'uv', 'dotnet (NuGet)'],
+    'Test Runner': ['vitest', 'jest', 'mocha', 'pytest', 'unittest', 'xUnit', 'NUnit', 'MSTest'],
+};
+
+const sharedLanguageOptions: Record<string, Record<string, string[]>> = {
+    'Runtime': {
+        'TypeScript': ['Node', 'Deno', 'Bun'],
+        'JavaScript': ['Node', 'Deno', 'Bun'],
+        'Python': ['CPython', 'PyPy'],
+        'C# (.NET)': ['.NET'],
+    },
+    'Frontend': {
+        'TypeScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
+        'JavaScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
+        'Python': ['React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
+        'C# (.NET)': ['Blazor', 'React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
+    },
+    'Package Manager': {
+        'TypeScript': ['npm', 'pnpm', 'yarn'],
+        'JavaScript': ['npm', 'pnpm', 'yarn'],
+        'Python': ['pip', 'poetry', 'uv'],
+        'C# (.NET)': ['dotnet (NuGet)'],
+    },
+    'Test Runner': {
+        'TypeScript': ['vitest', 'jest', 'mocha'],
+        'JavaScript': ['vitest', 'jest', 'mocha'],
+        'Python': ['pytest', 'unittest'],
+        'C# (.NET)': ['xUnit', 'NUnit', 'MSTest'],
+    },
+};
+
+const backendFrameworkOptions: Record<string, string[]> = {
+    'TypeScript': ['Azure Functions', 'Fastify', 'Express'],
+    'JavaScript': ['Azure Functions', 'Fastify', 'Express'],
+    'Python': ['Azure Functions', 'FastAPI', 'Flask'],
+    'C# (.NET)': ['Azure Functions', 'ASP.NET Core'],
+};
+
+const frontendFrameworkOptions: Record<string, string[]> = {
+    'TypeScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte'],
+    'JavaScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte'],
+    'Python': ['React + Vite', 'Vue + Vite', 'Svelte'],
+    'C# (.NET)': ['Blazor', 'React + Vite', 'Vue + Vite'],
+};
+
+const allFrameworks = [...new Set([
+    ...Object.values(backendFrameworkOptions).flat(),
+    ...Object.values(frontendFrameworkOptions).flat(),
+])];
+
+const fullySupportedOptions: Record<string, Set<string>> = {
+    'Runtime': new Set(['Node', 'CPython', '.NET']),
+    'Frontend': new Set(['React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor', 'None']),
+    'Package Manager': new Set(['npm', 'pnpm', 'pip', 'poetry', 'dotnet (NuGet)']),
+    'Test Runner': new Set(['vitest', 'jest', 'mocha', 'pytest', 'xUnit', 'NUnit', 'MSTest']),
+};
+
+const frontendLanguageOptions = ['JavaScript', 'TypeScript'];
+const legacyRuntimeOptions = ['JavaScript', 'TypeScript', 'Python', 'C# (.NET)'];
+
+export const languageDependentFields = ['Runtime', 'Frontend', 'Framework', 'Package Manager', 'Test Runner'];
+
+export function isServiceStackSection(section: ScaffoldPlanSection): boolean {
+    return section.content.some(content => {
+        if (content.type !== 'table') {
+            return false;
+        }
+        const rowLabels = new Set(content.rows.map(row => row[0]?.trim()));
+        return rowLabels.has('Language') || rowLabels.has('Backend') || rowLabels.has('Frontend');
+    });
+}
+
+export function getServiceStackKind(section: ScaffoldPlanSection): ServiceStackKind {
+    const tables = section.content.filter(content => content.type === 'table');
+
+    for (const table of tables) {
+        const rowLabels = new Set(table.rows.map(row => row[0]?.trim()));
+        if (rowLabels.has('Backend')) {
+            return 'backend';
+        }
+        if (rowLabels.has('Frontend')) {
+            return 'frontend';
+        }
+
+        const frameworkRow = table.rows.find(row => row[0]?.trim() === 'Framework');
+        const frameworkValues = frameworkRow?.slice(1).map(value => value.trim()) ?? [];
+        if (frameworkValues.some(isBackendFramework)) {
+            return 'backend';
+        }
+        if (frameworkValues.some(isFrontendFramework)) {
+            return 'frontend';
+        }
+    }
+
+    const titleRole = section.title.split(/\s+(?:\u2014|\u2013|-)\s+/).at(-1) ?? section.title;
+    return classifyRoleText(titleRole) ?? classifyRoleText(section.title) ?? 'unknown';
+}
+
+export function optionsForField(
+    field: string,
+    language: string | undefined,
+    serviceKind: ServiceStackKind,
+    usesLanguageRow = true,
+): string[] | undefined {
+    const normalizedField = field.trim();
+    const normalizedLanguage = language?.trim();
+
+    if (normalizedField === 'Runtime' && !usesLanguageRow) {
+        return legacyRuntimeOptions;
+    }
+    if (normalizedField === 'Frontend' && !usesLanguageRow) {
+        return editableOptions.Frontend;
+    }
+    if (normalizedField === 'Language' && serviceKind === 'frontend') {
+        return frontendLanguageOptions;
+    }
+
+    if (normalizedField === 'Framework') {
+        const optionsByLanguage = serviceKind === 'backend'
+            ? backendFrameworkOptions
+            : serviceKind === 'frontend'
+                ? frontendFrameworkOptions
+                : undefined;
+        if (!optionsByLanguage) {
+            return allFrameworks;
+        }
+        return normalizedLanguage
+            ? optionsByLanguage[normalizedLanguage] ?? [...new Set(Object.values(optionsByLanguage).flat())]
+            : [...new Set(Object.values(optionsByLanguage).flat())];
+    }
+
+    const optionsByLanguage = sharedLanguageOptions[normalizedField];
+    if (optionsByLanguage && normalizedLanguage) {
+        return optionsByLanguage[normalizedLanguage] ?? editableOptions[normalizedField];
+    }
+
+    return editableOptions[normalizedField];
+}
+
+export function isFullySupportedOption(
+    field: string,
+    value: string,
+    serviceKind: ServiceStackKind,
+    usesLanguageRow = true,
+): boolean | undefined {
+    const normalizedField = field.trim();
+    if (normalizedField === 'Runtime' && !usesLanguageRow) {
+        return undefined;
+    }
+    if (normalizedField === 'Framework') {
+        if (serviceKind === 'backend') {
+            return isBackendFramework(value);
+        }
+        if (serviceKind === 'frontend') {
+            return fullySupportedOptions.Frontend.has(value.trim());
+        }
+        return undefined;
+    }
+
+    return fullySupportedOptions[normalizedField]?.has(value.trim());
+}
+
+function classifyRoleText(value: string): Exclude<ServiceStackKind, 'unknown'> | undefined {
+    if (/\b(api|backend|worker|functions?)\b/i.test(value)) {
+        return 'backend';
+    }
+    if (/\b(frontend|web app|spa|client-side|client app)\b/i.test(value)) {
+        return 'frontend';
+    }
+    return undefined;
+}
+
+function isBackendFramework(value: string): boolean {
+    return /^(azure functions?(?:\b.*)?|express(?:\.js)?|fastify|flask|fastapi|spring boot|asp\.net core)$/i.test(value.trim());
+}
+
+function isFrontendFramework(value: string): boolean {
+    return /^(react\s*\+\s*vite|next\.js|vue\s*\+\s*vite|angular|svelte|blazor|none)$/i.test(value.trim());
+}

--- a/src/webviews/copilotOnRails/views/utils/scaffoldPlanTechnologyOptions.ts
+++ b/src/webviews/copilotOnRails/views/utils/scaffoldPlanTechnologyOptions.ts
@@ -5,183 +5,28 @@
 
 import type { ScaffoldPlanSection } from './parseScaffoldPlanMarkdown';
 
-export type ServiceStackKind = 'backend' | 'frontend' | 'unknown';
-
-const editableOptions: Record<string, string[]> = {
-    'Language': ['JavaScript', 'TypeScript', 'Python', 'C# (.NET)'],
-    'Runtime': ['Node', 'Deno', 'Bun', 'CPython', 'PyPy', '.NET'],
-    'Backend': ['Azure Functions v4 (Node.js v4 model)', 'Express.js', 'Fastify', 'Flask', 'FastAPI', 'Spring Boot', 'ASP.NET Core'],
-    'Frontend': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor', 'None'],
-    'Package Manager': ['npm', 'yarn', 'pnpm', 'pip', 'poetry', 'uv', 'dotnet (NuGet)'],
-    'Test Runner': ['vitest', 'jest', 'mocha', 'pytest', 'unittest', 'xUnit', 'NUnit', 'MSTest'],
-};
-
-const sharedLanguageOptions: Record<string, Record<string, string[]>> = {
-    'Runtime': {
-        'TypeScript': ['Node', 'Deno', 'Bun'],
-        'JavaScript': ['Node', 'Deno', 'Bun'],
-        'Python': ['CPython', 'PyPy'],
-        'C# (.NET)': ['.NET'],
-    },
-    'Frontend': {
-        'TypeScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
-        'JavaScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
-        'Python': ['React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
-        'C# (.NET)': ['Blazor', 'React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'None'],
-    },
-    'Package Manager': {
-        'TypeScript': ['npm', 'pnpm', 'yarn'],
-        'JavaScript': ['npm', 'pnpm', 'yarn'],
-        'Python': ['pip', 'poetry', 'uv'],
-        'C# (.NET)': ['dotnet (NuGet)'],
-    },
-    'Test Runner': {
-        'TypeScript': ['vitest', 'jest', 'mocha'],
-        'JavaScript': ['vitest', 'jest', 'mocha'],
-        'Python': ['pytest', 'unittest'],
-        'C# (.NET)': ['xUnit', 'NUnit', 'MSTest'],
-    },
-};
-
-const backendFrameworkOptions: Record<string, string[]> = {
-    'TypeScript': ['Azure Functions', 'Fastify', 'Express'],
-    'JavaScript': ['Azure Functions', 'Fastify', 'Express'],
-    'Python': ['Azure Functions', 'FastAPI', 'Flask'],
-    'C# (.NET)': ['Azure Functions', 'ASP.NET Core'],
-};
-
-const frontendFrameworkOptions: Record<string, string[]> = {
-    'TypeScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte'],
-    'JavaScript': ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte'],
-    'Python': ['React + Vite', 'Vue + Vite', 'Svelte'],
-    'C# (.NET)': ['Blazor', 'React + Vite', 'Vue + Vite'],
-};
-
-const allFrameworks = [...new Set([
-    ...Object.values(backendFrameworkOptions).flat(),
-    ...Object.values(frontendFrameworkOptions).flat(),
-])];
-
-const fullySupportedOptions: Record<string, Set<string>> = {
-    'Runtime': new Set(['Node', 'CPython', '.NET']),
-    'Frontend': new Set(['React + Vite', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor', 'None']),
-    'Package Manager': new Set(['npm', 'pnpm', 'pip', 'poetry', 'dotnet (NuGet)']),
-    'Test Runner': new Set(['vitest', 'jest', 'mocha', 'pytest', 'xUnit', 'NUnit', 'MSTest']),
-};
-
-const frontendLanguageOptions = ['JavaScript', 'TypeScript'];
-const legacyRuntimeOptions = ['JavaScript', 'TypeScript', 'Python', 'C# (.NET)'];
-
-export const languageDependentFields = ['Runtime', 'Frontend', 'Framework', 'Package Manager', 'Test Runner'];
-
-export function isServiceStackSection(section: ScaffoldPlanSection): boolean {
-    return section.content.some(content => {
+export function isBackendServiceSection(section: ScaffoldPlanSection): boolean {
+    for (const content of section.content) {
         if (content.type !== 'table') {
+            continue;
+        }
+
+        const frameworkValues = content.rows
+            .find(row => row[0]?.trim() === 'Framework')
+            ?.slice(1) ?? [];
+        if (frameworkValues.some(isFrontendFramework)) {
             return false;
         }
-        const rowLabels = new Set(content.rows.map(row => row[0]?.trim()));
-        return rowLabels.has('Language') || rowLabels.has('Backend') || rowLabels.has('Frontend');
-    });
-}
-
-export function getServiceStackKind(section: ScaffoldPlanSection): ServiceStackKind {
-    const tables = section.content.filter(content => content.type === 'table');
-
-    for (const table of tables) {
-        const rowLabels = new Set(table.rows.map(row => row[0]?.trim()));
-        if (rowLabels.has('Backend')) {
-            return 'backend';
-        }
-        if (rowLabels.has('Frontend')) {
-            return 'frontend';
-        }
-
-        const frameworkRow = table.rows.find(row => row[0]?.trim() === 'Framework');
-        const frameworkValues = frameworkRow?.slice(1).map(value => value.trim()) ?? [];
         if (frameworkValues.some(isBackendFramework)) {
-            return 'backend';
-        }
-        if (frameworkValues.some(isFrontendFramework)) {
-            return 'frontend';
+            return true;
         }
     }
 
-    const titleRole = section.title.split(/\s+(?:\u2014|\u2013|-)\s+/).at(-1) ?? section.title;
-    return classifyRoleText(titleRole) ?? classifyRoleText(section.title) ?? 'unknown';
+    return /\b(api|backend|worker|functions?)\b/i.test(section.title);
 }
 
-export function optionsForField(
-    field: string,
-    language: string | undefined,
-    serviceKind: ServiceStackKind,
-    usesLanguageRow = true,
-): string[] | undefined {
-    const normalizedField = field.trim();
-    const normalizedLanguage = language?.trim();
-
-    if (normalizedField === 'Runtime' && !usesLanguageRow) {
-        return legacyRuntimeOptions;
-    }
-    if (normalizedField === 'Frontend' && !usesLanguageRow) {
-        return editableOptions.Frontend;
-    }
-    if (normalizedField === 'Language' && serviceKind === 'frontend') {
-        return frontendLanguageOptions;
-    }
-
-    if (normalizedField === 'Framework') {
-        const optionsByLanguage = serviceKind === 'backend'
-            ? backendFrameworkOptions
-            : serviceKind === 'frontend'
-                ? frontendFrameworkOptions
-                : undefined;
-        if (!optionsByLanguage) {
-            return allFrameworks;
-        }
-        return normalizedLanguage
-            ? optionsByLanguage[normalizedLanguage] ?? [...new Set(Object.values(optionsByLanguage).flat())]
-            : [...new Set(Object.values(optionsByLanguage).flat())];
-    }
-
-    const optionsByLanguage = sharedLanguageOptions[normalizedField];
-    if (optionsByLanguage && normalizedLanguage) {
-        return optionsByLanguage[normalizedLanguage] ?? editableOptions[normalizedField];
-    }
-
-    return editableOptions[normalizedField];
-}
-
-export function isFullySupportedOption(
-    field: string,
-    value: string,
-    serviceKind: ServiceStackKind,
-    usesLanguageRow = true,
-): boolean | undefined {
-    const normalizedField = field.trim();
-    if (normalizedField === 'Runtime' && !usesLanguageRow) {
-        return undefined;
-    }
-    if (normalizedField === 'Framework') {
-        if (serviceKind === 'backend') {
-            return isAzureFunctionsFramework(value);
-        }
-        if (serviceKind === 'frontend') {
-            return fullySupportedOptions.Frontend.has(value.trim());
-        }
-        return undefined;
-    }
-
-    return fullySupportedOptions[normalizedField]?.has(value.trim());
-}
-
-function classifyRoleText(value: string): Exclude<ServiceStackKind, 'unknown'> | undefined {
-    if (/\b(api|backend|worker|functions?)\b/i.test(value)) {
-        return 'backend';
-    }
-    if (/\b(frontend|web app|spa|client-side|client app)\b/i.test(value)) {
-        return 'frontend';
-    }
-    return undefined;
+export function isAzureFunctionsFramework(value: string): boolean {
+    return /^azure functions?(?:\b.*)?$/i.test(value.trim());
 }
 
 function isBackendFramework(value: string): boolean {
@@ -189,10 +34,6 @@ function isBackendFramework(value: string): boolean {
         || /^(express(?:\.js)?|fastify|flask|fastapi|spring boot|asp\.net core)$/i.test(value.trim());
 }
 
-function isAzureFunctionsFramework(value: string): boolean {
-    return /^azure functions?(?:\b.*)?$/i.test(value.trim());
-}
-
 function isFrontendFramework(value: string): boolean {
-    return /^(react\s*\+\s*vite|next\.js|vue\s*\+\s*vite|angular|svelte|blazor|none)$/i.test(value.trim());
+    return /^(react\s*\+\s*vite|next\.js|vue\s*\+\s*vite|angular|svelte|blazor)$/i.test(value.trim());
 }

--- a/test/copilotOnRails/scaffoldPlanTechnologyOptions.test.ts
+++ b/test/copilotOnRails/scaffoldPlanTechnologyOptions.test.ts
@@ -6,109 +6,43 @@
 import assert from 'assert';
 import type { ScaffoldPlanSection } from '../../src/webviews/copilotOnRails/views/utils/parseScaffoldPlanMarkdown';
 import {
-    getServiceStackKind,
-    isFullySupportedOption,
-    isServiceStackSection,
-    optionsForField,
+    isAzureFunctionsFramework,
+    isBackendServiceSection,
 } from '../../src/webviews/copilotOnRails/views/utils/scaffoldPlanTechnologyOptions';
 
 suite('scaffold plan technology options', () => {
-    test('offers supported backend frameworks for an Azure Functions API', () => {
-        const section = serviceSection('Attendance API \u2014 Azure Functions', 'TypeScript', 'Azure Functions');
-        const kind = getServiceStackKind(section);
-        const options = optionsForField('Framework', 'TypeScript', kind);
-
-        assert.strictEqual(kind, 'backend');
-        assert.deepStrictEqual(options, ['Azure Functions', 'Fastify', 'Express']);
-        assert.strictEqual(options?.includes('React + Vite'), false);
-        assert.strictEqual(isFullySupportedOption('Framework', 'Azure Functions', kind), true);
-    });
-
-    test('offers frontend frameworks for a web app section', () => {
-        const section = serviceSection('Attendance Web App \u2014 Web App', 'TypeScript', 'React + Vite');
-        const kind = getServiceStackKind(section);
-        const options = optionsForField('Framework', 'TypeScript', kind);
-
-        assert.strictEqual(kind, 'frontend');
-        assert.deepStrictEqual(options, ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte']);
-        assert.strictEqual(options?.includes('Azure Functions'), false);
-        assert.deepStrictEqual(optionsForField('Language', 'TypeScript', kind), ['JavaScript', 'TypeScript']);
-    });
-
-    test('narrows backend frameworks when the language changes', () => {
-        const section = serviceSection('Orders \u2014 Backend', 'TypeScript', 'Fastify');
-        const kind = getServiceStackKind(section);
-
-        assert.deepStrictEqual(optionsForField('Framework', 'Python', kind), ['Azure Functions', 'FastAPI', 'Flask']);
-        assert.deepStrictEqual(optionsForField('Framework', 'C# (.NET)', kind), ['Azure Functions', 'ASP.NET Core']);
-    });
-
-    test('marks non-Functions backend frameworks as limited support', () => {
-        for (const framework of ['Express', 'Express.js', 'Fastify', 'FastAPI', 'Flask', 'Spring Boot', 'ASP.NET Core']) {
-            const section = serviceSection(`Orders API \u2014 ${framework}`, 'TypeScript', framework);
-            const kind = getServiceStackKind(section);
-
-            assert.strictEqual(kind, 'backend');
-            assert.strictEqual(isFullySupportedOption('Framework', framework, kind), false);
+    test('recognizes backend sections from their framework', () => {
+        for (const framework of ['Azure Functions', 'Express', 'Fastify', 'FastAPI']) {
+            assert.strictEqual(isBackendServiceSection(serviceSection('Application', framework)), true);
         }
     });
 
-    test('preserves legacy Backend and Frontend row choices', () => {
-        const section = legacyStackSection();
-        const kind = getServiceStackKind(section);
-
-        assert.strictEqual(kind, 'backend');
-        assert.strictEqual(isServiceStackSection(section), true);
-        assert.deepStrictEqual(
-            optionsForField('Runtime', undefined, kind, false),
-            ['JavaScript', 'TypeScript', 'Python', 'C# (.NET)'],
-        );
-        assert.deepStrictEqual(
-            optionsForField('Backend', undefined, kind, false),
-            ['Azure Functions v4 (Node.js v4 model)', 'Express.js', 'Fastify', 'Flask', 'FastAPI', 'Spring Boot', 'ASP.NET Core'],
-        );
-        assert.deepStrictEqual(
-            optionsForField('Frontend', undefined, kind, false),
-            ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor', 'None'],
-        );
-        assert.strictEqual(isFullySupportedOption('Runtime', 'TypeScript', kind, false), undefined);
+    test('does not classify frontend framework sections as backend', () => {
         assert.strictEqual(
-            isFullySupportedOption('Backend', 'Azure Functions v4 (Node.js v4 model)', kind, false),
-            undefined,
+            isBackendServiceSection(serviceSection('Attendance Web App', 'React + Vite')),
+            false,
         );
     });
 
-    test('recognizes Azure Functions framework label variants', () => {
-        const section = serviceSection('Functions service', 'TypeScript', 'Azure Functions v4 (Node.js v4 model)');
-        const kind = getServiceStackKind(section);
-
-        assert.strictEqual(kind, 'backend');
+    test('uses the section title when the framework is unfamiliar', () => {
         assert.strictEqual(
-            isFullySupportedOption('Framework', 'Azure Functions v4 (Node.js v4 model)', kind),
+            isBackendServiceSection(serviceSection('Attendance API', 'Custom HTTP host')),
+            true,
+        );
+        assert.strictEqual(
+            isBackendServiceSection(serviceSection('Attendance API', 'None')),
             true,
         );
     });
 
-    test('keeps an unclassified Framework row editable without assuming frontend', () => {
-        const section = serviceSection('Reporting Service', 'TypeScript', 'Custom HTTP host');
-        const kind = getServiceStackKind(section);
-        const options = optionsForField('Framework', 'TypeScript', kind);
-
-        assert.strictEqual(kind, 'unknown');
-        assert.strictEqual(options?.includes('Azure Functions'), true);
-        assert.strictEqual(options?.includes('React + Vite'), true);
-        assert.strictEqual(options?.includes('Azure Functions v4 (Node.js v4 model)'), false);
-        assert.strictEqual(isFullySupportedOption('Framework', 'Custom HTTP host', kind), undefined);
-    });
-
-    test('does not treat a generic client service name as frontend', () => {
-        const section = serviceSection('Client Service \u2014 Node.js Server', 'TypeScript', 'Custom Node Server');
-
-        assert.strictEqual(getServiceStackKind(section), 'unknown');
+    test('only Azure Functions variants are fully supported backend frameworks', () => {
+        assert.strictEqual(isAzureFunctionsFramework('Azure Functions'), true);
+        assert.strictEqual(isAzureFunctionsFramework('Azure Functions v4 (Node.js v4 model)'), true);
+        assert.strictEqual(isAzureFunctionsFramework('Express'), false);
     });
 });
 
-function serviceSection(title: string, language: string, framework: string): ScaffoldPlanSection {
+function serviceSection(title: string, framework: string): ScaffoldPlanSection {
     return {
         number: 2,
         title,
@@ -116,24 +50,8 @@ function serviceSection(title: string, language: string, framework: string): Sca
             type: 'table',
             headers: ['Component', 'Technology'],
             rows: [
-                ['Language', language],
+                ['Language', 'TypeScript'],
                 ['Framework', framework],
-            ],
-        }],
-    };
-}
-
-function legacyStackSection(): ScaffoldPlanSection {
-    return {
-        number: 2,
-        title: 'Runtime & Framework',
-        content: [{
-            type: 'table',
-            headers: ['Component', 'Technology'],
-            rows: [
-                ['Runtime', 'TypeScript'],
-                ['Backend', 'Azure Functions v4 (Node.js v4 model)'],
-                ['Frontend', 'React + Vite'],
             ],
         }],
     };

--- a/test/copilotOnRails/scaffoldPlanTechnologyOptions.test.ts
+++ b/test/copilotOnRails/scaffoldPlanTechnologyOptions.test.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import type { ScaffoldPlanSection } from '../../src/webviews/copilotOnRails/views/utils/parseScaffoldPlanMarkdown';
+import {
+    getServiceStackKind,
+    isFullySupportedOption,
+    isServiceStackSection,
+    optionsForField,
+} from '../../src/webviews/copilotOnRails/views/utils/scaffoldPlanTechnologyOptions';
+
+suite('scaffold plan technology options', () => {
+    test('offers supported backend frameworks for an Azure Functions API', () => {
+        const section = serviceSection('Attendance API \u2014 Azure Functions', 'TypeScript', 'Azure Functions');
+        const kind = getServiceStackKind(section);
+        const options = optionsForField('Framework', 'TypeScript', kind);
+
+        assert.strictEqual(kind, 'backend');
+        assert.deepStrictEqual(options, ['Azure Functions', 'Fastify', 'Express']);
+        assert.strictEqual(options?.includes('React + Vite'), false);
+        assert.strictEqual(isFullySupportedOption('Framework', 'Azure Functions', kind), true);
+    });
+
+    test('offers frontend frameworks for a web app section', () => {
+        const section = serviceSection('Attendance Web App \u2014 Web App', 'TypeScript', 'React + Vite');
+        const kind = getServiceStackKind(section);
+        const options = optionsForField('Framework', 'TypeScript', kind);
+
+        assert.strictEqual(kind, 'frontend');
+        assert.deepStrictEqual(options, ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte']);
+        assert.strictEqual(options?.includes('Azure Functions'), false);
+        assert.deepStrictEqual(optionsForField('Language', 'TypeScript', kind), ['JavaScript', 'TypeScript']);
+    });
+
+    test('narrows backend frameworks when the language changes', () => {
+        const section = serviceSection('Orders \u2014 Backend', 'TypeScript', 'Fastify');
+        const kind = getServiceStackKind(section);
+
+        assert.deepStrictEqual(optionsForField('Framework', 'Python', kind), ['Azure Functions', 'FastAPI', 'Flask']);
+        assert.deepStrictEqual(optionsForField('Framework', 'C# (.NET)', kind), ['Azure Functions', 'ASP.NET Core']);
+    });
+
+    test('preserves legacy Backend and Frontend row choices', () => {
+        const section = legacyStackSection();
+        const kind = getServiceStackKind(section);
+
+        assert.strictEqual(kind, 'backend');
+        assert.strictEqual(isServiceStackSection(section), true);
+        assert.deepStrictEqual(
+            optionsForField('Runtime', undefined, kind, false),
+            ['JavaScript', 'TypeScript', 'Python', 'C# (.NET)'],
+        );
+        assert.deepStrictEqual(
+            optionsForField('Backend', undefined, kind, false),
+            ['Azure Functions v4 (Node.js v4 model)', 'Express.js', 'Fastify', 'Flask', 'FastAPI', 'Spring Boot', 'ASP.NET Core'],
+        );
+        assert.deepStrictEqual(
+            optionsForField('Frontend', undefined, kind, false),
+            ['React + Vite', 'Next.js', 'Vue + Vite', 'Angular', 'Svelte', 'Blazor', 'None'],
+        );
+        assert.strictEqual(isFullySupportedOption('Runtime', 'TypeScript', kind, false), undefined);
+        assert.strictEqual(
+            isFullySupportedOption('Backend', 'Azure Functions v4 (Node.js v4 model)', kind, false),
+            undefined,
+        );
+    });
+
+    test('recognizes Azure Functions framework label variants', () => {
+        const section = serviceSection('Functions service', 'TypeScript', 'Azure Functions v4 (Node.js v4 model)');
+        const kind = getServiceStackKind(section);
+
+        assert.strictEqual(kind, 'backend');
+        assert.strictEqual(
+            isFullySupportedOption('Framework', 'Azure Functions v4 (Node.js v4 model)', kind),
+            true,
+        );
+    });
+
+    test('keeps an unclassified Framework row editable without assuming frontend', () => {
+        const section = serviceSection('Reporting Service', 'TypeScript', 'Custom HTTP host');
+        const kind = getServiceStackKind(section);
+        const options = optionsForField('Framework', 'TypeScript', kind);
+
+        assert.strictEqual(kind, 'unknown');
+        assert.strictEqual(options?.includes('Azure Functions'), true);
+        assert.strictEqual(options?.includes('React + Vite'), true);
+        assert.strictEqual(options?.includes('Azure Functions v4 (Node.js v4 model)'), false);
+        assert.strictEqual(isFullySupportedOption('Framework', 'Custom HTTP host', kind), undefined);
+    });
+
+    test('does not treat a generic client service name as frontend', () => {
+        const section = serviceSection('Client Service \u2014 Node.js Server', 'TypeScript', 'Custom Node Server');
+
+        assert.strictEqual(getServiceStackKind(section), 'unknown');
+    });
+});
+
+function serviceSection(title: string, language: string, framework: string): ScaffoldPlanSection {
+    return {
+        number: 2,
+        title,
+        content: [{
+            type: 'table',
+            headers: ['Component', 'Technology'],
+            rows: [
+                ['Language', language],
+                ['Framework', framework],
+            ],
+        }],
+    };
+}
+
+function legacyStackSection(): ScaffoldPlanSection {
+    return {
+        number: 2,
+        title: 'Runtime & Framework',
+        content: [{
+            type: 'table',
+            headers: ['Component', 'Technology'],
+            rows: [
+                ['Runtime', 'TypeScript'],
+                ['Backend', 'Azure Functions v4 (Node.js v4 model)'],
+                ['Frontend', 'React + Vite'],
+            ],
+        }],
+    };
+}

--- a/test/copilotOnRails/scaffoldPlanTechnologyOptions.test.ts
+++ b/test/copilotOnRails/scaffoldPlanTechnologyOptions.test.ts
@@ -43,6 +43,16 @@ suite('scaffold plan technology options', () => {
         assert.deepStrictEqual(optionsForField('Framework', 'C# (.NET)', kind), ['Azure Functions', 'ASP.NET Core']);
     });
 
+    test('marks non-Functions backend frameworks as limited support', () => {
+        for (const framework of ['Express', 'Express.js', 'Fastify', 'FastAPI', 'Flask', 'Spring Boot', 'ASP.NET Core']) {
+            const section = serviceSection(`Orders API \u2014 ${framework}`, 'TypeScript', framework);
+            const kind = getServiceStackKind(section);
+
+            assert.strictEqual(kind, 'backend');
+            assert.strictEqual(isFullySupportedOption('Framework', framework, kind), false);
+        }
+    });
+
     test('preserves legacy Backend and Frontend row choices', () => {
         const section = legacyStackSection();
         const kind = getServiceStackKind(section);


### PR DESCRIPTION
Ran into a bug when running GPT-Sol. The scaffold plan preview treated every `Framework` row as a frontend framework selector. This made Azure Functions appear unsupported in API sections and offered web frameworks for backend services.

This change keeps the existing frontend behavior and adds only the backend-specific handling needed for editable `Framework` rows:

- recognize backend sections from known backend framework values or explicit API, backend, worker, and Functions titles
- offer language-appropriate backend framework choices
- treat Azure Functions as fully supported while showing the existing limited-support warning for alternatives such as Express

The focused regression tests cover backend and frontend classification, unfamiliar framework fallback, Azure Functions label variants, and the Express warning state.

## Bug reproduction

The API framework selector offered frontend frameworks even though Azure Functions was the selected backend framework.

![API framework selector showing frontend options](https://github.com/user-attachments/assets/ef20de12-2f1e-4541-af8e-e69219a6234d)

![Azure Functions API framework selection](https://github.com/user-attachments/assets/3d2f673d-6360-49dc-9e6a-7e3f17f20a35)